### PR TITLE
Convert `ResponseMessage<T>` to `Result<ResponseMessage<T>, E>`

### DIFF
--- a/Connect/Interfaces/ConnectError.swift
+++ b/Connect/Interfaces/ConnectError.swift
@@ -29,6 +29,12 @@ public struct ConnectError: Swift.Error {
     /// Additional key-values that were provided by the server.
     public private(set) var metadata: Headers
 
+    public static func canceled() -> Self {
+        return .init(
+            code: .canceled, message: nil, exception: nil, details: [], metadata: [:]
+        )
+    }
+
     /// Unpacks values from `self.details` and returns the first matching error, if any.
     ///
     /// - returns: The unpacked typed error details, if available.

--- a/Connect/Interfaces/ProtocolClientInterface.swift
+++ b/Connect/Interfaces/ProtocolClientInterface.swift
@@ -36,7 +36,7 @@ public protocol ProtocolClientInterface {
         path: String,
         request: Input,
         headers: Headers,
-        completion: @escaping (ResponseMessage<Output>) -> Void
+        completion: @escaping (Result<ResponseMessage<Output>, ConnectError>) -> Void
     ) -> Cancelable
 
     /// Start a new bidirectional stream.
@@ -120,7 +120,7 @@ public protocol ProtocolClientInterface {
         path: String,
         request: Input,
         headers: Headers
-    ) async -> ResponseMessage<Output>
+    ) async -> Result<ResponseMessage<Output>, ConnectError>
 
     /// Start a new bidirectional stream.
     ///

--- a/Connect/Interfaces/ResponseMessage.swift
+++ b/Connect/Interfaces/ResponseMessage.swift
@@ -24,17 +24,33 @@ public struct ResponseMessage<Output: SwiftProtobuf.Message> {
     public let message: Output?
     /// Trailers provided by the server.
     public let trailers: Trailers
-    /// The accompanying error, if the request failed.
-    public let error: ConnectError?
 
     public init(
-        code: Code = .ok, headers: Headers = [:], message: Output?,
-        trailers: Trailers = [:], error: ConnectError? = nil
+        code: Code = .ok, headers: Headers = [:], message: Output?, trailers: Trailers = [:]
     ) {
         self.code = code
         self.headers = headers
         self.message = message
         self.trailers = trailers
-        self.error = error
+    }
+}
+
+extension Swift.Result where Failure == ConnectError {
+    public var error: ConnectError? {
+        switch self {
+        case .success:
+            return nil
+        case .failure(let error):
+            return error
+        }
+    }
+
+    public var response: Success? {
+        switch self {
+        case .success(let message):
+            return message
+        case .failure:
+            return nil
+        }
     }
 }

--- a/ConnectMocksTests/ConnectMocksTests.swift
+++ b/ConnectMocksTests/ConnectMocksTests.swift
@@ -27,12 +27,12 @@ final class ConnectMocksTests: XCTestCase {
         let client = Buf_Connect_Demo_Eliza_V1_ElizaServiceClientMock()
         client.mockSay = { request in
             XCTAssertEqual(request.sentence, "ping")
-            return ResponseMessage(message: .with { $0.sentence = "pong" })
+            return .success(.init(message: .with { $0.sentence = "pong" }))
         }
 
         var receivedMessage: Buf_Connect_Demo_Eliza_V1_SayResponse?
         client.say(request: .with { $0.sentence = "ping" }) { response in
-            receivedMessage = response.message
+            receivedMessage = try? response.get().message
         }
         XCTAssertEqual(receivedMessage?.sentence, "pong")
     }
@@ -41,11 +41,11 @@ final class ConnectMocksTests: XCTestCase {
         let client = Buf_Connect_Demo_Eliza_V1_ElizaServiceClientMock()
         client.mockAsyncSay = { request in
             XCTAssertEqual(request.sentence, "ping")
-            return ResponseMessage(message: .with { $0.sentence = "pong" })
+            return .success(.init(message: .with { $0.sentence = "pong" }))
         }
 
-        let response = await client.say(request: .with { $0.sentence = "ping" })
-        XCTAssertEqual(response.message?.sentence, "pong")
+        let result = await client.say(request: .with { $0.sentence = "ping" })
+        XCTAssertEqual(try? result.get().message?.sentence, "pong")
     }
 
     // MARK: - Bidirectional stream

