### PR TITLE
Relax `Sendable` requirements for interceptors

### DIFF
--- a/Libraries/Connect/Implementation/Interceptors/InterceptorChain.swift
+++ b/Libraries/Connect/Implementation/Interceptors/InterceptorChain.swift
@@ -14,7 +14,7 @@
 
 /// Represents a chain of interceptors that is used for a single request/stream,
 /// and orchestrates invoking each of them in the proper order.
-struct InterceptorChain: Sendable {
+struct InterceptorChain: @unchecked Sendable {
     private let interceptors: [Interceptor]
 
     /// Initialize the interceptor chain.
@@ -83,7 +83,7 @@ struct InterceptorChain: Sendable {
     }
 }
 
-private func executeInterceptors<T>(_ interceptors: [@Sendable (T) -> T], initial: T) -> T {
+private func executeInterceptors<T>(_ interceptors: [(T) -> T], initial: T) -> T {
     var next = initial
     for interceptor in interceptors {
         next = interceptor(next)

--- a/Libraries/Connect/Interfaces/Interceptor.swift
+++ b/Libraries/Connect/Interfaces/Interceptor.swift
@@ -18,7 +18,7 @@ import Foundation
 /// and inbound responses.
 ///
 /// Interceptors are expected to be instantiated once per request/stream.
-public protocol Interceptor: Sendable {
+public protocol Interceptor {
     /// Invoked when a unary call is started. Provides a set of closures that will be called
     /// as the request progresses, allowing the interceptor to alter request/response data.
     ///
@@ -39,15 +39,15 @@ public protocol Interceptor: Sendable {
 
 public typealias InterceptorInitializer = @Sendable (ProtocolClientConfig) -> Interceptor
 
-public struct UnaryFunction: Sendable {
-    public let requestFunction: @Sendable (HTTPRequest) -> HTTPRequest
-    public let responseFunction: @Sendable (HTTPResponse) -> HTTPResponse
-    public let responseMetricsFunction: @Sendable (HTTPMetrics) -> HTTPMetrics
+public struct UnaryFunction: @unchecked Sendable {
+    public let requestFunction: (HTTPRequest) -> HTTPRequest
+    public let responseFunction: (HTTPResponse) -> HTTPResponse
+    public let responseMetricsFunction: (HTTPMetrics) -> HTTPMetrics
 
     public init(
-        requestFunction: @escaping @Sendable (HTTPRequest) -> HTTPRequest,
-        responseFunction: @escaping @Sendable (HTTPResponse) -> HTTPResponse,
-        responseMetricsFunction: @escaping @Sendable (HTTPMetrics) -> HTTPMetrics = { $0 }
+        requestFunction: @escaping (HTTPRequest) -> HTTPRequest,
+        responseFunction: @escaping (HTTPResponse) -> HTTPResponse,
+        responseMetricsFunction: @escaping (HTTPMetrics) -> HTTPMetrics = { $0 }
     ) {
         self.requestFunction = requestFunction
         self.responseFunction = responseFunction
@@ -55,15 +55,15 @@ public struct UnaryFunction: Sendable {
     }
 }
 
-public struct StreamFunction: Sendable {
-    public let requestFunction: @Sendable (HTTPRequest) -> HTTPRequest
-    public let requestDataFunction: @Sendable (Data) -> Data
-    public let streamResultFunction: @Sendable (StreamResult<Data>) -> StreamResult<Data>
+public struct StreamFunction: @unchecked Sendable {
+    public let requestFunction: (HTTPRequest) -> HTTPRequest
+    public let requestDataFunction: (Data) -> Data
+    public let streamResultFunction: (StreamResult<Data>) -> StreamResult<Data>
 
     public init(
-        requestFunction: @escaping @Sendable (HTTPRequest) -> HTTPRequest,
-        requestDataFunction: @escaping @Sendable (Data) -> Data,
-        streamResultFunction: @escaping @Sendable (StreamResult<Data>) -> StreamResult<Data>
+        requestFunction: @escaping (HTTPRequest) -> HTTPRequest,
+        requestDataFunction: @escaping (Data) -> Data,
+        streamResultFunction: @escaping (StreamResult<Data>) -> StreamResult<Data>
     ) {
         self.requestFunction = requestFunction
         self.requestDataFunction = requestDataFunction

--- a/Libraries/Connect/Interfaces/NetworkProtocol.swift
+++ b/Libraries/Connect/Interfaces/NetworkProtocol.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Protocols that are supported by the library.
-public enum NetworkProtocol: Sendable {
+public enum NetworkProtocol: @unchecked Sendable {
     /// The Connect protocol:
     /// https://connectrpc.com/docs/protocol
     case connect


### PR DESCRIPTION
Instances of interceptors are not expected to be called concurrently from multiple threads, and the `Sendable` requirements currently imposed on them make it challenging for consumers to store state on the interceptors. This PR relaxes the `Sendable` requirements for interceptors, making it easier for consumers to store and access properties on them.

Relatedly, it looks like there may be a Swift bug which prevents annotating properties with `@MainActor` from properly handling sendability: https://forums.swift.org/t/is-this-sendable-warning-correct/55632/2

This PR builds without warnings on Xcode 15 with strict concurrency rules enabled.