### PR TITLE
Update SwiftLint to v0.55.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
   run-swiftlint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/realm/swiftlint:0.53.0
+      image: ghcr.io/realm/swiftlint:0.55.1
     steps:
       - uses: actions/checkout@v4
       - name: Run SwiftLint

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,7 @@ disabled_rules:
   - identifier_name
   - opening_brace
   - nesting
+  - non_optional_string_data_conversion
   - redundant_string_enum_value
   - todo
   - type_body_length


### PR DESCRIPTION
Updates our version of SwiftLint, but opts out of one of the new rules because making the required changes:

```diff
--- a/Libraries/Connect/Internal/Interceptors/GRPCWebInterceptor.swift
+++ b/Libraries/Connect/Internal/Interceptors/GRPCWebInterceptor.swift
@@ -260,17 +260,11 @@ extension GRPCWebInterceptor: StreamInterceptor {
     }
 }
 
-private struct TrailersDecodingError: Error {}
-
 private extension Trailers {
     static func fromGRPCHeadersBlock(_ source: Data) throws -> Self {
-        guard let string = String(data: source, encoding: .utf8) else {
-            throw TrailersDecodingError()
-        }
-
         // Decode trailers based on gRPC Web spec:
         // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
-        return string
+        return String(decoding: source, as: UTF8.self)
             .split(separator: "\r\n")
             .reduce(into: Trailers()) { trailers, line in
                 guard let separatorIndex = line.firstIndex(of: ":") else {
```

Caused some tests to fail:

```
FAILED: gRPC-Web Unexpected Responses/HTTPVersion:1/TLS:false/trailers-in-body/unary/multiple-responses:
	actual error {code: 2 (unknown), message: "RPC response missing status"} does not match expected code 12 (unimplemented)
```

It looks like there was some discussion around this rule being potentially problematic here: https://github.com/realm/SwiftLint/issues/5263#issuecomment-2115182747