### PR TITLE
Rename podspec definition to `Connect-Swift`

### DIFF
--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -1,5 +1,6 @@
 Pod::Spec.new do |spec|
-  spec.name = 'Connect'
+  spec.name = 'Connect-Swift'
+  spec.module_name = 'Connect'
   spec.version = '0.0.1'
   spec.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
   spec.summary = 'Connect is a slim library for building Protobuf- and gRPC-compatible HTTP APIs.'

--- a/ConnectExamples/ElizaCocoaPodsApp/Podfile
+++ b/ConnectExamples/ElizaCocoaPodsApp/Podfile
@@ -4,6 +4,6 @@ target 'ElizaCocoaPodsApp' do
   use_frameworks!
 
   # For real projects, use a version instead of a path:
-  # pod 'Connect', '~> x.y.z'
-  pod 'Connect', :path => '../..'
+  # pod 'Connect-Swift', '~> x.y.z'
+  pod 'Connect-Swift', :path => '../..'
 end

--- a/ConnectExamples/ElizaCocoaPodsApp/Podfile.lock
+++ b/ConnectExamples/ElizaCocoaPodsApp/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
-  - Connect (0.0.1):
+  - Connect-Swift (0.0.1):
     - SwiftProtobuf (~> 1.20.3)
   - SwiftProtobuf (1.20.3)
 
 DEPENDENCIES:
-  - Connect (from `../..`)
+  - Connect-Swift (from `../..`)
 
 SPEC REPOS:
   trunk:
     - SwiftProtobuf
 
 EXTERNAL SOURCES:
-  Connect:
+  Connect-Swift:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Connect: 0dc61db3f1fb891ced603026785301590dfc422a
+  Connect-Swift: 149f90ab735a3a2fbbd84f4bf19427d89e1d60cd
   SwiftProtobuf: b02b5075dcf60c9f5f403000b3b0c202a11b6ae1
 
-PODFILE CHECKSUM: 9b085eadf81f07f74247c9cfc524d0a0eac3ae3b
+PODFILE CHECKSUM: b598f373a6ab5add976b09c2ac79029bf2200d48
 
 COCOAPODS: 1.11.3

--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ CocoaPods support.
 To integrate using CocoaPods, add this line to your `Podfile`:
 
 ```rb
-pod 'Connect'
+# Use the current version (automatically pinned in Podfile.lock after):
+pod 'Connect-Swift'
+
+# Or pin a specific version:
+pod 'Connect-Swift', '~> x.y.z'
 ```
 
-You can pin to a specific version using:
-
-```rb
-pod 'Connect', '~> x.y.z'
-```
+You can then use the library by adding `import Connect` to your sources.
 
 For an example of integrating `Connect` via CocoaPods,
 see the [`ElizaCocoaPodsApp`](./ConnectExamples/ElizaCocoaPodsApp).


### PR DESCRIPTION
Unfortunately, `Connect` [is taken](https://cocoapods.org/pods/Connect). To work around this, I'm renaming the pod to `Connect-Swift` but maintaining the `Connect` module name (so consumers can still `import Connect` and the only impact is to their `Podfile` dependency entry).
