### PR TITLE
Add `exclude` to tests to resolve Swift warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,10 @@ let package = Package(
                 "GeneratedExamples",
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
             ],
-            path: "crosstests"
+            path: "crosstests",
+            exclude: [
+                "local.patch",
+            ]
         ),
         .target(
             name: "GeneratedExamples",


### PR DESCRIPTION
```
warning: 'connect-swift': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/rebello/Development/connect-swift/crosstests/local.patch
```