### PR TITLE
Allow custom `JSONCodec` encoding options

### DIFF
--- a/Connect/Implementation/Codecs/JSONCodec.swift
+++ b/Connect/Implementation/Codecs/JSONCodec.swift
@@ -2,13 +2,25 @@ import Foundation
 import SwiftProtobuf
 
 public struct JSONCodec {
+    private let encodingOptions: JSONEncodingOptions
     private let decodingOptions: JSONDecodingOptions = {
         var options = JSONDecodingOptions()
         options.ignoreUnknownFields = true
         return options
     }()
 
-    public init() {}
+    /// Designated initializer.
+    ///
+    /// - parameter alwaysPrintEnumsAsInts: Always print enums as ints. By default they are printed
+    ///                                     as strings.
+    /// - parameter preserveProtoFieldNames: Whether to preserve proto field names. By default they
+    ///                                      are converted to JSON (lowerCamelCase) names.
+    public init(alwaysEncodeEnumsAsInts: Bool = false, encodeProtoFieldNames: Bool = false) {
+        var encodingOptions = JSONEncodingOptions()
+        encodingOptions.alwaysPrintEnumsAsInts = alwaysEncodeEnumsAsInts
+        encodingOptions.preserveProtoFieldNames = encodeProtoFieldNames
+        self.encodingOptions = encodingOptions
+    }
 }
 
 extension JSONCodec: Codec {
@@ -17,8 +29,7 @@ extension JSONCodec: Codec {
     }
 
     public func serialize<Input: SwiftProtobuf.Message>(message: Input) throws -> Data {
-        // TODO: Expose support for `JSONEncodingOptions`?
-        return try message.jsonUTF8Data()
+        return try message.jsonUTF8Data(options: self.encodingOptions)
     }
 
     public func deserialize<Output: SwiftProtobuf.Message>(source: Data) throws -> Output {


### PR DESCRIPTION
These options map through to SwiftProtobuf encoding options.