### PR TITLE
Update SwiftProtobuf to v1.27.0

### DIFF
--- a/Connect-Swift-Mocks.podspec
+++ b/Connect-Swift-Mocks.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
   spec.watchos.deployment_target = '6.0'
 
   spec.dependency 'Connect-Swift', "#{spec.version.to_s}"
-  spec.dependency 'SwiftProtobuf', '~> 1.26.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.27.0'
 
   spec.source_files = 'Libraries/ConnectMocks/**/*.swift'
 

--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '13.0'
   spec.watchos.deployment_target = '6.0'
 
-  spec.dependency 'SwiftProtobuf', '~> 1.26.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.27.0'
 
   spec.source_files = 'Libraries/Connect/**/*.swift'
 

--- a/Examples/ElizaCocoaPodsApp/Podfile.lock
+++ b/Examples/ElizaCocoaPodsApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Connect-Swift (0.14.0):
-    - SwiftProtobuf (~> 1.26.0)
-  - SwiftProtobuf (1.26.0)
+    - SwiftProtobuf (~> 1.27.0)
+  - SwiftProtobuf (1.27.0)
 
 DEPENDENCIES:
   - Connect-Swift (from `../..`)
@@ -15,8 +15,8 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Connect-Swift: 6b4b5267a58ab231531935fd3331b1eeac726b45
-  SwiftProtobuf: 5e8349171e7c2f88f5b9e683cb3cb79d1dc780b3
+  Connect-Swift: 3cee5c7a7258aa85c3b73408ba30a397a6c23e80
+  SwiftProtobuf: 07b360b482e7015be5add8475cbe314853516814
 
 PODFILE CHECKSUM: b598f373a6ab5add976b09c2ac79029bf2200d48
 

