### PR TITLE
Update logic in example apps

### DIFF
--- a/Examples/ElizaSharedSources/AppSources/MenuView.swift
+++ b/Examples/ElizaSharedSources/AppSources/MenuView.swift
@@ -42,26 +42,28 @@ struct MenuView: View {
         -> Connectrpc_Eliza_V1_ElizaServiceClient
     {
         let host = "https://demo.connectrpc.com"
-        #if COCOAPODS
-        let protocolClient = ProtocolClient(
-            httpClient: URLSessionHTTPClient(),
-            config: ProtocolClientConfig(
-                host: host,
-                networkProtocol: networkProtocol,
-                codec: ProtoCodec() // Protobuf binary, or JSONCodec() for JSON
-            )
+        let config = ProtocolClientConfig(
+            host: host,
+            networkProtocol: networkProtocol,
+            codec: ProtoCodec() // Protobuf binary, or JSONCodec() for JSON
         )
-        #else
-        let protocolClient = ProtocolClient(
-            httpClient: NIOHTTPClient(host: host), // Or URLSessionHTTPClient()
-            config: ProtocolClientConfig(
-                host: host,
-                networkProtocol: networkProtocol,
-                codec: ProtoCodec() // Protobuf binary, or JSONCodec() for JSON
+        #if !COCOAPODS
+        // For gRPC (which is not supported by CocoaPods), use the NIO HTTP client:
+        if case .custom = networkProtocol {
+            return Connectrpc_Eliza_V1_ElizaServiceClient(
+                client: ProtocolClient(
+                    httpClient: NIOHTTPClient(host: host), // Or URLSessionHTTPClient()
+                    config: config
+                )
             )
-        )
+        }
         #endif
-        return Connectrpc_Eliza_V1_ElizaServiceClient(client: protocolClient)
+        return Connectrpc_Eliza_V1_ElizaServiceClient(
+            client: ProtocolClient(
+                httpClient: URLSessionHTTPClient(),
+                config: config
+            )
+        )
     }
 
     var body: some View {

--- a/Examples/ElizaSharedSources/AppSources/MenuView.swift
+++ b/Examples/ElizaSharedSources/AppSources/MenuView.swift
@@ -52,7 +52,7 @@ struct MenuView: View {
         if case .custom = networkProtocol {
             return Connectrpc_Eliza_V1_ElizaServiceClient(
                 client: ProtocolClient(
-                    httpClient: NIOHTTPClient(host: host), // Or URLSessionHTTPClient()
+                    httpClient: NIOHTTPClient(host: host),
                     config: config
                 )
             )


### PR DESCRIPTION
This PR makes a few changes to the example apps:
- Updates the view model to be `@MainActor` and removes these annotations on individual fields
- Removes one-line functions
- Uses the `URLSessionHTTPClient` for all protocols except gRPC