### PR TITLE
Remove `Generated` module from Swift package

### DIFF
--- a/ConnectExamples/ElizaSharedSources/MessagingViewModel.swift
+++ b/ConnectExamples/ElizaSharedSources/MessagingViewModel.swift
@@ -15,10 +15,6 @@
 import Combine
 import Connect
 import Dispatch
-#if !COCOAPODS
-// The CocoaPods example references these files directly instead of through Swift Package Manager
-import Generated
-#endif
 import os.log
 
 private typealias ConverseRequest = Buf_Connect_Demo_Eliza_V1_ConverseRequest

--- a/ConnectExamples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.pbxproj
+++ b/ConnectExamples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B22C4BAC2964EE0F00D89051 /* test.connect.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22C4B9D2964EE0F00D89051 /* test.connect.swift */; };
+		B22C4BAD2964EE0F00D89051 /* eliza.connect.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22C4B9E2964EE0F00D89051 /* eliza.connect.swift */; };
+		B22C4BAE2964EE0F00D89051 /* eliza.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22C4BA02964EE0F00D89051 /* eliza.pb.swift */; };
+		B22C4BAF2964EE0F00D89051 /* status.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22C4BA42964EE0F00D89051 /* status.pb.swift */; };
+		B22C4BB02964EE0F00D89051 /* messages.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22C4BA62964EE0F00D89051 /* messages.pb.swift */; };
+		B22C4BB12964EE0F00D89051 /* empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22C4BA72964EE0F00D89051 /* empty.pb.swift */; };
+		B22C4BB22964EE0F00D89051 /* test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22C4BA82964EE0F00D89051 /* test.pb.swift */; };
+		B22C4BB32964EE0F00D89051 /* server.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22C4BAB2964EE0F00D89051 /* server.pb.swift */; };
 		B236EE8C295F564900DDCDA9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B236EE8B295F564900DDCDA9 /* Assets.xcassets */; };
 		B236EE9B295F565500DDCDA9 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B236EE96295F565500DDCDA9 /* Message.swift */; };
 		B236EE9C295F565500DDCDA9 /* MessagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B236EE97295F565500DDCDA9 /* MessagingView.swift */; };
@@ -14,10 +22,17 @@
 		B236EE9E295F565500DDCDA9 /* ElizaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B236EE99295F565500DDCDA9 /* ElizaApp.swift */; };
 		B236EE9F295F565500DDCDA9 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B236EE9A295F565500DDCDA9 /* MenuView.swift */; };
 		B236EEA4295F569700DDCDA9 /* Connect in Frameworks */ = {isa = PBXBuildFile; productRef = B236EEA3295F569700DDCDA9 /* Connect */; };
