### PR TITLE
Default generator to only generate async/await interfaces

### DIFF
--- a/ConnectExamples/ElizaSharedSources/GeneratedSources/eliza.connect.swift
+++ b/ConnectExamples/ElizaSharedSources/GeneratedSources/eliza.connect.swift
@@ -17,24 +17,11 @@ internal protocol Buf_Connect_Demo_Eliza_V1_ElizaServiceClientInterface {
 
     /// Say is a unary request demo. This method should allow for a one sentence
     /// response given a one sentence request.
-    @discardableResult
-    func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable
-
-    /// Say is a unary request demo. This method should allow for a one sentence
-    /// response given a one sentence request.
     func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers) async -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>
 
     /// Converse is a bi-directional streaming request demo. This method should allow for
     /// many requests and many responses.
-    func `converse`(headers: Connect.Headers, onResult: @escaping (Connect.StreamResult<Buf_Connect_Demo_Eliza_V1_ConverseResponse>) -> Void) -> any Connect.BidirectionalStreamInterface<Buf_Connect_Demo_Eliza_V1_ConverseRequest>
-
-    /// Converse is a bi-directional streaming request demo. This method should allow for
-    /// many requests and many responses.
     func `converse`(headers: Connect.Headers) -> any Connect.BidirectionalAsyncStreamInterface<Buf_Connect_Demo_Eliza_V1_ConverseRequest, Buf_Connect_Demo_Eliza_V1_ConverseResponse>
-
-    /// Introduce is a server-streaming request demo.  This method allows for a single request that will return a series
-    /// of responses
-    func `introduce`(headers: Connect.Headers, onResult: @escaping (Connect.StreamResult<Buf_Connect_Demo_Eliza_V1_IntroduceResponse>) -> Void) -> any Connect.ServerOnlyStreamInterface<Buf_Connect_Demo_Eliza_V1_IntroduceRequest>
 
     /// Introduce is a server-streaming request demo.  This method allows for a single request that will return a series
     /// of responses
@@ -49,25 +36,12 @@ internal final class Buf_Connect_Demo_Eliza_V1_ElizaServiceClient: Buf_Connect_D
         self.client = client
     }
 
-    @discardableResult
-    internal func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "buf.connect.demo.eliza.v1.ElizaService/Say", request: request, headers: headers, completion: completion)
-    }
-
     internal func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse> {
         return await self.client.unary(path: "buf.connect.demo.eliza.v1.ElizaService/Say", request: request, headers: headers)
     }
 
-    internal func `converse`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Buf_Connect_Demo_Eliza_V1_ConverseResponse>) -> Void) -> any Connect.BidirectionalStreamInterface<Buf_Connect_Demo_Eliza_V1_ConverseRequest> {
-        return self.client.bidirectionalStream(path: "buf.connect.demo.eliza.v1.ElizaService/Converse", headers: headers, onResult: onResult)
-    }
-
     internal func `converse`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Buf_Connect_Demo_Eliza_V1_ConverseRequest, Buf_Connect_Demo_Eliza_V1_ConverseResponse> {
         return self.client.bidirectionalStream(path: "buf.connect.demo.eliza.v1.ElizaService/Converse", headers: headers)
-    }
-
-    internal func `introduce`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Buf_Connect_Demo_Eliza_V1_IntroduceResponse>) -> Void) -> any Connect.ServerOnlyStreamInterface<Buf_Connect_Demo_Eliza_V1_IntroduceRequest> {
-        return self.client.serverOnlyStream(path: "buf.connect.demo.eliza.v1.ElizaService/Introduce", headers: headers, onResult: onResult)
     }
 
     internal func `introduce`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Buf_Connect_Demo_Eliza_V1_IntroduceRequest, Buf_Connect_Demo_Eliza_V1_IntroduceResponse> {

--- a/ConnectTests/buf.gen.yaml
+++ b/ConnectTests/buf.gen.yaml
@@ -4,7 +4,12 @@ plugins:
     opt: Visibility=Internal
     out: ./Generated
   - name: connect-swift
-    opt: Visibility=Internal
+    opt: >
+      GenerateAsyncMocks=false,
+      GenerateCallbackMocks=false,
+      GenerateAsyncMethods=true,
+      GenerateCallbackMethods=true,
+      Visibility=Internal
     out: ./Generated
     path: ../.tmp/bin/protoc-gen-connect-swift
   - name: connect-swift

--- a/protoc-gen-connect-swift/GeneratorOptions.swift
+++ b/protoc-gen-connect-swift/GeneratorOptions.swift
@@ -74,7 +74,7 @@ struct GeneratorOptions {
     private(set) var fileNaming = FileNaming.fullPath
     private(set) var generateAsyncMethods = true
     private(set) var generateAsyncMocks = false
-    private(set) var generateCallbackMethods = true
+    private(set) var generateCallbackMethods = false
     private(set) var generateCallbackMocks = false
     private(set) var keepMethodCasing = false
     private(set) var protoToModuleMappings = ProtoFileToModuleMappings()


### PR DESCRIPTION
Defaulting to only generating async/await instead of both async/await and callbacks. This default is what users are most likely going to want out-of-the-box (not both implementations side-by-side).