--- a/Examples/ElizaSharedSources/GeneratedSources/connectrpc/eliza/v1/eliza.pb.swift
+++ b/Examples/ElizaSharedSources/GeneratedSources/connectrpc/eliza/v1/eliza.pb.swift
@@ -35,7 +35,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// SayRequest is a single-sentence request.
-struct Connectrpc_Eliza_V1_SayRequest {
+struct Connectrpc_Eliza_V1_SayRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -48,7 +48,7 @@ struct Connectrpc_Eliza_V1_SayRequest {
 }
 
 /// SayResponse is a single-sentence response.
-struct Connectrpc_Eliza_V1_SayResponse {
+struct Connectrpc_Eliza_V1_SayResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -62,7 +62,7 @@ struct Connectrpc_Eliza_V1_SayResponse {
 
 /// ConverseRequest is a single sentence request sent as part of a
 /// back-and-forth conversation.
-struct Connectrpc_Eliza_V1_ConverseRequest {
+struct Connectrpc_Eliza_V1_ConverseRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -76,7 +76,7 @@ struct Connectrpc_Eliza_V1_ConverseRequest {
 
 /// ConverseResponse is a single sentence response sent in answer to a
 /// ConverseRequest.
-struct Connectrpc_Eliza_V1_ConverseResponse {
+struct Connectrpc_Eliza_V1_ConverseResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -89,7 +89,7 @@ struct Connectrpc_Eliza_V1_ConverseResponse {
 }
 
 /// IntroduceRequest asks Eliza to introduce itself to the named user.
-struct Connectrpc_Eliza_V1_IntroduceRequest {
+struct Connectrpc_Eliza_V1_IntroduceRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -102,7 +102,7 @@ struct Connectrpc_Eliza_V1_IntroduceRequest {
 }
 
 /// IntroduceResponse is one sentence of Eliza's introductory monologue.
-struct Connectrpc_Eliza_V1_IntroduceResponse {
+struct Connectrpc_Eliza_V1_IntroduceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -113,15 +113,6 @@ struct Connectrpc_Eliza_V1_IntroduceResponse {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Connectrpc_Eliza_V1_SayRequest: @unchecked Sendable {}
-extension Connectrpc_Eliza_V1_SayResponse: @unchecked Sendable {}
-extension Connectrpc_Eliza_V1_ConverseRequest: @unchecked Sendable {}
-extension Connectrpc_Eliza_V1_ConverseResponse: @unchecked Sendable {}
-extension Connectrpc_Eliza_V1_IntroduceRequest: @unchecked Sendable {}
-extension Connectrpc_Eliza_V1_IntroduceResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "635b2589494c97e48c62514bc8b37ced762e0a62",
-        "version" : "2.63.0"
+        "revision" : "fc79798d5a150d61361a27ce0c51169b889e23de",
+        "version" : "2.68.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "0904bf0feb5122b7e5c3f15db7df0eabe623dd87",
-        "version" : "1.30.0"
+        "revision" : "a0224f3d20438635dd59c9fcc593520d80d131d0",
+        "version" : "1.33.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "7c381eb6083542b124a6c18fae742f55001dc2b5",
-        "version" : "2.26.0"
+        "revision" : "2b09805797f21c380f7dc9bedaab3157c5508efb",
+        "version" : "2.27.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
-        "version" : "1.26.0"
+        "revision" : "d57a5aecf24a25b32ec4a74be2f5d0a995a47c4b",
+        "version" : "1.27.0"
       }
     },
     {

--- a/Examples/buf.gen.yaml
+++ b/Examples/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.26.0
+  - plugin: buf.build/apple/swift:v1.27.0
     opt: Visibility=Internal
     out: ./ElizaSharedSources/GeneratedSources
   - name: connect-swift

--- a/Libraries/Connect/Internal/GeneratedSources/proto/grpc/status/v1/status.pb.swift
+++ b/Libraries/Connect/Internal/GeneratedSources/proto/grpc/status/v1/status.pb.swift
@@ -38,7 +38,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 ///
 /// This struct must remain binary-compatible with
 /// https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto.
-struct Grpc_Status_V1_Status {
+struct Grpc_Status_V1_Status: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -55,10 +55,6 @@ struct Grpc_Status_V1_Status {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Status_V1_Status: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Libraries/Connect/Public/Implementation/Codecs/JSONCodec.swift
+++ b/Libraries/Connect/Public/Implementation/Codecs/JSONCodec.swift
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 import Foundation
-// TODO: Remove `@preconcurrency` once `SwiftProtobuf.JSON{Encoding|Decoding}Options` are `Sendable`
-@preconcurrency import SwiftProtobuf
+import SwiftProtobuf
 
 /// Codec providing functionality for serializing to/from JSON.
 public struct JSONCodec: Sendable {

--- a/Libraries/Connect/Public/Implementation/Codecs/ProtoCodec.swift
+++ b/Libraries/Connect/Public/Implementation/Codecs/ProtoCodec.swift
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 import Foundation
-// TODO: Remove `@preconcurrency` once `SwiftProtobuf.BinaryEncodingOptions` is `Sendable`
-@preconcurrency import SwiftProtobuf
+import SwiftProtobuf
 
 /// Codec providing functionality for serializing to/from Protobuf binary.
 public struct ProtoCodec {
@@ -41,6 +40,6 @@ extension ProtoCodec: Codec {
     }
 
     public func deserialize<Output: ProtobufMessage>(source: Data) throws -> Output {
-        return try Output(serializedData: source)
+        return try Output(serializedBytes: source)
     }
 }

--- a/Libraries/Connect/Public/Interfaces/ConnectError.swift
+++ b/Libraries/Connect/Public/Interfaces/ConnectError.swift
@@ -43,7 +43,7 @@ public struct ConnectError: Swift.Error, Sendable {
                 return nil
             }
 
-            return detail.payload.flatMap { try? Output(serializedData: $0) }
+            return detail.payload.flatMap { try? Output(serializedBytes: $0) }
         }
     }
 

--- a/Libraries/Connect/Public/Interfaces/ProtobufMessage.swift
+++ b/Libraries/Connect/Public/Interfaces/ProtobufMessage.swift
@@ -14,4 +14,4 @@
 
 import SwiftProtobuf
 
-public typealias ProtobufMessage = SwiftProtobuf.Message & Sendable
+public typealias ProtobufMessage = SwiftProtobuf.Message

--- a/Libraries/Connect/buf.gen.yaml
+++ b/Libraries/Connect/buf.gen.yaml
@@ -1,5 +1,5 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.26.0
+  - plugin: buf.build/apple/swift:v1.27.0
     opt: Visibility=Internal
     out: ./Internal/GeneratedSources

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
-        "version" : "1.26.0"
+        "revision" : "d57a5aecf24a25b32ec4a74be2f5d0a995a47c4b",
+        "version" : "1.27.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
-            from: "1.26.0"
+            from: "1.27.0"
         ),
     ],
     targets: [

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
@@ -38,7 +38,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// these from stdin and, for each one, invokes an RPC as directed
 /// and writes the results (in the form of a ClientCompatResponse
 /// message) to stdout.
-struct Connectrpc_Conformance_V1_ClientCompatRequest {
+struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -229,7 +229,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Cancel {
+  struct Cancel: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -282,7 +282,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest {
     /// after all request messages are sent and the send side is
     /// closed (as if the after_close_send_ms field were present
     /// and zero).
-    enum OneOf_CancelTiming: Equatable {
+    enum OneOf_CancelTiming: Equatable, Sendable {
       /// When present, the client should cancel *instead of*
       /// closing the send side of the stream, after all requests
       /// have been sent. This applies only to client and bidi
@@ -297,28 +297,6 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest {
       /// This applies only to server and bidi stream RPCs.
       case afterNumResponses(UInt32)
 
-    #if !swift(>=4.1)
-      static func ==(lhs: Connectrpc_Conformance_V1_ClientCompatRequest.Cancel.OneOf_CancelTiming, rhs: Connectrpc_Conformance_V1_ClientCompatRequest.Cancel.OneOf_CancelTiming) -> Bool {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch (lhs, rhs) {
-        case (.beforeCloseSend, .beforeCloseSend): return {
-          guard case .beforeCloseSend(let l) = lhs, case .beforeCloseSend(let r) = rhs else { preconditionFailure() }
-          return l == r
-        }()
-        case (.afterCloseSendMs, .afterCloseSendMs): return {
-          guard case .afterCloseSendMs(let l) = lhs, case .afterCloseSendMs(let r) = rhs else { preconditionFailure() }
-          return l == r
-        }()
-        case (.afterNumResponses, .afterNumResponses): return {
-          guard case .afterNumResponses(let l) = lhs, case .afterNumResponses(let r) = rhs else { preconditionFailure() }
-          return l == r
-        }()
-        default: return false
-        }
-      }
-    #endif
     }
 
     init() {}
@@ -330,7 +308,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest {
 }
 
 /// The outcome of one ClientCompatRequest.
-struct Connectrpc_Conformance_V1_ClientCompatResponse {
+struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -376,28 +354,10 @@ struct Connectrpc_Conformance_V1_ClientCompatResponse {
   /// (e.g. a unary request that defines zero or multiple request messages).
   ///
   /// However, once the RPC is issued, any resulting error should instead be encoded in response.
-  enum OneOf_Result: Equatable {
+  enum OneOf_Result: Equatable, Sendable {
     case response(Connectrpc_Conformance_V1_ClientResponseResult)
     case error(Connectrpc_Conformance_V1_ClientErrorResult)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Connectrpc_Conformance_V1_ClientCompatResponse.OneOf_Result, rhs: Connectrpc_Conformance_V1_ClientCompatResponse.OneOf_Result) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.response, .response): return {
-        guard case .response(let l) = lhs, case .response(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.error, .error): return {
-        guard case .error(let l) = lhs, case .error(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
@@ -405,7 +365,7 @@ struct Connectrpc_Conformance_V1_ClientCompatResponse {
 
 /// The result of a ClientCompatRequest, which may or may not be successful.
 /// The client will build this message and return it back to the test runner.
-struct Connectrpc_Conformance_V1_ClientResponseResult {
+struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -470,7 +430,7 @@ struct Connectrpc_Conformance_V1_ClientResponseResult {
 /// The client is not able to fulfill the ClientCompatRequest. This may be due
 /// to a runtime error or an unexpected internal error such as the requested protocol
 /// not being supported. This is completely independent of the actual RPC invocation.
-struct Connectrpc_Conformance_V1_ClientErrorResult {
+struct Connectrpc_Conformance_V1_ClientErrorResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -488,7 +448,7 @@ struct Connectrpc_Conformance_V1_ClientErrorResult {
 /// Details about various values as observed on the wire. This message is used
 /// only by the reference client when reporting results and should not be populated
 /// by clients under test.
-struct Connectrpc_Conformance_V1_WireDetails {
+struct Connectrpc_Conformance_V1_WireDetails: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -535,17 +495,6 @@ struct Connectrpc_Conformance_V1_WireDetails {
   fileprivate var _connectErrorRaw: SwiftProtobuf.Google_Protobuf_Struct? = nil
   fileprivate var _actualGrpcwebTrailers: String? = nil
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel.OneOf_CancelTiming: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ClientCompatResponse: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ClientCompatResponse.OneOf_Result: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ClientResponseResult: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ClientErrorResult: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_WireDetails: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum {
+enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case httpVersion1 // = 1
@@ -66,11 +66,6 @@ enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Connectrpc_Conformance_V1_HTTPVersion: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Connectrpc_Conformance_V1_HTTPVersion] = [
     .unspecified,
@@ -78,11 +73,10 @@ extension Connectrpc_Conformance_V1_HTTPVersion: CaseIterable {
     .httpVersion2,
     .httpVersion3,
   ]
+
 }
 
-#endif  // swift(>=4.2)
-
-enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum {
+enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case connect // = 1
@@ -118,11 +112,6 @@ enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Connectrpc_Conformance_V1_Protocol: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Connectrpc_Conformance_V1_Protocol] = [
     .unspecified,
@@ -130,11 +119,10 @@ extension Connectrpc_Conformance_V1_Protocol: CaseIterable {
     .grpc,
     .grpcWeb,
   ]
+
 }
 
-#endif  // swift(>=4.2)
-
-enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum {
+enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case proto // = 1
@@ -166,11 +154,6 @@ enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Connectrpc_Conformance_V1_Codec: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Connectrpc_Conformance_V1_Codec] = [
     .unspecified,
@@ -178,11 +161,10 @@ extension Connectrpc_Conformance_V1_Codec: CaseIterable {
     .json,
     .text,
   ]
+
 }
 
-#endif  // swift(>=4.2)
-
-enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum {
+enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case identity // = 1
@@ -223,11 +205,6 @@ enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Connectrpc_Conformance_V1_Compression: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Connectrpc_Conformance_V1_Compression] = [
     .unspecified,
@@ -238,11 +215,10 @@ extension Connectrpc_Conformance_V1_Compression: CaseIterable {
     .deflate,
     .snappy,
   ]
+
 }
 
-#endif  // swift(>=4.2)
-
-enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum {
+enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case unary // = 1
@@ -280,11 +256,6 @@ enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Connectrpc_Conformance_V1_StreamType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Connectrpc_Conformance_V1_StreamType] = [
     .unspecified,
@@ -294,11 +265,10 @@ extension Connectrpc_Conformance_V1_StreamType: CaseIterable {
     .halfDuplexBidiStream,
     .fullDuplexBidiStream,
   ]
+
 }
 
-#endif  // swift(>=4.2)
-
-enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum {
+enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case canceled // = 1
@@ -369,11 +339,6 @@ enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Connectrpc_Conformance_V1_Code: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Connectrpc_Conformance_V1_Code] = [
     .unspecified,
@@ -394,13 +359,12 @@ extension Connectrpc_Conformance_V1_Code: CaseIterable {
     .dataLoss,
     .unauthenticated,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 /// Config defines the configuration for running conformance tests.
 /// This enumerates all of the "flavors" of the test suite to run.
-struct Connectrpc_Conformance_V1_Config {
+struct Connectrpc_Conformance_V1_Config: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -437,7 +401,7 @@ struct Connectrpc_Conformance_V1_Config {
 /// used to determine the server configurations and test cases that
 /// will be run. They are defined in YAML files and are specified as part of the
 /// --conf flag to the test runner.
-struct Connectrpc_Conformance_V1_Features {
+struct Connectrpc_Conformance_V1_Features: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -560,7 +524,7 @@ struct Connectrpc_Conformance_V1_Features {
 /// run, the Config and the supported features therein are used to compute all
 /// of the cases relevant to the implementation under test. These configuration
 /// cases are then used to select which test cases are applicable.
-struct Connectrpc_Conformance_V1_ConfigCase {
+struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -626,7 +590,7 @@ struct Connectrpc_Conformance_V1_ConfigCase {
 /// TLSCreds represents credentials for TLS. It includes both a
 /// certificate and corresponding private key. Both are encoded
 /// in PEM format.
-struct Connectrpc_Conformance_V1_TLSCreds {
+struct Connectrpc_Conformance_V1_TLSCreds: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -639,19 +603,6 @@ struct Connectrpc_Conformance_V1_TLSCreds {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Connectrpc_Conformance_V1_HTTPVersion: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_Protocol: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_Codec: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_Compression: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_StreamType: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_Code: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_Config: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_Features: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ConfigCase: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_TLSCreds: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
@@ -48,7 +48,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// Each test process is expected to start only one RPC server.
 /// When testing multiple configurations, multiple test processes
 /// will be started, each with different properties.
-struct Connectrpc_Conformance_V1_ServerCompatRequest {
+struct Connectrpc_Conformance_V1_ServerCompatRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -120,7 +120,7 @@ struct Connectrpc_Conformance_V1_ServerCompatRequest {
 }
 
 /// The outcome of one ServerCompatRequest.
-struct Connectrpc_Conformance_V1_ServerCompatResponse {
+struct Connectrpc_Conformance_V1_ServerCompatResponse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -142,11 +142,6 @@ struct Connectrpc_Conformance_V1_ServerCompatResponse {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Connectrpc_Conformance_V1_ServerCompatRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ServerCompatResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
@@ -36,7 +36,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 /// A definition of a response to be sent from a single-response endpoint.
 /// Can be used to define a response for unary or client-streaming calls.
-struct Connectrpc_Conformance_V1_UnaryResponseDefinition {
+struct Connectrpc_Conformance_V1_UnaryResponseDefinition: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -88,7 +88,7 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Response: Equatable {
+  enum OneOf_Response: Equatable, @unchecked Sendable {
     /// Response data to send
     case responseData(Data)
     /// Error to raise instead of response message
@@ -96,24 +96,6 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition {
     /// requested error.
     case error(Connectrpc_Conformance_V1_Error)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Connectrpc_Conformance_V1_UnaryResponseDefinition.OneOf_Response, rhs: Connectrpc_Conformance_V1_UnaryResponseDefinition.OneOf_Response) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.responseData, .responseData): return {
-        guard case .responseData(let l) = lhs, case .responseData(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.error, .error): return {
-        guard case .error(let l) = lhs, case .error(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
@@ -123,7 +105,7 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition {
 
 /// A definition of responses to be sent from a streaming endpoint.
 /// Can be used to define responses for server-streaming or bidi-streaming calls.
-struct Connectrpc_Conformance_V1_StreamResponseDefinition {
+struct Connectrpc_Conformance_V1_StreamResponseDefinition: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -176,7 +158,7 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition {
   fileprivate var _rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnaryRequest {
+struct Connectrpc_Conformance_V1_UnaryRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -201,7 +183,7 @@ struct Connectrpc_Conformance_V1_UnaryRequest {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnaryResponse {
+struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -223,7 +205,7 @@ struct Connectrpc_Conformance_V1_UnaryResponse {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_IdempotentUnaryRequest {
+struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -248,7 +230,7 @@ struct Connectrpc_Conformance_V1_IdempotentUnaryRequest {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_IdempotentUnaryResponse {
+struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -270,7 +252,7 @@ struct Connectrpc_Conformance_V1_IdempotentUnaryResponse {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ServerStreamRequest {
+struct Connectrpc_Conformance_V1_ServerStreamRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -295,7 +277,7 @@ struct Connectrpc_Conformance_V1_ServerStreamRequest {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_ServerStreamResponse {
+struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -317,7 +299,7 @@ struct Connectrpc_Conformance_V1_ServerStreamResponse {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ClientStreamRequest {
+struct Connectrpc_Conformance_V1_ClientStreamRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -345,7 +327,7 @@ struct Connectrpc_Conformance_V1_ClientStreamRequest {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_ClientStreamResponse {
+struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -367,7 +349,7 @@ struct Connectrpc_Conformance_V1_ClientStreamResponse {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_BidiStreamRequest {
+struct Connectrpc_Conformance_V1_BidiStreamRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -409,7 +391,7 @@ struct Connectrpc_Conformance_V1_BidiStreamRequest {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_BidiStreamResponse {
+struct Connectrpc_Conformance_V1_BidiStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -431,7 +413,7 @@ struct Connectrpc_Conformance_V1_BidiStreamResponse {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnimplementedRequest {
+struct Connectrpc_Conformance_V1_UnimplementedRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -441,7 +423,7 @@ struct Connectrpc_Conformance_V1_UnimplementedRequest {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_UnimplementedResponse {
+struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -451,7 +433,7 @@ struct Connectrpc_Conformance_V1_UnimplementedResponse {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_ConformancePayload {
+struct Connectrpc_Conformance_V1_ConformancePayload: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -472,7 +454,7 @@ struct Connectrpc_Conformance_V1_ConformancePayload {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct RequestInfo {
+  struct RequestInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -523,7 +505,7 @@ struct Connectrpc_Conformance_V1_ConformancePayload {
     fileprivate var _connectGetInfo: Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo? = nil
   }
 
-  struct ConnectGetInfo {
+  struct ConnectGetInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -542,7 +524,7 @@ struct Connectrpc_Conformance_V1_ConformancePayload {
 }
 
 /// An error definition used for specifying a desired error response
-struct Connectrpc_Conformance_V1_Error {
+struct Connectrpc_Conformance_V1_Error: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -576,7 +558,7 @@ struct Connectrpc_Conformance_V1_Error {
 }
 
 /// A tuple of name and values (ASCII) for a header or trailer entry.
-struct Connectrpc_Conformance_V1_Header {
+struct Connectrpc_Conformance_V1_Header: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -597,7 +579,7 @@ struct Connectrpc_Conformance_V1_Header {
 /// RawHTTPRequest models a raw HTTP request. This can be used to craft
 /// custom requests with odd properties (including certain kinds of
 /// malformed requests) to test edge cases in servers.
-struct Connectrpc_Conformance_V1_RawHTTPRequest {
+struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -642,34 +624,16 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Body: Equatable {
+  enum OneOf_Body: Equatable, Sendable {
     /// The body is a single message.
     case unary(Connectrpc_Conformance_V1_MessageContents)
     /// The body is a stream, encoded using a five-byte
     /// prefix before each item in the stream.
     case stream(Connectrpc_Conformance_V1_StreamContents)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Connectrpc_Conformance_V1_RawHTTPRequest.OneOf_Body, rhs: Connectrpc_Conformance_V1_RawHTTPRequest.OneOf_Body) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.unary, .unary): return {
-        guard case .unary(let l) = lhs, case .unary(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.stream, .stream): return {
-        guard case .stream(let l) = lhs, case .stream(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
-  struct EncodedQueryParam {
+  struct EncodedQueryParam: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -702,7 +666,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest {
 }
 
 /// MessageContents represents a message in a request body.
-struct Connectrpc_Conformance_V1_MessageContents {
+struct Connectrpc_Conformance_V1_MessageContents: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -746,7 +710,7 @@ struct Connectrpc_Conformance_V1_MessageContents {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The message data can be defined in one of three ways.
-  enum OneOf_Data: Equatable {
+  enum OneOf_Data: Equatable, @unchecked Sendable {
     /// Arbitrary bytes.
     case binary(Data)
     /// Arbitrary text.
@@ -756,35 +720,13 @@ struct Connectrpc_Conformance_V1_MessageContents {
     /// resulting bytes will be the contents.
     case binaryMessage(SwiftProtobuf.Google_Protobuf_Any)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Connectrpc_Conformance_V1_MessageContents.OneOf_Data, rhs: Connectrpc_Conformance_V1_MessageContents.OneOf_Data) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.binary, .binary): return {
-        guard case .binary(let l) = lhs, case .binary(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.text, .text): return {
-        guard case .text(let l) = lhs, case .text(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.binaryMessage, .binaryMessage): return {
-        guard case .binaryMessage(let l) = lhs, case .binaryMessage(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
 
 /// StreamContents represents a sequence of messages in a request body.
-struct Connectrpc_Conformance_V1_StreamContents {
+struct Connectrpc_Conformance_V1_StreamContents: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -794,7 +736,7 @@ struct Connectrpc_Conformance_V1_StreamContents {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct StreamItem {
+  struct StreamItem: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -835,7 +777,7 @@ struct Connectrpc_Conformance_V1_StreamContents {
 /// RawHTTPResponse models a raw HTTP response. This can be used to craft
 /// custom responses with odd properties (including certain kinds of
 /// malformed responses) to test edge cases in clients.
-struct Connectrpc_Conformance_V1_RawHTTPResponse {
+struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -872,67 +814,17 @@ struct Connectrpc_Conformance_V1_RawHTTPResponse {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Body: Equatable {
+  enum OneOf_Body: Equatable, Sendable {
     /// The body is a single message.
     case unary(Connectrpc_Conformance_V1_MessageContents)
     /// The body is a stream, encoded using a five-byte
     /// prefix before each item in the stream.
     case stream(Connectrpc_Conformance_V1_StreamContents)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Connectrpc_Conformance_V1_RawHTTPResponse.OneOf_Body, rhs: Connectrpc_Conformance_V1_RawHTTPResponse.OneOf_Body) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.unary, .unary): return {
-        guard case .unary(let l) = lhs, case .unary(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.stream, .stream): return {
-        guard case .stream(let l) = lhs, case .stream(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Connectrpc_Conformance_V1_UnaryResponseDefinition: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_UnaryResponseDefinition.OneOf_Response: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_StreamResponseDefinition: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_UnaryRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_UnaryResponse: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ServerStreamRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ServerStreamResponse: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ClientStreamRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ClientStreamResponse: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_BidiStreamRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_BidiStreamResponse: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_UnimplementedRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_UnimplementedResponse: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ConformancePayload: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_Error: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_Header: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_RawHTTPRequest: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_RawHTTPRequest.OneOf_Body: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_MessageContents: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_MessageContents.OneOf_Data: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_StreamContents: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_StreamContents.StreamItem: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_RawHTTPResponse: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_RawHTTPResponse.OneOf_Body: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -1494,8 +1386,8 @@ extension Connectrpc_Conformance_V1_UnimplementedRequest: SwiftProtobuf.Message,
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
@@ -1513,8 +1405,8 @@ extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
@@ -39,7 +39,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// suite, which can contain numerous cases. Each test suite has various properties
 /// that indicate the kinds of features that are tested. Test suites may be skipped
 /// based on whether the client or server under test implements these features.
-struct Connectrpc_Conformance_V1_TestSuite {
+struct Connectrpc_Conformance_V1_TestSuite: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -96,7 +96,7 @@ struct Connectrpc_Conformance_V1_TestSuite {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestMode: SwiftProtobuf.Enum {
+  enum TestMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Used when the test suite does not apply to a particular mode. Such tests
@@ -137,9 +137,16 @@ struct Connectrpc_Conformance_V1_TestSuite {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Connectrpc_Conformance_V1_TestSuite.TestMode] = [
+      .unspecified,
+      .client,
+      .server,
+    ]
+
   }
 
-  enum ConnectVersionMode: SwiftProtobuf.Enum {
+  enum ConnectVersionMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Used when the suite is agnostic to the server's validation
@@ -177,34 +184,19 @@ struct Connectrpc_Conformance_V1_TestSuite {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode] = [
+      .unspecified,
+      .require,
+      .ignore,
+    ]
+
   }
 
   init() {}
 }
 
-#if swift(>=4.2)
-
-extension Connectrpc_Conformance_V1_TestSuite.TestMode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Connectrpc_Conformance_V1_TestSuite.TestMode] = [
-    .unspecified,
-    .client,
-    .server,
-  ]
-}
-
-extension Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode] = [
-    .unspecified,
-    .require,
-    .ignore,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-struct Connectrpc_Conformance_V1_TestCase {
+struct Connectrpc_Conformance_V1_TestCase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -276,7 +268,7 @@ struct Connectrpc_Conformance_V1_TestCase {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct ExpandedSize {
+  struct ExpandedSize: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -306,14 +298,6 @@ struct Connectrpc_Conformance_V1_TestCase {
   fileprivate var _request: Connectrpc_Conformance_V1_ClientCompatRequest? = nil
   fileprivate var _expectedResponse: Connectrpc_Conformance_V1_ClientResponseResult? = nil
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Connectrpc_Conformance_V1_TestSuite: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_TestSuite.TestMode: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_TestCase: @unchecked Sendable {}
-extension Connectrpc_Conformance_V1_TestCase.ExpandedSize: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/ConformanceClient/Sources/main.swift
+++ b/Tests/ConformanceClient/Sources/main.swift
@@ -42,7 +42,7 @@ private func main() async throws {
         }
 
         let request = try Connectrpc_Conformance_V1_ClientCompatRequest(
-            serializedData: nextRequestData
+            serializedBytes: nextRequestData
         )
         let invoker = try ConformanceInvoker(request: request, clientType: clientTypeArg)
         let response: Connectrpc_Conformance_V1_ClientCompatResponse

--- a/Tests/ConformanceClient/buf.gen.yaml
+++ b/Tests/ConformanceClient/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.26.0
+  - plugin: buf.build/apple/swift:v1.27.0
     opt: Visibility=Internal
     out: ./GeneratedSources
   - name: connect-swift


### PR DESCRIPTION
Updates our SwiftProtobuf dependency: https://github.com/apple/swift-protobuf/releases/tag/1.27.0

Notably, his also allows us to remove a couple of TODOs and brings `Sendable` support to generated types by default.