### PR TITLE
Update default license header template

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>FILEHEADER</key>
-    <string> Copyright 2022-2023 Buf Technologies, Inc.
+    <string> Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This matches the new values that are set by `make licenseheaders`.