### PR TITLE
Remove slow/flaky Docker setup CI dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,8 @@ jobs:
       - name: Select Xcode version
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
         run: sudo xcode-select --switch /Applications/Xcode_14.1.app
+      - name: Install Docker for conformance tests
+        run: brew install docker
       - name: Run tests
         run: make test
   run-swiftlint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,6 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
-      - uses: docker-practice/actions-setup-docker@master
       - name: Select Xcode version
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
         run: sudo xcode-select --switch /Applications/Xcode_14.1.app

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,8 +62,11 @@ jobs:
       - name: Select Xcode version
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
         run: sudo xcode-select --switch /Applications/Xcode_14.1.app
-      - name: Install Docker for conformance tests
-        run: brew install docker
+      - name: Set up docker (missing on macOS GitHub runners)
+        # https://github.com/actions/runner-images/issues/2150
+        run: |
+          brew install docker
+          colima start
       - name: Run tests
         run: make test
   run-swiftlint:


### PR DESCRIPTION
This dependency has been quite flaky recently and has required a bunch of manual retries on CI jobs.

This PR removes the dependency which should speed up CI and reduce flakes: Tests previously took 7-12 minutes to run, and with these changes they only take 5-6 minutes.