### PR TITLE
Replace hardcoded status code integers with `URLError`

### DIFF
--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -196,24 +196,18 @@ extension HTTPURLResponse {
 extension Code {
     static func fromURLSessionCode(_ code: Int) -> Self {
         // https://developer.apple.com/documentation/cfnetwork/cfnetworkerrors?language=swift
-        switch Int32(code) {
-        // CFNetworkErrors.cfurlErrorUnknown.rawValue
-        case -998:
+        switch code {
+        case URLError.unknown.rawValue:
             return .unknown
-        // CFNetworkErrors.cfurlErrorCancelled.rawValue
-        case -999:
+        case URLError.cancelled.rawValue:
             return .canceled
-        // CFNetworkErrors.cfurlErrorBadURL.rawValue
-        case -1_000:
+        case URLError.badURL.rawValue:
             return .invalidArgument
-        // CFNetworkErrors.cfurlErrorTimedOut.rawValue
-        case -1_001:
+        case URLError.timedOut.rawValue:
             return .deadlineExceeded
-        // CFNetworkErrors.cfurlErrorUnsupportedURL.rawValue
-        case -1_002:
+        case URLError.unsupportedURL.rawValue:
             return .unimplemented
-        // URLSession can return errors in this range
-        case ...100:
+        case ...100: // URLSession can return errors in this range
             return .unknown
         default:
             return Code.fromHTTPStatus(code)


### PR DESCRIPTION
These were changed from `CFNetworkErrors` to hardcoded values in https://github.com/connectrpc/connect-swift/pull/227 to remove the `CFNetwork` import in order to support watchOS.

As an alternative, we can use `URLError` values and keep them strongly typed. The replacements are the same except for `CFNetworkErrors.cfurlErrorUnknown.rawValue` which will still be correctly mapped to `.unknown` via the `...100` case.

<img width="629" alt="Screenshot 2024-01-20 at 10 07 47 AM" src="https://github.com/connectrpc/connect-swift/assets/2643476/0d77a632-ccae-4b6a-811f-86481fddc4b7">
