### PR TITLE
Update CI release job to use Xcode 15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
+      - name: Select Xcode version
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.app
       - uses: bufbuild/buf-setup-action@v1.28.0
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
Without this, the release job fails because the `Package.swift` requires a Swift version higher than the GitHub runner's default.