### PR TITLE
Revert usage of `package` keyword & unsafe flags

### DIFF
--- a/Libraries/Connect/PackageInternal/ConnectError+GRPC.swift
+++ b/Libraries/Connect/PackageInternal/ConnectError+GRPC.swift
@@ -15,23 +15,16 @@
 import Foundation
 
 extension ConnectError {
+    /// This should not be considered part of Connect's public/stable interface, and is subject
+    /// to change. When the compiler supports it, this should be package-internal.
+    ///
     /// Creates an error using gRPC trailers.
     ///
     /// - parameter trailers: The trailers (or headers, for gRPC-Web) from which to parse the error.
     /// - parameter code: The status code received from the server.
     ///
     /// - returns: An error, if the status indicated an error.
-#if COCOAPODS // ConnectNIO is unavailable from CocoaPods, so this can be internal.
-    static func fromGRPCTrailers(_ trailers: Trailers, code: Code) -> Self? {
-        return self._fromGRPCTrailers(trailers, code: code)
-    }
-#else
-    package static func fromGRPCTrailers(_ trailers: Trailers, code: Code) -> Self? {
-        return self._fromGRPCTrailers(trailers, code: code)
-    }
-#endif
-
-    private static func _fromGRPCTrailers(_ trailers: Trailers, code: Code) -> Self? {
+    public static func fromGRPCTrailers(_ trailers: Trailers, code: Code) -> Self? {
         if code == .ok {
             return nil
         }

--- a/Libraries/Connect/PackageInternal/Envelope.swift
+++ b/Libraries/Connect/PackageInternal/Envelope.swift
@@ -17,8 +17,8 @@ import SwiftProtobuf
 
 /// Provides functionality for packing and unpacking (headers and length prefixed) messages.
 ///
-/// This API is not considered part of Connect's public interface and is subject to change.
-/// TODO: Make this `package` instead of `public` if/when CocoaPods support is dropped.
+/// This should not be considered part of Connect's public/stable interface, and is subject
+/// to change. When the compiler supports it, this should be package-internal.
 public enum Envelope {
     /// Packs a message into an "envelope", adding required header bytes and optionally
     /// applying compression.

--- a/Libraries/Connect/PackageInternal/Headers+GRPC.swift
+++ b/Libraries/Connect/PackageInternal/Headers+GRPC.swift
@@ -15,6 +15,9 @@
 import Foundation
 
 extension Headers {
+    /// This should not be considered part of Connect's public/stable interface, and is subject
+    /// to change. When the compiler supports it, this should be package-internal.
+    ///
     /// Adds required headers to gRPC and gRPC-Web requests/streams.
     ///
     /// - parameter config: The configuration to use for adding headers (i.e., for compression
@@ -22,17 +25,7 @@ extension Headers {
     /// - parameter grpcWeb: Should be true if using gRPC-Web, false if gRPC.
     ///
     /// - returns: A set of updated headers.
-#if COCOAPODS // ConnectNIO is unavailable from CocoaPods, so this can be internal.
-    func addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
-        return self._addingGRPCHeaders(using: config, grpcWeb: grpcWeb)
-    }
-#else
-    package func addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
-        return self._addingGRPCHeaders(using: config, grpcWeb: grpcWeb)
-    }
-#endif
-
-    private func _addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
+    public func addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
         var headers = self
         headers[HeaderConstants.grpcAcceptEncoding] = config
             .acceptCompressionPoolNames()

--- a/Libraries/Connect/PackageInternal/Trailers+gRPC.swift
+++ b/Libraries/Connect/PackageInternal/Trailers+gRPC.swift
@@ -13,20 +13,13 @@
 // limitations under the License.
 
 extension Trailers {
+    /// This should not be considered part of Connect's public/stable interface, and is subject
+    /// to change. When the compiler supports it, this should be package-internal.
+    ///
     /// Identifies the status code from gRPC and gRPC-Web trailers.
     ///
     /// - returns: The gRPC status code, if specified.
-#if COCOAPODS // ConnectNIO is unavailable from CocoaPods, so this can be internal.
-    func grpcStatus() -> Code? {
-        return self._grpcStatus()
-    }
-#else
-    package func grpcStatus() -> Code? {
-        return self._grpcStatus()
-    }
-#endif
-
-    private func _grpcStatus() -> Code? {
+    public func grpcStatus() -> Code? {
         return self[HeaderConstants.grpcStatus]?
             .first
             .flatMap(Int.init)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.6
 
 // Copyright 2022-2023 Buf Technologies, Inc.
 //
@@ -16,10 +16,8 @@
 
 import PackageDescription
 
-private let packageName = "Connect"
-
 let package = Package(
-    name: packageName,
+    name: "Connect",
     platforms: [
         .iOS(.v12),
         .macOS(.v10_15),
@@ -77,9 +75,6 @@ let package = Package(
                 "buf.work.yaml",
                 "proto",
                 "README.md",
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-package-name", packageName])
             ]
         ),
         .testTarget(
@@ -109,9 +104,6 @@ let package = Package(
             path: "Libraries/ConnectMocks",
             exclude: [
                 "README.md",
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-package-name", packageName])
             ]
         ),
         .executableTarget(
@@ -137,9 +129,6 @@ let package = Package(
             path: "Libraries/ConnectNIO",
             exclude: [
                 "README.md",
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-package-name", packageName])
             ]
         ),
         .target(


### PR DESCRIPTION
Resolves https://github.com/connectrpc/connect-swift/issues/217.

Instead of using the `package` keyword which is supported by Swift 5.9+ but does not seem to work out-of-the-box because I didn't see `-package-name` get passed by Xcode to the build system, I'm reverting back to just keeping these few files in a `PackageInternal` directory and documenting them as not being part of the public interface. This eliminates the need for unsafe flags and resolves the aforementioned issue.