--- a/Generated/connect-swift/eliza.connect.swift
+++ b/Generated/connect-swift/eliza.connect.swift
@@ -18,11 +18,11 @@ public protocol Buf_Connect_Demo_Eliza_V1_ElizaServiceClientInterface {
     /// Say is a unary request demo. This method should allow for a one sentence
     /// response given a one sentence request.
     @discardableResult
-    func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable
+    func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// Say is a unary request demo. This method should allow for a one sentence
     /// response given a one sentence request.
-    func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers) async -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>
+    func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>, Connect.ConnectError>
 
     /// Converse is a bi-directional streaming request demo. This method should allow for
     /// many requests and many responses.
@@ -50,11 +50,11 @@ public final class Buf_Connect_Demo_Eliza_V1_ElizaServiceClient: Buf_Connect_Dem
     }
 
     @discardableResult
-    public func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable {
+    public func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "buf.connect.demo.eliza.v1.ElizaService/Say", request: request, headers: headers, completion: completion)
     }
 
-    public func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse> {
+    public func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>, Connect.ConnectError> {
         return await self.client.unary(path: "buf.connect.demo.eliza.v1.ElizaService/Say", request: request, headers: headers)
     }
 

--- a/Generated/connect-swift/grpc/testing/test.connect.swift
+++ b/Generated/connect-swift/grpc/testing/test.connect.swift
@@ -13,35 +13,35 @@ public protocol Grpc_Testing_TestServiceClientInterface {
 
     /// One empty request followed by one empty response.
     @discardableResult
-    func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
+    func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// One empty request followed by one empty response.
-    func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
+    func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>
 
     /// One request followed by one response.
     @discardableResult
-    func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable
+    func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// One request followed by one response.
-    func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_SimpleResponse>
+    func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>
 
     /// One request followed by one response. This RPC always fails.
     @discardableResult
-    func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable
+    func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// One request followed by one response. This RPC always fails.
-    func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_SimpleResponse>
+    func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>
 
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     @discardableResult
-    func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable
+    func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
-    func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_SimpleResponse>
+    func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>
 
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
@@ -90,11 +90,11 @@ public protocol Grpc_Testing_TestServiceClientInterface {
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     @discardableResult
-    func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
+    func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
-    func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
+    func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented streaming output methods.
@@ -114,38 +114,38 @@ public final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceClien
     }
 
     @discardableResult
-    public func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    public func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.TestService/EmptyCall", request: request, headers: headers, completion: completion)
     }
 
-    public func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    public func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.TestService/EmptyCall", request: request, headers: headers)
     }
 
     @discardableResult
-    public func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+    public func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.TestService/UnaryCall", request: request, headers: headers, completion: completion)
     }
 
-    public func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
+    public func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.TestService/UnaryCall", request: request, headers: headers)
     }
 
     @discardableResult
-    public func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+    public func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.TestService/FailUnaryCall", request: request, headers: headers, completion: completion)
     }
 
-    public func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
+    public func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.TestService/FailUnaryCall", request: request, headers: headers)
     }
 
     @discardableResult
-    public func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+    public func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers, completion: completion)
     }
 
-    public func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
+    public func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers)
     }
 
@@ -190,11 +190,11 @@ public final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceClien
     }
 
     @discardableResult
-    public func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    public func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.TestService/UnimplementedCall", request: request, headers: headers, completion: completion)
     }
 
-    public func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    public func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.TestService/UnimplementedCall", request: request, headers: headers)
     }
 
