### PR TITLE
Fix new CI failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
         run: |
           brew unlink python@3.12 && brew link --overwrite python@3.12
           brew install docker colima
-          colima start
+          /usr/local/opt/colima/bin/colima start -f
       - name: Run tests
         run: make test
   run-swiftlint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
         run: |
           brew unlink python@3.12 && brew link --overwrite python@3.12
           brew install docker colima
-          /usr/local/opt/colima/bin/colima start -f
+          colima delete && colima start
       - name: Run tests
         run: make test
   run-swiftlint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up docker (missing on macOS GitHub runners)
         # https://github.com/actions/runner-images/issues/2150
         run: |
-          brew link --overwrite python@3.12
+          brew unlink python@3.12 && brew link python@3.12
           brew install docker colima
           colima start
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,10 +68,7 @@ jobs:
       - name: Set up docker (missing on macOS GitHub runners)
         # https://github.com/actions/runner-images/issues/2150
         run: |
-          rm '/usr/local/bin/2to3-3.12'
-          rm '/usr/local/bin/idle3.12'
-          rm '/usr/local/bin/pydoc3.12'
-          rm '/usr/local/bin/python3.12'
+          brew link --overwrite python@3.12
           brew install docker colima
           colima start
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up docker (missing on macOS GitHub runners)
         # https://github.com/actions/runner-images/issues/2150
         run: |
-          brew unlink python@3.12 && brew link python@3.12
+          brew unlink python@3.12 && brew link --overwrite python@3.12
           brew install docker colima
           colima start
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
           rm '/usr/local/bin/2to3-3.12'
           rm '/usr/local/bin/idle3.12'
           rm '/usr/local/bin/pydoc3.12'
-          brew unlink python@3.12
+          rm '/usr/local/bin/python3.12'
           brew install docker colima
           colima start
       - name: Run tests


### PR DESCRIPTION
Although the fix in #228 passed CI on the PR, it failed on `main`. As far as I can tell, it seems to be inconsistent depending on which GitHub runner gets assigned to the job. After further experimentation and digging, it looks like `colima` [had some breaking changes from 0.5.x -> 0.6.x](https://github.com/abiosoft/colima/releases/tag/v0.6.6) which require `colima delete` to be run prior to starting. The changes in this PR address the issue, and I've re-run CI multiple times on this PR to try on multiple runners.

Thankfully, we'll be able to axe this setup once we switch to the new conformance runner.

Error:

```
==> Pouring python@3.12--3.12.0_1.ventura.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/python3.12
Target /usr/local/bin/python3.12
already exists. You may want to remove it:
  rm '/usr/local/bin/python3.12'
```