### PR TITLE
Remove verbose logs from conformance tests

### DIFF
--- a/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
@@ -29,19 +29,16 @@ private typealias UnimplementedServiceClient = Connectrpc_Conformance_V1_Unimple
 @available(iOS 13, *)
 final class AsyncAwaitConformance: XCTestCase {
     private func executeTestWithClients(
-        function: Selector = #function,
         timeout: TimeInterval = 60,
         runTestsWithClient: (TestServiceClient) async throws -> Void
     ) async rethrows {
         let configurations = ConformanceConfiguration.all(timeout: timeout)
         for configuration in configurations {
             try await runTestsWithClient(TestServiceClient(client: configuration.protocolClient))
-            print("Ran \(function) with \(configuration.description)")
         }
     }
 
     private func executeTestWithUnimplementedClients(
-        function: Selector = #function,
         runTestsWithClient: (UnimplementedServiceClient) async throws -> Void
     ) async rethrows {
         let configurations = ConformanceConfiguration.all(timeout: 60)
@@ -49,7 +46,6 @@ final class AsyncAwaitConformance: XCTestCase {
             try await runTestsWithClient(
                 UnimplementedServiceClient(client: configuration.protocolClient)
             )
-            print("Ran \(function) with \(configuration.description)")
         }
     }
 

--- a/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
@@ -28,25 +28,21 @@ private typealias UnimplementedServiceClient = Connectrpc_Conformance_V1_Unimple
 /// Tests are written using callback APIs.
 final class CallbackConformance: XCTestCase {
     private func executeTestWithClients(
-        function: Selector = #function,
         timeout: TimeInterval = 60,
         runTestsWithClient: (TestServiceClient) throws -> Void
     ) rethrows {
         let configurations = ConformanceConfiguration.all(timeout: timeout)
         for configuration in configurations {
             try runTestsWithClient(TestServiceClient(client: configuration.protocolClient))
-            print("Ran \(function) with \(configuration.description)")
         }
     }
 
     private func executeTestWithUnimplementedClients(
-        function: Selector = #function,
         runTestsWithClient: (UnimplementedServiceClient) throws -> Void
     ) rethrows {
         let configurations = ConformanceConfiguration.all(timeout: 60)
         for configuration in configurations {
             try runTestsWithClient(UnimplementedServiceClient(client: configuration.protocolClient))
-            print("Ran \(function) with \(configuration.description)")
         }
     }
 

--- a/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
@@ -20,11 +20,9 @@ import Foundation
 
 /// Represents a specific configuration with which to run a suite of conformance tests.
 final class ConformanceConfiguration {
-    let description: String
     let protocolClient: ProtocolClient
 
-    private init(description: String, protocolClient: ProtocolClient) {
-        self.description = description
+    private init(protocolClient: ProtocolClient) {
         self.protocolClient = protocolClient
     }
 
@@ -61,10 +59,6 @@ final class ConformanceConfiguration {
             for httpClient in tuple.httpClients {
                 for codec in tuple.codecs {
                     configurations.append(.init(
-                        description: """
-                        \(tuple.networkProtocol) + \(type(of: codec)) via \(type(of: httpClient)) \
-                        on port \(tuple.port)
-                        """,
                         protocolClient: ProtocolClient(
                             httpClient: httpClient,
                             config: ProtocolClientConfig(


### PR DESCRIPTION
Running `swift test` doesn't consistently print these as the tests are running, and seems to dump them at the end of the run. This makes them generally unhelpful for debugging test failures, and makes actual errors more difficult to find in the logs. Removing them.