### PR TITLE
[DRAFT] Remove `os.log` usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,8 +61,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install zlib
-        run: sudo apt-get install zlib1g-dev
         # Swift 5.10: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime
       - name: Build Connect Linux library
         run: swift build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Install zlib
+        run: sudo apt-get install zlib1g-dev
         # Swift 5.10: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime
       - name: Build Connect Linux library
         run: swift build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,13 @@ jobs:
         run: brew install xcbeautify
       - name: Build Connect macOS library
         run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=macOS' | xcbeautify
+  build-library-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        # Swift 5.10: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime
+      - name: Build Connect Linux library
+        run: swift build
   build-library-tvos:
     runs-on: macos-14
     steps:
@@ -121,7 +128,7 @@ jobs:
       - name: Run unit tests
         run: make testunit
   run-swiftlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/realm/swiftlint:0.53.0
     steps:
@@ -129,7 +136,7 @@ jobs:
       - name: Run SwiftLint
         run: swiftlint lint --strict
   validate-license-headers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Validate license headers

--- a/Examples/ElizaSharedSources/AppSources/MessagingViewModel.swift
+++ b/Examples/ElizaSharedSources/AppSources/MessagingViewModel.swift
@@ -14,7 +14,6 @@
 
 import Combine
 import Connect
-import os.log
 
 private typealias ConverseRequest = Connectrpc_Eliza_V1_ConverseRequest
 private typealias ConverseResponse = Connectrpc_Eliza_V1_ConverseResponse
@@ -54,7 +53,7 @@ final class UnaryMessagingViewModel: MessagingViewModel {
         self.messages.append(Message(message: sentence, author: .user))
 
         let response = await self.client.say(request: request, headers: [:])
-        os_log(.debug, "Eliza unary response: %@", String(describing: response))
+        print("Eliza unary response: %@", String(describing: response))
         self.messages.append(Message(
             message: response.message?.sentence ?? "No response", author: .eliza
         ))
@@ -82,9 +81,7 @@ final class BidirectionalStreamingMessagingViewModel: MessagingViewModel {
             self.messages.append(Message(message: sentence, author: .user))
             try self.elizaStream.send(request)
         } catch let error {
-            os_log(
-                .error, "Failed to write message to stream: %@", error.localizedDescription
-            )
+            print("Failed to write message to stream: \(error.localizedDescription)")
         }
     }
 