@@ -213,10 +213,10 @@ public protocol Grpc_Testing_UnimplementedServiceClientInterface {
 
     /// A call that no server should implement
     @discardableResult
-    func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
+    func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// A call that no server should implement
-    func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
+    func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>
 
     /// A call that no server should implement
     func `unimplementedStreamingOutputCall`(headers: Connect.Headers, onResult: @escaping (Connect.StreamResult<Grpc_Testing_Empty>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_Empty>
@@ -234,11 +234,11 @@ public final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimple
     }
 
     @discardableResult
-    public func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    public func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers, completion: completion)
     }
 
-    public func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    public func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers)
     }
 
@@ -255,14 +255,14 @@ public final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimple
 public protocol Grpc_Testing_ReconnectServiceClientInterface {
 
     @discardableResult
-    func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
+    func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
-    func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
+    func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>
 
     @discardableResult
-    func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void) -> Connect.Cancelable
+    func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_ReconnectInfo>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
-    func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_ReconnectInfo>
+    func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_ReconnectInfo>, Connect.ConnectError>
 }
 
 /// Concrete implementation of `Grpc_Testing_ReconnectServiceClientInterface`.
@@ -274,20 +274,20 @@ public final class Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectSe
     }
 
     @discardableResult
-    public func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    public func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.ReconnectService/Start", request: request, headers: headers, completion: completion)
     }
 
-    public func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    public func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.ReconnectService/Start", request: request, headers: headers)
     }
 
     @discardableResult
-    public func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void) -> Connect.Cancelable {
+    public func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_ReconnectInfo>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.ReconnectService/Stop", request: request, headers: headers, completion: completion)
     }
 
-    public func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ReconnectInfo> {
+    public func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_ReconnectInfo>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.ReconnectService/Stop", request: request, headers: headers)
     }
 }
@@ -297,17 +297,17 @@ public protocol Grpc_Testing_LoadBalancerStatsServiceClientInterface {
 
     /// Gets the backend distribution for RPCs sent by a test client.
     @discardableResult
-    func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void) -> Connect.Cancelable
+    func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// Gets the backend distribution for RPCs sent by a test client.
-    func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>
+    func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>, Connect.ConnectError>
 
     /// Gets the accumulated stats for RPCs sent by a test client.
     @discardableResult
-    func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void) -> Connect.Cancelable
+    func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// Gets the accumulated stats for RPCs sent by a test client.
-    func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>
+    func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>, Connect.ConnectError>
 }
 
 /// Concrete implementation of `Grpc_Testing_LoadBalancerStatsServiceClientInterface`.
@@ -319,20 +319,20 @@ public final class Grpc_Testing_LoadBalancerStatsServiceClient: Grpc_Testing_Loa
     }
 
     @discardableResult
-    public func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void) -> Connect.Cancelable {
+    public func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers, completion: completion)
     }
 
-    public func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> {
+    public func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers)
     }
 
     @discardableResult
-    public func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void) -> Connect.Cancelable {
+    public func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers, completion: completion)
     }
 
-    public func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> {
+    public func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers)
     }
 }
@@ -341,14 +341,14 @@ public final class Grpc_Testing_LoadBalancerStatsServiceClient: Grpc_Testing_Loa
 public protocol Grpc_Testing_XdsUpdateHealthServiceClientInterface {
 
     @discardableResult
-    func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
+    func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
-    func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
+    func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>
 
     @discardableResult
-    func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
+    func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
-    func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
+    func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>
 }
 
 /// Concrete implementation of `Grpc_Testing_XdsUpdateHealthServiceClientInterface`.
@@ -360,20 +360,20 @@ public final class Grpc_Testing_XdsUpdateHealthServiceClient: Grpc_Testing_XdsUp
     }
 
     @discardableResult
-    public func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    public func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers, completion: completion)
     }
 
-    public func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    public func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers)
     }
 
     @discardableResult
-    public func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    public func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers, completion: completion)
     }
 
-    public func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    public func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers)
     }
 }
