### PR TITLE
Remove unnecessary `te` headers from gRPC-Web

### DIFF
--- a/Libraries/Connect/Implementation/GRPC/Headers+GRPC.swift
+++ b/Libraries/Connect/Implementation/GRPC/Headers+GRPC.swift
@@ -19,15 +19,18 @@ extension Headers {
     ///
     /// - parameter config: The configuration to use for adding headers (i.e., for compression
     ///                     headers).
+    /// - parameter grpcWeb: Should be true if using gRPC-Web, false if gRPC.
     ///
     /// - returns: A set of updated headers.
-    public func addingGRPCHeaders(using config: ProtocolClientConfig) -> Self {
+    public func addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
         var headers = self
         headers[HeaderConstants.grpcAcceptEncoding] = config
             .acceptCompressionPoolNames()
         headers[HeaderConstants.grpcContentEncoding] = config.requestCompression
             .map { [$0.pool.name()] }
-        headers[HeaderConstants.grpcTE] = ["trailers"]
+        if !grpcWeb {
+            headers[HeaderConstants.grpcTE] = ["trailers"]
+        }
 
         // Note that we do not comply with the recommended structure for user-agent:
         // https://github.com/grpc/grpc/blob/v1.51.1/doc/PROTOCOL-HTTP2.md#user-agents

--- a/Libraries/Connect/Implementation/Interceptors/GRPCWebInterceptor.swift
+++ b/Libraries/Connect/Implementation/Interceptors/GRPCWebInterceptor.swift
@@ -37,7 +37,7 @@ extension GRPCWebInterceptor: Interceptor {
                     url: request.url,
                     // Override the content type to be gRPC Web.
                     contentType: "application/grpc-web+\(self.config.codec.name())",
-                    headers: request.headers.addingGRPCHeaders(using: self.config),
+                    headers: request.headers.addingGRPCHeaders(using: self.config, grpcWeb: true),
                     message: envelopedRequestBody,
                     trailers: nil
                 )
@@ -118,7 +118,7 @@ extension GRPCWebInterceptor: Interceptor {
                     url: request.url,
                     // Override the content type to be gRPC Web.
                     contentType: "application/grpc-web+\(self.config.codec.name())",
-                    headers: request.headers.addingGRPCHeaders(using: self.config),
+                    headers: request.headers.addingGRPCHeaders(using: self.config, grpcWeb: true),
                     message: request.message,
                     trailers: nil
                 )

--- a/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
+++ b/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
@@ -38,7 +38,7 @@ extension GRPCInterceptor: Connect.Interceptor {
                     url: request.url,
                     // Override the content type to be gRPC.
                     contentType: "application/grpc+\(self.config.codec.name())",
-                    headers: request.headers.addingGRPCHeaders(using: self.config),
+                    headers: request.headers.addingGRPCHeaders(using: self.config, grpcWeb: false),
                     message: envelopedRequestBody,
                     trailers: nil
                 )
@@ -102,7 +102,7 @@ extension GRPCInterceptor: Connect.Interceptor {
                     url: request.url,
                     // Override the content type to be gRPC.
                     contentType: "application/grpc+\(self.config.codec.name())",
-                    headers: request.headers.addingGRPCHeaders(using: self.config),
+                    headers: request.headers.addingGRPCHeaders(using: self.config, grpcWeb: false),
                     message: request.message,
                     trailers: nil
                 )


### PR DESCRIPTION
This is only necessary for gRPC.

Matches Connect-Go: https://github.com/connectrpc/connect-go/blob/065b6ad19e9243bb66472c20f88504fc3c8e9fbb/protocol_grpc.go#L278

Kotlin is also being updated: https://github.com/connectrpc/connect-kotlin/pull/101/files#r1329474025