### PR TITLE
Update CI to use Xcode 16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Eliza CocoaPods example
@@ -27,8 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Eliza Swift PM example
@@ -40,8 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Connect iOS library
@@ -51,8 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Connect macOS library
@@ -62,8 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Connect tvOS library
@@ -73,8 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Connect watchOS library
@@ -84,8 +84,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - uses: bufbuild/buf-setup-action@v1.42.0
         with:
           github_token: ${{ github.token }}
@@ -102,8 +102,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Install conformance runner
         run: make installconformancerunner
       - name: Run conformance tests
@@ -116,8 +116,8 @@ jobs:
         with:
           go-version: 1.21.x
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Run unit tests
         run: make testunit
   run-swiftlint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Connect iOS library
-        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.3' | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' | xcbeautify
   build-library-macos:
     runs-on: macos-14
     steps:
@@ -67,7 +67,7 @@ jobs:
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Connect tvOS library
-        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=tvOS Simulator,name=Apple TV,OS=17.3' | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.0' | xcbeautify
   build-library-watchos:
     runs-on: macos-14
     steps:
@@ -78,7 +78,7 @@ jobs:
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Build Connect watchOS library
-        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm),OS=10.3' | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.0' | xcbeautify
   build-plugin-and-generate:
     runs-on: macos-14
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode version
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select --switch /Applications/Xcode_16.app
       - uses: bufbuild/buf-setup-action@v1.42.0
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
We can upgrade to the Swift 6 toolchain separately; need some fixes in SwiftProtobuf first (like https://github.com/apple/swift-protobuf/issues/1729).