@@ -97,17 +94,17 @@ final class BidirectionalStreamingMessagingViewModel: MessagingViewModel {
             for await result in self.elizaStream.results() {
                 switch result {
                 case .headers(let headers):
-                    os_log(.debug, "Eliza headers: %@", headers)
+                    print("Eliza headers: \(headers)")
 
                 case .message(let message):
-                    os_log(.debug, "Eliza message: %@", String(describing: message))
+                    print("Eliza message: %@", String(describing: message))
                     self.messages.append(Message(message: message.sentence, author: .eliza))
 
                 case .complete(_, let error, let trailers):
-                    os_log(.debug, "Eliza completed with trailers: %@", trailers ?? [:])
+                    print("Eliza completed with trailers: \(trailers ?? [:])")
                     let sentence: String
                     if let error = error {
-                        os_log(.error, "Eliza error: %@", error.localizedDescription)
+                        print("Eliza error: \(error.localizedDescription)")
                         sentence = "[Error: \(error)]"
                     } else {
                         sentence = "[Conversation ended]"

--- a/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
+++ b/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Stream implementation that wraps a `URLSession` stream.
 ///

--- a/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import SwiftProtobuf
 
 /// Concrete implementation of the `ProtocolClientInterface`.

--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -125,6 +125,7 @@ open class URLSessionHTTPClient: NSObject, HTTPClientInterface, @unchecked Senda
 }
 
 extension URLSessionHTTPClient: URLSessionDataDelegate {
+    @objc
     open func urlSession(
         _ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse,
         completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
@@ -139,6 +140,7 @@ extension URLSessionHTTPClient: URLSessionDataDelegate {
         stream?.handleResponse(httpURLResponse)
     }
 
+    @objc
     open func urlSession(
         _ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data
     ) {
@@ -146,6 +148,7 @@ extension URLSessionHTTPClient: URLSessionDataDelegate {
         stream?.handleResponseData(data)
     }
 
+    @objc
     open func urlSession(
         _ session: URLSession, task: URLSessionTask,
         needNewBodyStream completionHandler: @escaping (InputStream?) -> Void
@@ -157,6 +160,7 @@ extension URLSessionHTTPClient: URLSessionDataDelegate {
 }
 
 extension URLSessionHTTPClient: URLSessionTaskDelegate {
+    @objc
     open func urlSession(
         _ session: URLSession, task: URLSessionTask, didCompleteWithError error: Swift.Error?
     ) {
@@ -164,6 +168,7 @@ extension URLSessionHTTPClient: URLSessionTaskDelegate {
         stream?.handleCompletion(error: error)
     }
 
+    @objc
     open func urlSession(
         _ session: URLSession, task: URLSessionTask,
         didFinishCollecting metrics: URLSessionTaskMetrics

--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import Foundation
-import os.log
 
 /// Concrete implementation of `HTTPClientInterface` backed by `URLSession`.
 ///
@@ -113,11 +112,7 @@ open class URLSessionHTTPClient: NSObject, HTTPClientInterface, @unchecked Senda
                 do {
                     try urlSessionStream.sendData(data)
                 } catch let error {
-                    os_log(
-                        .error,
-                        "Failed to write data to stream - closing connection: %@",
-                        error.localizedDescription
-                    )
+                    assertionFailure("Failed to write data, closing stream: \(error)")
                     urlSessionStream.close()
                 }
             },

--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Concrete implementation of `HTTPClientInterface` backed by `URLSession`.
 ///

--- a/Libraries/Connect/Public/Implementation/Compression/GzipCompressionPool.swift
+++ b/Libraries/Connect/Public/Implementation/Compression/GzipCompressionPool.swift
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import Foundation
+#if os(linux)
+import ZlibLinux
+#else
 import zlib
+#endif
 
 /// Compression pool that handles gzip compression/decompression.
 public struct GzipCompressionPool: Sendable {

--- a/Libraries/Connect/Public/Implementation/Compression/GzipCompressionPool.swift
+++ b/Libraries/Connect/Public/Implementation/Compression/GzipCompressionPool.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Foundation
-#if os(linux)
+#if os(Linux)
 import ZlibLinux
 #else
 import zlib

--- a/Libraries/Connect/Public/Interfaces/HTTPMetrics.swift
+++ b/Libraries/Connect/Public/Interfaces/HTTPMetrics.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Contains metrics collected during the span of an HTTP request.
 public struct HTTPMetrics: Sendable {

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -20,7 +20,6 @@ import NIOHTTP1
 import NIOHTTP2
 import NIOPosix
 import NIOSSL
-import os.log
 
 /// HTTP client powered by Swift NIO which supports trailers (unlike URLSession).
 open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
@@ -213,7 +212,6 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
                         self?.flushOrFailPendingRequests(using: multiplexer)
                     }
                 case .failure(let error):
-                    os_log(.error, "NIOHTTPClient disconnected: %@", "\(error)")
                     self?.lock.withLock {
                         self?.state = .disconnected
                         self?.flushOrFailPendingRequests(using: nil)

--- a/Libraries/ZlibLinux/empty.c
+++ b/Libraries/ZlibLinux/empty.c
@@ -11,5 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "Empty.h"

--- a/Libraries/ZlibLinux/empty.c
+++ b/Libraries/ZlibLinux/empty.c
@@ -1,0 +1,15 @@
+// Copyright 2022-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Empty.h"

--- a/Libraries/ZlibLinux/include/zliblinux.h
+++ b/Libraries/ZlibLinux/include/zliblinux.h
@@ -1,0 +1,37 @@
+// Copyright 2022-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef zliblinux_h
+#define zliblinux_h
+
+#include <zlib.h>
+
+static inline int CNIOExtrasZlib_deflateInit2(z_streamp strm,
+                                              int level,
+                                              int method,
+                                              int windowBits,
+                                              int memLevel,
+                                              int strategy) {
+    return deflateInit2(strm, level, method, windowBits, memLevel, strategy);
+}
+
+static inline int CNIOExtrasZlib_inflateInit2(z_streamp strm, int windowBits) {
+    return inflateInit2(strm, windowBits);
+}
+
+static inline Bytef *CNIOExtrasZlib_voidPtr_to_BytefPtr(void *in) {
+    return (Bytef *)in;
+}
+
+#endif /* zliblinux_h */

--- a/Package.swift
+++ b/Package.swift
@@ -69,6 +69,7 @@ let package = Package(
             name: "Connect",
             dependencies: [
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+                "ZlibLinux",
             ],
             path: "Libraries/Connect",
             exclude: [
@@ -148,6 +149,13 @@ let package = Package(
                 .product(name: "SwiftProtobufPluginLibrary", package: "swift-protobuf"),
             ],
             path: "Plugins/ConnectPluginUtilities"
+        ),
+        .target(
+            name: "ZlibLinux",
+            dependencies: [],
+            linkerSettings: [
+                .linkedLibrary("z")
+            ]
         ),
         .testTarget(
             name: "ConnectPluginUtilitiesTests",

--- a/Package.swift
+++ b/Package.swift
@@ -153,6 +153,7 @@ let package = Package(
         .target(
             name: "ZlibLinux",
             dependencies: [],
+            path: "Libraries/ZlibLinux",
             linkerSettings: [
                 .linkedLibrary("z")
             ]


### PR DESCRIPTION
- Removes `os.log` usage which is unavailable on Linux
- Adds a CI job to build the library on Ubuntu

Resolves https://github.com/connectrpc/connect-swift/issues/262.