### PR TITLE
Allow additional path extensions on configured hosts

### DIFF
--- a/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
@@ -50,7 +50,7 @@ extension ProtocolClient: ProtocolClientInterface {
         var headers = headers
         headers[HeaderConstants.contentType] = ["application/\(config.codec.name())"]
         let request = HTTPRequest<Input>(
-            url: URL(string: path, relativeTo: URL(string: config.host))!,
+            url: config.createURL(forPath: path),
             headers: headers,
             message: request,
             method: .post,
@@ -330,7 +330,7 @@ extension ProtocolClient: ProtocolClientInterface {
         var headers = headers
         headers[HeaderConstants.contentType] = ["application/connect+\(codec.name())"]
         let request = HTTPRequest<Void>(
-            url: URL(string: path, relativeTo: URL(string: self.config.host))!,
+            url: config.createURL(forPath: path),
             headers: headers,
             message: (),
             method: .post,

--- a/Libraries/Connect/Public/Interfaces/ProtocolClientConfig.swift
+++ b/Libraries/Connect/Public/Interfaces/ProtocolClientConfig.swift
@@ -121,4 +121,8 @@ extension ProtocolClientConfig {
     func createStreamInterceptorChain() -> InterceptorChain<any StreamInterceptor> {
         return .init(self.interceptors.compactMap { $0.createStream(with: self) })
     }
+
+    func createURL(forPath path: String) -> URL {
+        return URL(string: self.host)!.appendingPathComponent(path)
+    }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -57,29 +57,31 @@ final class ProtocolClientConfigTests: XCTestCase {
             "https://connectrpc.com/connectrpc.conformance.v1.ConformanceService/Unary"
         )
         XCTAssertEqual(
-            ProtocolClientConfig(host: "https://connectrpc.com/api")
+            ProtocolClientConfig(host: "https://connectrpc.com/a")
                 .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/api/connectrpc.conformance.v1.ConformanceService/Unary"
+            "https://connectrpc.com/a/connectrpc.conformance.v1.ConformanceService/Unary"
         )
         XCTAssertEqual(
-            ProtocolClientConfig(host: "https://connectrpc.com/api/")
+            ProtocolClientConfig(host: "https://connectrpc.com/a/")
                 .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/api/connectrpc.conformance.v1.ConformanceService/Unary"
+            "https://connectrpc.com/a/connectrpc.conformance.v1.ConformanceService/Unary"
         )
         XCTAssertEqual(
-            ProtocolClientConfig(host: "https://connectrpc.com/api/ext")
+            ProtocolClientConfig(host: "https://connectrpc.com/a/b/c")
                 .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/api/ext/connectrpc.conformance.v1.ConformanceService/Unary"
+            "https://connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
         )
         XCTAssertEqual(
-            ProtocolClientConfig(host: "https://connectrpc.com/api/ext/")
+            ProtocolClientConfig(host: "https://connectrpc.com/a/b/c/")
                 .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/api/ext/connectrpc.conformance.v1.ConformanceService/Unary"
+            "https://connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
         )
+        print(ProtocolClientConfig(host: "https://connectrpc.com/a/b/c/")
+            .createURL(forPath: rpcPath))
         XCTAssertEqual(
-            ProtocolClientConfig(host: "connectrpc.com/api/ext")
+            ProtocolClientConfig(host: "connectrpc.com/a/b/c")
                 .createURL(forPath: rpcPath).absoluteString,
-            "connectrpc.com/api/ext/connectrpc.conformance.v1.ConformanceService/Unary"
+            "connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
         )
     }
 

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -43,6 +43,46 @@ final class ProtocolClientConfigTests: XCTestCase {
         XCTAssertFalse(compression.shouldCompress(data))
     }
 
+    func testCreatingURLsWithVariousHosts() {
+        let rpcPath = Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.unary.path
+
+        XCTAssertEqual(
+            ProtocolClientConfig(host: "https://connectrpc.com")
+                .createURL(forPath: rpcPath).absoluteString,
+            "https://connectrpc.com/connectrpc.conformance.v1.ConformanceService/Unary"
+        )
+        XCTAssertEqual(
+            ProtocolClientConfig(host: "https://connectrpc.com/")
+                .createURL(forPath: rpcPath).absoluteString,
+            "https://connectrpc.com/connectrpc.conformance.v1.ConformanceService/Unary"
+        )
+        XCTAssertEqual(
+            ProtocolClientConfig(host: "https://connectrpc.com/api")
+                .createURL(forPath: rpcPath).absoluteString,
+            "https://connectrpc.com/api/connectrpc.conformance.v1.ConformanceService/Unary"
+        )
+        XCTAssertEqual(
+            ProtocolClientConfig(host: "https://connectrpc.com/api/")
+                .createURL(forPath: rpcPath).absoluteString,
+            "https://connectrpc.com/api/connectrpc.conformance.v1.ConformanceService/Unary"
+        )
+        XCTAssertEqual(
+            ProtocolClientConfig(host: "https://connectrpc.com/api/ext")
+                .createURL(forPath: rpcPath).absoluteString,
+            "https://connectrpc.com/api/ext/connectrpc.conformance.v1.ConformanceService/Unary"
+        )
+        XCTAssertEqual(
+            ProtocolClientConfig(host: "https://connectrpc.com/api/ext/")
+                .createURL(forPath: rpcPath).absoluteString,
+            "https://connectrpc.com/api/ext/connectrpc.conformance.v1.ConformanceService/Unary"
+        )
+        XCTAssertEqual(
+            ProtocolClientConfig(host: "connectrpc.com/api/ext")
+                .createURL(forPath: rpcPath).absoluteString,
+            "connectrpc.com/api/ext/connectrpc.conformance.v1.ConformanceService/Unary"
+        )
+    }
+
     func testAddsConnectInterceptorLastWhenUsingConnectProtocol() {
         let config = ProtocolClientConfig(
             host: "https://connectrpc.com",

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -76,8 +76,6 @@ final class ProtocolClientConfigTests: XCTestCase {
                 .createURL(forPath: rpcPath).absoluteString,
             "https://connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
         )
-        print(ProtocolClientConfig(host: "https://connectrpc.com/a/b/c/")
-            .createURL(forPath: rpcPath))
         XCTAssertEqual(
             ProtocolClientConfig(host: "connectrpc.com/a/b/c")
                 .createURL(forPath: rpcPath).absoluteString,


### PR DESCRIPTION
This adds support for specifying hosts with additional path extensions, such as `https://connectrpc.com/a/b/c/`. Previously, `/a/b/c` would be dropped.

Resolves https://github.com/connectrpc/connect-swift/issues/252.

Also related to https://github.com/connectrpc/connect-swift/issues/161.