### PR TITLE
Rename `JSONCodec` init parameter for clarity

### DIFF
--- a/Libraries/Connect/Implementation/Codecs/JSONCodec.swift
+++ b/Libraries/Connect/Implementation/Codecs/JSONCodec.swift
@@ -27,14 +27,15 @@ public struct JSONCodec: Sendable {
 
     /// Designated initializer.
     ///
-    /// - parameter alwaysPrintEnumsAsInts: Always print enums as ints. By default they are printed
-    ///                                     as strings.
-    /// - parameter preserveProtoFieldNames: Whether to preserve proto field names. By default they
-    ///                                      are converted to JSON (lowerCamelCase) names.
-    public init(alwaysEncodeEnumsAsInts: Bool = false, encodeProtoFieldNames: Bool = false) {
+    /// - parameter alwaysEncodeEnumsAsInts: Always encode enums as ints. By default they are
+    ///                                      encoded as strings.
+    /// - parameter preserveProtobufFieldNames: Whether to preserve Protobuf field names as they're
+    ///                                         defined in the `.proto` files. By default they are
+    ///                                         converted to Protobuf's JSON lowerCamelCase format.
+    public init(alwaysEncodeEnumsAsInts: Bool = false, preserveProtobufFieldNames: Bool = false) {
         var encodingOptions = JSONEncodingOptions()
         encodingOptions.alwaysPrintEnumsAsInts = alwaysEncodeEnumsAsInts
-        encodingOptions.preserveProtoFieldNames = encodeProtoFieldNames
+        encodingOptions.preserveProtoFieldNames = preserveProtobufFieldNames
         self.encodingOptions = encodingOptions
     }
 }

--- a/Tests/ConnectLibraryTests/ConnectTests/JSONCodecTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/JSONCodecTests.swift
@@ -32,7 +32,7 @@ final class JSONCodecTests: XCTestCase {
     }
 
     func testSerializingAndDeserializingWithEnumsAsInts() throws {
-        let codec = JSONCodec(alwaysEncodeEnumsAsInts: true, encodeProtoFieldNames: false)
+        let codec = JSONCodec(alwaysEncodeEnumsAsInts: true, preserveProtobufFieldNames: false)
         let serialized = try codec.serialize(message: self.message)
         let dictionary = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: serialized) as? [String: Any]
@@ -42,7 +42,7 @@ final class JSONCodecTests: XCTestCase {
     }
 
     func testSerializingAndDeserializingWithEnumsAsStrings() throws {
-        let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, encodeProtoFieldNames: false)
+        let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: false)
         let serialized = try codec.serialize(message: self.message)
         let dictionary = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: serialized) as? [String: Any]
@@ -51,8 +51,8 @@ final class JSONCodecTests: XCTestCase {
         XCTAssertEqual(try codec.deserialize(source: serialized), self.message)
     }
 
-    func testSerializingAndDeserializingWithProtoFieldNames() throws {
-        let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, encodeProtoFieldNames: true)
+    func testSerializingAndDeserializingWithProtobufFieldNames() throws {
+        let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: true)
         let serialized = try codec.serialize(message: self.message)
         let dictionary = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: serialized) as? [String: Any]
@@ -66,7 +66,7 @@ final class JSONCodecTests: XCTestCase {
     }
 
     func testSerializingAndDeserializingWithCamelCaseFieldNames() throws {
-        let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, encodeProtoFieldNames: false)
+        let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: false)
         let serialized = try codec.serialize(message: self.message)
         let dictionary = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: serialized) as? [String: Any]


### PR DESCRIPTION
Makes this option clearer and updates the documentation.