### PR TITLE
Remove `blanket_disable_command` from SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,7 +7,6 @@ excluded:
   - Libraries/Connect/Implementation/Generated
   - Tests/ConnectLibraryTests/Generated
 disabled_rules:
-  - blanket_disable_command
   - cyclomatic_complexity
   - file_length
   - function_body_length


### PR DESCRIPTION
This currently warns with:

```
warning: 'blanket_disable_command' is not a valid rule identifier
```