### PR TITLE
Remove SwiftLint rule to silence warning

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,7 +17,6 @@ disabled_rules:
   - type_name
   - unavailable_function
 opt_in_rules:
-  - anyobject_protocol
   - array_init
   - attributes
   - closure_end_indentation


### PR DESCRIPTION
Fixes:

> The `anyobject_protocol` rule is now deprecated and will be completely removed in a future release.