@@ -383,10 +383,10 @@ public protocol Grpc_Testing_XdsUpdateClientConfigureServiceClientInterface {
 
     /// Update the tes client's configuration.
     @discardableResult
-    func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void) -> Connect.Cancelable
+    func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers, completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_ClientConfigureResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable
 
     /// Update the tes client's configuration.
-    func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_ClientConfigureResponse>
+    func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers) async -> Swift.Result<ResponseMessage<Grpc_Testing_ClientConfigureResponse>, Connect.ConnectError>
 }
 
 /// Concrete implementation of `Grpc_Testing_XdsUpdateClientConfigureServiceClientInterface`.
@@ -398,11 +398,11 @@ public final class Grpc_Testing_XdsUpdateClientConfigureServiceClient: Grpc_Test
     }
 
     @discardableResult
-    public func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void) -> Connect.Cancelable {
+    public func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_ClientConfigureResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers, completion: completion)
     }
 
-    public func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> {
+    public func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_ClientConfigureResponse>, Connect.ConnectError> {
         return await self.client.unary(path: "grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers)
     }
 }

--- a/GeneratedMocks/connect-swift/eliza.mock.swift
+++ b/GeneratedMocks/connect-swift/eliza.mock.swift
@@ -20,9 +20,9 @@ open class Buf_Connect_Demo_Eliza_V1_ElizaServiceClientMock: Buf_Connect_Demo_El
     private var cancellables = [Combine.AnyCancellable]()
 
     /// Mocked for calls to `say()`.
-    public var mockSay = { (_: Buf_Connect_Demo_Eliza_V1_SayRequest) -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse> in .init(message: .init()) }
+    public var mockSay = { (_: Buf_Connect_Demo_Eliza_V1_SayRequest) -> Result<ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `say()`.
-    public var mockAsyncSay = { (_: Buf_Connect_Demo_Eliza_V1_SayRequest) -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse> in .init(message: .init()) }
+    public var mockAsyncSay = { (_: Buf_Connect_Demo_Eliza_V1_SayRequest) -> Result<ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `converse()`.
     public var mockConverse = MockBidirectionalStream<Buf_Connect_Demo_Eliza_V1_ConverseRequest, Buf_Connect_Demo_Eliza_V1_ConverseResponse>()
     /// Mocked for async calls to `converse()`.
@@ -35,13 +35,13 @@ open class Buf_Connect_Demo_Eliza_V1_ElizaServiceClientMock: Buf_Connect_Demo_El
     public init() {}
 
     @discardableResult
-    open func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable {
+    open func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockSay(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse> {
+    open func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>, Connect.ConnectError> {
         return self.mockAsyncSay(request)
     }
 

--- a/GeneratedMocks/connect-swift/grpc/testing/test.mock.swift
+++ b/GeneratedMocks/connect-swift/grpc/testing/test.mock.swift
@@ -20,21 +20,21 @@ open class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClientInt
     private var cancellables = [Combine.AnyCancellable]()
 
     /// Mocked for calls to `emptyCall()`.
-    public var mockEmptyCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockEmptyCall = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `emptyCall()`.
-    public var mockAsyncEmptyCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockAsyncEmptyCall = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `unaryCall()`.
-    public var mockUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(message: .init()) }
+    public var mockUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> Result<ResponseMessage<Grpc_Testing_SimpleResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `unaryCall()`.
-    public var mockAsyncUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(message: .init()) }
+    public var mockAsyncUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> Result<ResponseMessage<Grpc_Testing_SimpleResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `failUnaryCall()`.
-    public var mockFailUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(message: .init()) }
+    public var mockFailUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> Result<ResponseMessage<Grpc_Testing_SimpleResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `failUnaryCall()`.
-    public var mockAsyncFailUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(message: .init()) }
+    public var mockAsyncFailUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> Result<ResponseMessage<Grpc_Testing_SimpleResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `cacheableUnaryCall()`.
-    public var mockCacheableUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(message: .init()) }
+    public var mockCacheableUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> Result<ResponseMessage<Grpc_Testing_SimpleResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `cacheableUnaryCall()`.
-    public var mockAsyncCacheableUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(message: .init()) }
+    public var mockAsyncCacheableUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> Result<ResponseMessage<Grpc_Testing_SimpleResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `streamingOutputCall()`.
     public var mockStreamingOutputCall = MockServerOnlyStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for async calls to `streamingOutputCall()`.
