### PR TITLE
Handle `grpc-status` in headers rather than only trailers

### DIFF
--- a/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
+++ b/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
@@ -172,7 +172,7 @@ private func grpcResult(
     } else {
         return (.unknown, nil)
     }
-    
+
     let grpcCode = finalTrailers.grpcStatus() ?? .unknown
     return (grpcCode, .fromGRPCTrailers(finalTrailers, code: grpcCode))
 }

--- a/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
+++ b/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
@@ -51,7 +51,7 @@ extension GRPCInterceptor: Connect.Interceptor {
 
                 guard let responseData = response.message, !responseData.isEmpty else {
                     let grpcCode = response.trailers.grpcStatus()
-                    ?? response.headers.grpcStatus() // Trailers-only can be send in headers block
+                    ?? response.headers.grpcStatus() // Trailers-only can be sent in headers block
                     ?? response.code
                     return Connect.HTTPResponse(
                         code: grpcCode,

--- a/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
+++ b/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
@@ -50,14 +50,17 @@ extension GRPCInterceptor: Connect.Interceptor {
                 }
 
                 guard let responseData = response.message, !responseData.isEmpty else {
-                    let code = response.trailers.grpcStatus() ?? response.code
+                    let grpcCode = response.trailers.grpcStatus()
+                    ?? response.headers.grpcStatus() // Trailers-only can be send in headers block
+                    ?? response.code
                     return Connect.HTTPResponse(
-                        code: code,
+                        code: grpcCode,
                         headers: response.headers,
                         message: response.message,
                         trailers: response.trailers,
                         error: response.error ?? ConnectError.fromGRPCTrailers(
-                            response.trailers, code: code
+                            response.trailers.isEmpty ? response.headers : response.trailers,
+                            code: grpcCode
                         ),
                         tracingInfo: response.tracingInfo
                     )

--- a/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
@@ -356,7 +356,6 @@ final class AsyncAwaitConformance: XCTestCase {
             let response = await client.failUnaryCall(
                 request: Connectrpc_Conformance_V1_SimpleRequest()
             )
-            XCTAssertEqual(response.code, .resourceExhausted)
             XCTAssertEqual(response.error?.code, .resourceExhausted)
             XCTAssertEqual(response.error?.message, "soirée 🎉")
             XCTAssertEqual(response.error?.unpackedDetails(), [expectedErrorDetail])

--- a/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
@@ -356,6 +356,7 @@ final class AsyncAwaitConformance: XCTestCase {
             let response = await client.failUnaryCall(
                 request: Connectrpc_Conformance_V1_SimpleRequest()
             )
+            XCTAssertEqual(response.code, .resourceExhausted)
             XCTAssertEqual(response.error?.code, .resourceExhausted)
             XCTAssertEqual(response.error?.message, "soirée 🎉")
             XCTAssertEqual(response.error?.unpackedDetails(), [expectedErrorDetail])

--- a/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
@@ -385,6 +385,7 @@ final class CallbackConformance: XCTestCase {
             }
             let expectation = self.expectation(description: "Request completes")
             client.failUnaryCall(request: Connectrpc_Conformance_V1_SimpleRequest()) { response in
+                XCTAssertEqual(response.code, .resourceExhausted)
                 XCTAssertEqual(response.error?.code, .resourceExhausted)
                 XCTAssertEqual(response.error?.message, "soirée 🎉")
                 XCTAssertEqual(response.error?.unpackedDetails(), [expectedErrorDetail])

--- a/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
@@ -301,14 +301,17 @@ final class CallbackConformance: XCTestCase {
     }
 
     func testUnimplementedMethod() {
+        let validErrorMessages = [
+            // connect-go
+            "connectrpc.conformance.v1.TestService.UnimplementedCall is not implemented",
+            // grpc-go
+            "method UnimplementedCall not implemented",
+        ]
         self.executeTestWithClients { client in
             let expectation = self.expectation(description: "Request completes")
             client.unimplementedCall(request: SwiftProtobuf.Google_Protobuf_Empty()) { response in
                 XCTAssertEqual(response.code, .unimplemented)
-                XCTAssertEqual(
-                    response.error?.message,
-                    "connectrpc.conformance.v1.TestService.UnimplementedCall is not implemented"
-                )
+                XCTAssertTrue(validErrorMessages.contains(response.error?.message ?? ""))
                 expectation.fulfill()
             }
 
@@ -317,6 +320,15 @@ final class CallbackConformance: XCTestCase {
     }
 
     func testUnimplementedServerStreamingMethod() throws {
+        let validErrorMessages = [
+            // connect-go
+            """
+            connectrpc.conformance.v1.TestService.UnimplementedStreamingOutputCall is \
+            not implemented
+            """,
+            // grpc-go
+            "method UnimplementedStreamingOutputCall not implemented",
+        ]
         try self.executeTestWithClients { client in
             let expectation = self.expectation(description: "Stream completes")
             let stream = client.unimplementedStreamingOutputCall { result in
@@ -326,13 +338,9 @@ final class CallbackConformance: XCTestCase {
 
                 case .complete(let code, let error, _):
                     XCTAssertEqual(code, .unimplemented)
-                    XCTAssertEqual(
-                        (error as? ConnectError)?.message,
-                        """
-                        connectrpc.conformance.v1.TestService.UnimplementedStreamingOutputCall is \
-                        not implemented
-                        """
-                    )
+                    XCTAssertTrue(validErrorMessages.contains(
+                        (error as? ConnectError)?.message ?? ""
+                    ))
                     expectation.fulfill()
                 }
             }

--- a/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
@@ -385,7 +385,6 @@ final class CallbackConformance: XCTestCase {
             }
             let expectation = self.expectation(description: "Request completes")
             client.failUnaryCall(request: Connectrpc_Conformance_V1_SimpleRequest()) { response in
-                XCTAssertEqual(response.code, .resourceExhausted)
                 XCTAssertEqual(response.error?.code, .resourceExhausted)
                 XCTAssertEqual(response.error?.message, "soirée 🎉")
                 XCTAssertEqual(response.error?.unpackedDetails(), [expectedErrorDetail])

--- a/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
@@ -48,6 +48,7 @@ final class ConformanceConfiguration {
             codecs: [Codec],
             port: Int
         )] = [
+            // Port 8081 is used to test against connect-go
             (.connect, [urlSessionClient, nioClient8081], [JSONCodec(), ProtoCodec()], 8081),
             (.grpcWeb, [urlSessionClient, nioClient8081], [JSONCodec(), ProtoCodec()], 8081),
             // URLSession does not support gRPC

--- a/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// swiftlint:disable number_separator
+
 import Connect
 import ConnectNIO
 import Foundation
@@ -35,13 +37,12 @@ final class ConformanceConfiguration {
     static func all(timeout: TimeInterval) -> [ConformanceConfiguration] {
         let urlSessionClient = ConformanceURLSessionHTTPClient(timeout: timeout)
         let nioClient8081 = ConformanceNIOHTTPClient(
-            // swiftlint:disable:next number_separator
             host: "https://localhost", port: 8081, timeout: timeout
         )
         let nioClient8083 = ConformanceNIOHTTPClient(
-            // swiftlint:disable:next number_separator
             host: "https://localhost", port: 8083, timeout: timeout
         )
+        // swiftlint:disable:next large_tuple
         let matrix: [(
             networkProtocol: NetworkProtocol,
             httpClients: [HTTPClientInterface],

--- a/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
@@ -54,7 +54,7 @@ final class ConformanceConfiguration {
             (.grpcWeb, [urlSessionClient, nioClient8081], [JSONCodec(), ProtoCodec()], 8081),
             // URLSession does not support gRPC
             (.grpc, [nioClient8081], [JSONCodec(), ProtoCodec()], 8081),
-            // gRPC should also be tested against grpc-go, which runs on a separate port
+            // gRPC should also be tested against grpc-go, which runs on port 8083
             (.grpc, [nioClient8083], [ProtoCodec()], 8083),
         ]
         return matrix.reduce(into: [ConformanceConfiguration]()) { configurations, tuple in


### PR DESCRIPTION
"Trailers-only" responses can actually be just headers, in which case we should read `grpc-status` from them.

This PR:
- Updates the logic for both unary and streaming APIs to properly handle cases where "trailers-only" responses are returned using the headers block
- Updates the conformance test suite to test against grpc-go in addition to connect-go in order to catch this case. (grpc-go returns "trailers-only" responses in headers, and connect-go returns them in trailers)

Here's the new logic for gRPC:
- If non-HTTP 200, report an invalid response
- If no body data, assume "trailers-only"
  - Look for the gRPC status and error details in the headers
  - Look for the gRPC status and error details in the trailers
  - If the status is an error, don't process the body

Resolves #168.