-		B236EEA6295F569700DDCDA9 /* Generated in Frameworks */ = {isa = PBXBuildFile; productRef = B236EEA5295F569700DDCDA9 /* Generated */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		B22C4B9D2964EE0F00D89051 /* test.connect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = test.connect.swift; sourceTree = "<group>"; };
+		B22C4B9E2964EE0F00D89051 /* eliza.connect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = eliza.connect.swift; sourceTree = "<group>"; };
+		B22C4BA02964EE0F00D89051 /* eliza.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = eliza.pb.swift; sourceTree = "<group>"; };
+		B22C4BA42964EE0F00D89051 /* status.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = status.pb.swift; sourceTree = "<group>"; };
+		B22C4BA62964EE0F00D89051 /* messages.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = messages.pb.swift; sourceTree = "<group>"; };
+		B22C4BA72964EE0F00D89051 /* empty.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = empty.pb.swift; sourceTree = "<group>"; };
+		B22C4BA82964EE0F00D89051 /* test.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = test.pb.swift; sourceTree = "<group>"; };
+		B22C4BAB2964EE0F00D89051 /* server.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = server.pb.swift; sourceTree = "<group>"; };
 		B236EE84295F564800DDCDA9 /* ElizaSwiftPackageApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ElizaSwiftPackageApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B236EE8B295F564900DDCDA9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B236EE96295F565500DDCDA9 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -33,7 +48,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B236EEA6295F569700DDCDA9 /* Generated in Frameworks */,
 				B236EEA4295F569700DDCDA9 /* Connect in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -41,6 +55,102 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B22C4B992964EE0F00D89051 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4B9A2964EE0F00D89051 /* connect-swift */,
+				B22C4B9F2964EE0F00D89051 /* swift-protobuf */,
+			);
+			name = Generated;
+			path = ../../../Generated;
+			sourceTree = "<group>";
+		};
+		B22C4B9A2964EE0F00D89051 /* connect-swift */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4B9B2964EE0F00D89051 /* grpc */,
+				B22C4B9E2964EE0F00D89051 /* eliza.connect.swift */,
+			);
+			path = "connect-swift";
+			sourceTree = "<group>";
+		};
+		B22C4B9B2964EE0F00D89051 /* grpc */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4B9C2964EE0F00D89051 /* testing */,
+			);
+			path = grpc;
+			sourceTree = "<group>";
+		};
+		B22C4B9C2964EE0F00D89051 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4B9D2964EE0F00D89051 /* test.connect.swift */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		B22C4B9F2964EE0F00D89051 /* swift-protobuf */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4BA02964EE0F00D89051 /* eliza.pb.swift */,
+				B22C4BA12964EE0F00D89051 /* grpc */,
+				B22C4BA92964EE0F00D89051 /* server */,
+			);
+			path = "swift-protobuf";
+			sourceTree = "<group>";
+		};
+		B22C4BA12964EE0F00D89051 /* grpc */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4BA22964EE0F00D89051 /* status */,
+				B22C4BA52964EE0F00D89051 /* testing */,
+			);
+			path = grpc;
+			sourceTree = "<group>";
+		};
+		B22C4BA22964EE0F00D89051 /* status */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4BA32964EE0F00D89051 /* v1 */,
+			);
+			path = status;
+			sourceTree = "<group>";
+		};
+		B22C4BA32964EE0F00D89051 /* v1 */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4BA42964EE0F00D89051 /* status.pb.swift */,
+			);
+			path = v1;
+			sourceTree = "<group>";
+		};
+		B22C4BA52964EE0F00D89051 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4BA62964EE0F00D89051 /* messages.pb.swift */,
+				B22C4BA72964EE0F00D89051 /* empty.pb.swift */,
+				B22C4BA82964EE0F00D89051 /* test.pb.swift */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		B22C4BA92964EE0F00D89051 /* server */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4BAA2964EE0F00D89051 /* v1 */,
+			);
+			path = server;
+			sourceTree = "<group>";
+		};
+		B22C4BAA2964EE0F00D89051 /* v1 */ = {
+			isa = PBXGroup;
+			children = (
+				B22C4BAB2964EE0F00D89051 /* server.pb.swift */,
+			);
+			path = v1;
+			sourceTree = "<group>";
+		};
 		B236EE7B295F564800DDCDA9 = {
 			isa = PBXGroup;
 			children = (
@@ -63,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				B236EE95295F565500DDCDA9 /* ElizaSharedSources */,
+				B22C4B992964EE0F00D89051 /* Generated */,
 				B236EE8B295F564900DDCDA9 /* Assets.xcassets */,
 			);
 			path = ElizaSwiftPackageApp;
@@ -114,7 +225,6 @@
 			name = ElizaSwiftPackageApp;
 			packageProductDependencies = (
 				B236EEA3295F569700DDCDA9 /* Connect */,
-				B236EEA5295F569700DDCDA9 /* Generated */,
 			);
 			productName = ElizaSwiftPackageApp;
 			productReference = B236EE84295F564800DDCDA9 /* ElizaSwiftPackageApp.app */;
@@ -169,10 +279,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B22C4BB02964EE0F00D89051 /* messages.pb.swift in Sources */,
+				B22C4BB12964EE0F00D89051 /* empty.pb.swift in Sources */,
 				B236EE9F295F565500DDCDA9 /* MenuView.swift in Sources */,
 				B236EE9B295F565500DDCDA9 /* Message.swift in Sources */,
+				B22C4BB22964EE0F00D89051 /* test.pb.swift in Sources */,
 				B236EE9C295F565500DDCDA9 /* MessagingView.swift in Sources */,
+				B22C4BB32964EE0F00D89051 /* server.pb.swift in Sources */,
+				B22C4BAC2964EE0F00D89051 /* test.connect.swift in Sources */,
+				B22C4BAF2964EE0F00D89051 /* status.pb.swift in Sources */,
 				B236EE9D295F565500DDCDA9 /* MessagingViewModel.swift in Sources */,
+				B22C4BAD2964EE0F00D89051 /* eliza.connect.swift in Sources */,
+				B22C4BAE2964EE0F00D89051 /* eliza.pb.swift in Sources */,
 				B236EE9E295F565500DDCDA9 /* ElizaApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -387,10 +505,6 @@
 		B236EEA3295F569700DDCDA9 /* Connect */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Connect;
-		};
-		B236EEA5295F569700DDCDA9 /* Generated */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Generated;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Package.swift
+++ b/Package.swift
@@ -23,15 +23,10 @@ let package = Package(
         .macOS(.v10_15),
     ],
     products: [
-        // Primary library for consumers to use.
+        // Primary Connect runtime that is depended on by generated classes.
         .library(
             name: "Connect",
             targets: ["Connect"]
-        ),
-        // Library used by example apps within this repository.
-        .library(
-            name: "Generated",
-            targets: ["Generated"]
         ),
         // Generator executable for Connect RPCs.
         .executable(


### PR DESCRIPTION
Exposing this publicly as a product is confusing. Removing it in favor of referencing the generated files within the Swift PM Eliza example app the same way that the CocoaPods example does.