@@ -56,9 +56,9 @@ open class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClientInt
     /// Mocked for async calls to `halfDuplexCall()`.
     public var mockAsyncHalfDuplexCall = MockBidirectionalAsyncStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for calls to `unimplementedCall()`.
-    public var mockUnimplementedCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockUnimplementedCall = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `unimplementedCall()`.
-    public var mockAsyncUnimplementedCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockAsyncUnimplementedCall = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `unimplementedStreamingOutputCall()`.
     public var mockUnimplementedStreamingOutputCall = MockServerOnlyStream<Grpc_Testing_Empty, Grpc_Testing_Empty>()
     /// Mocked for async calls to `unimplementedStreamingOutputCall()`.
@@ -67,46 +67,46 @@ open class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClientInt
     public init() {}
 
     @discardableResult
-    open func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    open func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockEmptyCall(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    open func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return self.mockAsyncEmptyCall(request)
     }
 
     @discardableResult
-    open func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+    open func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockUnaryCall(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
+    open func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError> {
         return self.mockAsyncUnaryCall(request)
     }
 
     @discardableResult
-    open func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+    open func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockFailUnaryCall(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
+    open func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError> {
         return self.mockAsyncFailUnaryCall(request)
     }
 
     @discardableResult
-    open func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
+    open func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockCacheableUnaryCall(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
+    open func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_SimpleResponse>, Connect.ConnectError> {
         return self.mockAsyncCacheableUnaryCall(request)
     }
 
@@ -156,13 +156,13 @@ open class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClientInt
     }
 
     @discardableResult
-    open func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    open func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockUnimplementedCall(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    open func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return self.mockAsyncUnimplementedCall(request)
     }
 
@@ -186,9 +186,9 @@ open class Grpc_Testing_UnimplementedServiceClientMock: Grpc_Testing_Unimplement
     private var cancellables = [Combine.AnyCancellable]()
 
     /// Mocked for calls to `unimplementedCall()`.
-    public var mockUnimplementedCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockUnimplementedCall = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `unimplementedCall()`.
-    public var mockAsyncUnimplementedCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockAsyncUnimplementedCall = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `unimplementedStreamingOutputCall()`.
     public var mockUnimplementedStreamingOutputCall = MockServerOnlyStream<Grpc_Testing_Empty, Grpc_Testing_Empty>()
     /// Mocked for async calls to `unimplementedStreamingOutputCall()`.
@@ -197,13 +197,13 @@ open class Grpc_Testing_UnimplementedServiceClientMock: Grpc_Testing_Unimplement
     public init() {}
 
     @discardableResult
-    open func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    open func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockUnimplementedCall(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    open func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return self.mockAsyncUnimplementedCall(request)
     }
 
@@ -227,35 +227,35 @@ open class Grpc_Testing_ReconnectServiceClientMock: Grpc_Testing_ReconnectServic
     private var cancellables = [Combine.AnyCancellable]()
 
     /// Mocked for calls to `start()`.
-    public var mockStart = { (_: Grpc_Testing_ReconnectParams) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockStart = { (_: Grpc_Testing_ReconnectParams) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `start()`.
-    public var mockAsyncStart = { (_: Grpc_Testing_ReconnectParams) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockAsyncStart = { (_: Grpc_Testing_ReconnectParams) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `stop()`.
-    public var mockStop = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_ReconnectInfo> in .init(message: .init()) }
+    public var mockStop = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_ReconnectInfo>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `stop()`.
-    public var mockAsyncStop = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_ReconnectInfo> in .init(message: .init()) }
+    public var mockAsyncStop = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_ReconnectInfo>, ConnectError> in .success(.init(message: .init())) }
 
     public init() {}
 
     @discardableResult
-    open func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    open func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockStart(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    open func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return self.mockAsyncStart(request)
     }
 
     @discardableResult
-    open func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void) -> Connect.Cancelable {
+    open func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_ReconnectInfo>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockStop(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ReconnectInfo> {
+    open func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_ReconnectInfo>, Connect.ConnectError> {
         return self.mockAsyncStop(request)
     }
 }
@@ -270,35 +270,35 @@ open class Grpc_Testing_LoadBalancerStatsServiceClientMock: Grpc_Testing_LoadBal
     private var cancellables = [Combine.AnyCancellable]()
 
     /// Mocked for calls to `getClientStats()`.
-    public var mockGetClientStats = { (_: Grpc_Testing_LoadBalancerStatsRequest) -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> in .init(message: .init()) }
+    public var mockGetClientStats = { (_: Grpc_Testing_LoadBalancerStatsRequest) -> Result<ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `getClientStats()`.
-    public var mockAsyncGetClientStats = { (_: Grpc_Testing_LoadBalancerStatsRequest) -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> in .init(message: .init()) }
+    public var mockAsyncGetClientStats = { (_: Grpc_Testing_LoadBalancerStatsRequest) -> Result<ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `getClientAccumulatedStats()`.
-    public var mockGetClientAccumulatedStats = { (_: Grpc_Testing_LoadBalancerAccumulatedStatsRequest) -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> in .init(message: .init()) }
+    public var mockGetClientAccumulatedStats = { (_: Grpc_Testing_LoadBalancerAccumulatedStatsRequest) -> Result<ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `getClientAccumulatedStats()`.
-    public var mockAsyncGetClientAccumulatedStats = { (_: Grpc_Testing_LoadBalancerAccumulatedStatsRequest) -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> in .init(message: .init()) }
+    public var mockAsyncGetClientAccumulatedStats = { (_: Grpc_Testing_LoadBalancerAccumulatedStatsRequest) -> Result<ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>, ConnectError> in .success(.init(message: .init())) }
 
     public init() {}
 
     @discardableResult
-    open func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void) -> Connect.Cancelable {
+    open func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockGetClientStats(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> {
+    open func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>, Connect.ConnectError> {
         return self.mockAsyncGetClientStats(request)
     }
 
     @discardableResult
-    open func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void) -> Connect.Cancelable {
+    open func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockGetClientAccumulatedStats(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> {
+    open func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>, Connect.ConnectError> {
         return self.mockAsyncGetClientAccumulatedStats(request)
     }
 }
@@ -313,35 +313,35 @@ open class Grpc_Testing_XdsUpdateHealthServiceClientMock: Grpc_Testing_XdsUpdate
     private var cancellables = [Combine.AnyCancellable]()
 
     /// Mocked for calls to `setServing()`.
-    public var mockSetServing = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockSetServing = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `setServing()`.
-    public var mockAsyncSetServing = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockAsyncSetServing = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for calls to `setNotServing()`.
-    public var mockSetNotServing = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockSetNotServing = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `setNotServing()`.
-    public var mockAsyncSetNotServing = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(message: .init()) }
+    public var mockAsyncSetNotServing = { (_: Grpc_Testing_Empty) -> Result<ResponseMessage<Grpc_Testing_Empty>, ConnectError> in .success(.init(message: .init())) }
 
     public init() {}
 
     @discardableResult
-    open func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    open func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockSetServing(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    open func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return self.mockAsyncSetServing(request)
     }
 
     @discardableResult
-    open func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
+    open func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockSetNotServing(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
+    open func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_Empty>, Connect.ConnectError> {
         return self.mockAsyncSetNotServing(request)
     }
 }
@@ -356,20 +356,20 @@ open class Grpc_Testing_XdsUpdateClientConfigureServiceClientMock: Grpc_Testing_
     private var cancellables = [Combine.AnyCancellable]()
 
     /// Mocked for calls to `configure()`.
-    public var mockConfigure = { (_: Grpc_Testing_ClientConfigureRequest) -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> in .init(message: .init()) }
+    public var mockConfigure = { (_: Grpc_Testing_ClientConfigureRequest) -> Result<ResponseMessage<Grpc_Testing_ClientConfigureResponse>, ConnectError> in .success(.init(message: .init())) }
     /// Mocked for async calls to `configure()`.
-    public var mockAsyncConfigure = { (_: Grpc_Testing_ClientConfigureRequest) -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> in .init(message: .init()) }
+    public var mockAsyncConfigure = { (_: Grpc_Testing_ClientConfigureRequest) -> Result<ResponseMessage<Grpc_Testing_ClientConfigureResponse>, ConnectError> in .success(.init(message: .init())) }
 
     public init() {}
 
     @discardableResult
-    open func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void) -> Connect.Cancelable {
+    open func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:], completion: @escaping (Swift.Result<ResponseMessage<Grpc_Testing_ClientConfigureResponse>, Connect.ConnectError>) -> Void) -> Connect.Cancelable {
         completion(self.mockConfigure(request))
         return Connect.Cancelable {}
     }
 
     @discardableResult
-    open func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> {
+    open func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:]) async -> Swift.Result<ResponseMessage<Grpc_Testing_ClientConfigureResponse>, Connect.ConnectError> {
         return self.mockAsyncConfigure(request)
     }
 }

--- a/protoc-gen-connect-swift/ConnectMockGenerator.swift
+++ b/protoc-gen-connect-swift/ConnectMockGenerator.swift
@@ -178,7 +178,9 @@ private extension MethodDescriptor {
             return "MockClientOnlyStream<\(inputName), \(outputName)>()"
         } else {
             return """
-            { (_: \(inputName)) -> ResponseMessage<\(outputName)> in .init(message: .init()) }
+            { (_: \(inputName)) -> Result<ResponseMessage<\(outputName)>, ConnectError> in \
+            .success(.init(message: .init())) \
+            }
             """
         }
     }
@@ -194,7 +196,9 @@ private extension MethodDescriptor {
             return "MockClientOnlyAsyncStream<\(inputName), \(outputName)>()"
         } else {
             return """
-            { (_: \(inputName)) -> ResponseMessage<\(outputName)> in .init(message: .init()) }
+            { (_: \(inputName)) -> Result<ResponseMessage<\(outputName)>, ConnectError> in \
+            .success(.init(message: .init())) \
+            }
             """
         }
     }

--- a/protoc-gen-connect-swift/MethodDescriptor+Extensions.swift
+++ b/protoc-gen-connect-swift/MethodDescriptor+Extensions.swift
@@ -62,7 +62,9 @@ extension MethodDescriptor {
             return """
             func `\(methodName)`\
             (request: \(inputName), headers: Connect.Headers\(includeDefaults ? " = [:]" : ""), \
-            completion: @escaping (ResponseMessage<\(outputName)>) -> Void) \
+            completion: \
+            @escaping (Swift.Result<ResponseMessage<\(outputName)>, Connect.ConnectError>) \
+            -> Void) \
             -> Connect.Cancelable
             """
         }
@@ -98,7 +100,7 @@ extension MethodDescriptor {
             return """
             func `\(methodName)`\
             (request: \(inputName), headers: Connect.Headers\(includeDefaults ? " = [:]" : "")) \
-            async -> ResponseMessage<\(outputName)>
+            async -> Swift.Result<ResponseMessage<\(outputName)>, Connect.ConnectError>
             """
         }
     }


### PR DESCRIPTION
This has the benefit of ensuring that only one of `response` or `error` is specified, making it clear to consumers that they are mutually exclusive. This also adds helper extensions to the relevant `Result` to provide `.response` and `.error` accessors so that consumers don't necessarily have to `switch` over the result.