### PR TITLE
Add support for canceling unary requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Usage:
 # buf registry login
 # docker login -u $USERNAME -p $PASSWORD plugins.buf.build
-# docker build -t plugins.buf.build/mrebello/connect-swift:v0.0.1-3 -f Dockerfile .
-# docker push plugins.buf.build/mrebello/connect-swift:v0.0.1-3
+# docker build -t plugins.buf.build/mrebello/connect-swift:v0.0.1-4 -f Dockerfile .
+# docker push plugins.buf.build/mrebello/connect-swift:v0.0.1-4
 
 FROM golang:alpine as build
 WORKDIR /app

--- a/crosstests/Crosstests.swift
+++ b/crosstests/Crosstests.swift
@@ -96,7 +96,7 @@ final class Crosstests: XCTestCase {
 //        try runTestsWithClient(UnimplementedServiceClient(client: clients.grpcWebProtoClient))
     }
 
-    // MARK: - Test cases
+    // MARK: - Crosstest cases
 
     func testEmptyUnary() {
         self.executeTestWithClients { client in
@@ -478,6 +478,21 @@ final class Crosstests: XCTestCase {
                     }
             })
 
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+        }
+    }
+
+    // MARK: - Additional cases
+
+    func testCancelingUnary() {
+        self.executeTestWithClients { client in
+            let expectation = self.expectation(description: "Receives canceled response")
+            let cancelable = client.emptyCall(request: Grpc_Testing_Empty()) { response in
+                XCTAssertEqual(response.code, .canceled)
+                XCTAssertEqual(response.error?.code, .canceled)
+                expectation.fulfill()
+            }
+            cancelable.cancel()
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }

--- a/gen/proto/connectswift/plugins/protoc-gen-connect-swift/eliza.swift
+++ b/gen/proto/connectswift/plugins/protoc-gen-connect-swift/eliza.swift
@@ -15,7 +15,8 @@ public protocol ElizaServiceClientInterface {
 
 	// Say is a unary request demo. This method should allow for a one sentence
 	// response given a one sentence request.
-	func say(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void)
+	@discardableResult
+	func say(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable
 
 	// Converse is a bi-directional streaming request demo. This method should allow for
 	// many requests and many responses.
@@ -34,8 +35,9 @@ public final class ElizaServiceClient: ElizaServiceClientInterface {
 		self.client = client
 	}
 
-	public func say(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void) {
-		self.client.unary(path: "buf.connect.demo.eliza.v1.ElizaService/Say", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func say(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "buf.connect.demo.eliza.v1.ElizaService/Say", request: request, headers: headers, completion: completion)
 	}
 
 	public func converse(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Buf_Connect_Demo_Eliza_V1_ConverseResponse>) -> Void) -> any Connect.BidirectionalStreamInterface<Buf_Connect_Demo_Eliza_V1_ConverseRequest> {

--- a/gen/proto/connectswift/plugins/protoc-gen-connect-swift/grpc/testing/test.swift
+++ b/gen/proto/connectswift/plugins/protoc-gen-connect-swift/grpc/testing/test.swift
@@ -10,18 +10,22 @@ import Foundation
 public protocol TestServiceClientInterface {
 
 	// One empty request followed by one empty response.
-	func emptyCall(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void)
+	@discardableResult
+	func emptyCall(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
 	// One request followed by one response.
-	func unaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void)
+	@discardableResult
+	func unaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable
 
 	// One request followed by one response. This RPC always fails.
-	func failUnaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void)
+	@discardableResult
+	func failUnaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable
 
 	// One request followed by one response. Response has cache control
 	// headers set such that a caching HTTP proxy (such as GFE) can
 	// satisfy subsequent requests.
-	func cacheableUnaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void)
+	@discardableResult
+	func cacheableUnaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable
 
 	// One request followed by a sequence of responses (streamed download).
 	// The server returns the payload with client desired type and sizes.
@@ -47,7 +51,8 @@ public protocol TestServiceClientInterface {
 
 	// The test server will not implement this method. It will be used
 	// to test the behavior when clients call unimplemented methods.
-	func unimplementedCall(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void)
+	@discardableResult
+	func unimplementedCall(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
 	// The test server will not implement this method. It will be used
 	// to test the behavior when clients call unimplemented streaming output methods.
@@ -62,20 +67,24 @@ public final class TestServiceClient: TestServiceClientInterface {
 		self.client = client
 	}
 
-	public func emptyCall(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) {
-		self.client.unary(path: "grpc.testing.TestService/EmptyCall", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func emptyCall(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.TestService/EmptyCall", request: request, headers: headers, completion: completion)
 	}
 
-	public func unaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) {
-		self.client.unary(path: "grpc.testing.TestService/UnaryCall", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func unaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.TestService/UnaryCall", request: request, headers: headers, completion: completion)
 	}
 
-	public func failUnaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) {
-		self.client.unary(path: "grpc.testing.TestService/FailUnaryCall", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func failUnaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.TestService/FailUnaryCall", request: request, headers: headers, completion: completion)
 	}
 
-	public func cacheableUnaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) {
-		self.client.unary(path: "grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func cacheableUnaryCall(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers, completion: completion)
 	}
 
 	public func streamingOutputCall(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_StreamingOutputCallResponse>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_StreamingOutputCallRequest> {
@@ -98,8 +107,9 @@ public final class TestServiceClient: TestServiceClientInterface {
 		return self.client.bidirectionalStream(path: "grpc.testing.TestService/HalfDuplexCall", headers: headers, onResult: onResult)
 	}
 
-	public func unimplementedCall(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) {
-		self.client.unary(path: "grpc.testing.TestService/UnimplementedCall", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func unimplementedCall(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.TestService/UnimplementedCall", request: request, headers: headers, completion: completion)
 	}
 
 	public func unimplementedStreamingOutputCall(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_Empty>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_Empty> {
@@ -111,7 +121,8 @@ public final class TestServiceClient: TestServiceClientInterface {
 public protocol UnimplementedServiceClientInterface {
 
 	// A call that no server should implement
-	func unimplementedCall(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void)
+	@discardableResult
+	func unimplementedCall(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
 	// A call that no server should implement
 	func unimplementedStreamingOutputCall(headers: Connect.Headers, onResult: @escaping (Connect.StreamResult<Grpc_Testing_Empty>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_Empty>
@@ -125,8 +136,9 @@ public final class UnimplementedServiceClient: UnimplementedServiceClientInterfa
 		self.client = client
 	}
 
-	public func unimplementedCall(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) {
-		self.client.unary(path: "grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func unimplementedCall(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers, completion: completion)
 	}
 
 	public func unimplementedStreamingOutputCall(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_Empty>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_Empty> {
@@ -137,10 +149,12 @@ public final class UnimplementedServiceClient: UnimplementedServiceClientInterfa
 public protocol ReconnectServiceClientInterface {
 
 	
-	func start(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void)
+	@discardableResult
+	func start(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
 	
-	func stop(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void)
+	@discardableResult
+	func stop(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void) -> Connect.Cancelable
 }
 
 // Concrete implementation of ReconnectServiceClientInterface.
@@ -151,22 +165,26 @@ public final class ReconnectServiceClient: ReconnectServiceClientInterface {
 		self.client = client
 	}
 
-	public func start(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) {
-		self.client.unary(path: "grpc.testing.ReconnectService/Start", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func start(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.ReconnectService/Start", request: request, headers: headers, completion: completion)
 	}
 
-	public func stop(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void) {
-		self.client.unary(path: "grpc.testing.ReconnectService/Stop", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func stop(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.ReconnectService/Stop", request: request, headers: headers, completion: completion)
 	}
 }
 // A service used to obtain stats for verifying LB behavior.
 public protocol LoadBalancerStatsServiceClientInterface {
 
 	// Gets the backend distribution for RPCs sent by a test client.
-	func getClientStats(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void)
+	@discardableResult
+	func getClientStats(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void) -> Connect.Cancelable
 
 	// Gets the accumulated stats for RPCs sent by a test client.
-	func getClientAccumulatedStats(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void)
+	@discardableResult
+	func getClientAccumulatedStats(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void) -> Connect.Cancelable
 }
 
 // Concrete implementation of LoadBalancerStatsServiceClientInterface.
@@ -177,22 +195,26 @@ public final class LoadBalancerStatsServiceClient: LoadBalancerStatsServiceClien
 		self.client = client
 	}
 
-	public func getClientStats(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void) {
-		self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func getClientStats(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers, completion: completion)
 	}
 
-	public func getClientAccumulatedStats(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void) {
-		self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func getClientAccumulatedStats(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers, completion: completion)
 	}
 }
 // A service to remotely control health status of an xDS test server.
 public protocol XdsUpdateHealthServiceClientInterface {
 
 	
-	func setServing(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void)
+	@discardableResult
+	func setServing(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
 	
-	func setNotServing(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void)
+	@discardableResult
+	func setNotServing(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 }
 
 // Concrete implementation of XdsUpdateHealthServiceClientInterface.
@@ -203,19 +225,22 @@ public final class XdsUpdateHealthServiceClient: XdsUpdateHealthServiceClientInt
 		self.client = client
 	}
 
-	public func setServing(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) {
-		self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func setServing(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers, completion: completion)
 	}
 
-	public func setNotServing(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) {
-		self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func setNotServing(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers, completion: completion)
 	}
 }
 // A service to dynamically update the configuration of an xDS test client.
 public protocol XdsUpdateClientConfigureServiceClientInterface {
 
 	// Update the tes client's configuration.
-	func configure(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void)
+	@discardableResult
+	func configure(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void) -> Connect.Cancelable
 }
 
 // Concrete implementation of XdsUpdateClientConfigureServiceClientInterface.
@@ -226,7 +251,8 @@ public final class XdsUpdateClientConfigureServiceClient: XdsUpdateClientConfigu
 		self.client = client
 	}
 
-	public func configure(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void) {
-		self.client.unary(path: "grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers, completion: completion)
+	@discardableResult
+	public func configure(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void) -> Connect.Cancelable {
+		return self.client.unary(path: "grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers, completion: completion)
 	}
 }

--- a/library/interfaces/Cancelable.swift
+++ b/library/interfaces/Cancelable.swift
@@ -1,0 +1,5 @@
+/// Type that wraps an action that can be canceled.
+public struct Cancelable {
+    /// Cancel the current action.
+    public let cancel: () -> Void
+}

--- a/library/interfaces/HTTPClientInterface.swift
+++ b/library/interfaces/HTTPClientInterface.swift
@@ -1,6 +1,6 @@
 public protocol HTTPClientInterface {
-    // TODO: Allow for canceling (return a `Cancellable`?)
-    func unary(request: HTTPRequest, completion: @escaping (HTTPResponse) -> Void)
+    @discardableResult
+    func unary(request: HTTPRequest, completion: @escaping (HTTPResponse) -> Void) -> Cancelable
 
     func stream(request: HTTPRequest, responseCallbacks: ResponseCallbacks) -> RequestCallbacks
 }

--- a/library/interfaces/ProtocolClientInterface.swift
+++ b/library/interfaces/ProtocolClientInterface.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftProtobuf
 
 public protocol ProtocolClientInterface {
+    @discardableResult
     func unary<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(
@@ -9,7 +10,7 @@ public protocol ProtocolClientInterface {
         request: Input,
         headers: Headers,
         completion: @escaping (ResponseMessage<Output>) -> Void
-    )
+    ) -> Cancelable
 
     func bidirectionalStream<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message


### PR DESCRIPTION
Adds the ability to cancel outbound unary requests by calling a new `cancel()` function on the return value for generated unary RPCs.