### PR TITLE
Add Dockerfile for uploading artifact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+# TODO: Replace when we switch to an official BSR plugin.
+# Usage:
+# buf registry login
+# docker login -u $USERNAME -p $PASSWORD plugins.buf.build
+# docker build -t plugins.buf.build/mrebello/connect-swift:v0.0.1-3 -f Dockerfile .
+# docker push plugins.buf.build/mrebello/connect-swift:v0.0.1-3
+
 FROM golang:alpine as build
 WORKDIR /app
 ADD go.mod go.sum .

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -8,8 +8,11 @@ plugins:
   - plugin: buf.build/apple/swift
     opt: Visibility=Public
     out: gen/proto/swift-protobuf
-  # - name: connect-swift
-  #   out: gen/proto/connectswift
-  #   path: ./protoc-gen-connect-swift/protoc-gen-connect-swift
-  - remote: buf.build/mrebello/plugins/connect-swift
+  - name: connect-swift
     out: gen/proto/connectswift
+    path: ./protoc-gen-connect-swift/protoc-gen-connect-swift
+
+  # TODO: Replace this with an official BSR plugin once open-sourced.
+  # To use the remote plugin instead of the local one:
+  # - remote: buf.build/mrebello/plugins/connect-swift
+  #   out: gen/proto/connectswift


### PR DESCRIPTION
Adds a `Dockerfile` which allows for building & uploading the `protoc-gen-connect-swift` plugin to the BSR.

For now, this is being pushed to my personal BSR account (though it's public). Once we are ready to OSS the repo, it'll be moved to the official Buf plugins. The reason for this delay is that once we make it an official plugin, it'll be publicly discoverable at https://buf.build/plugins.