### PR TITLE
Add more `Sendable` conformances to resolve warnings

### DIFF
--- a/Libraries/Connect/Internal/Streaming/ClientOnlyAsyncStream.swift
+++ b/Libraries/Connect/Internal/Streaming/ClientOnlyAsyncStream.swift
@@ -23,7 +23,7 @@ import Foundation
 @available(iOS 13, *)
 final class ClientOnlyAsyncStream<
     Input: ProtobufMessage, Output: ProtobufMessage
->: BidirectionalAsyncStream<Input, Output> {
+>: BidirectionalAsyncStream<Input, Output>, @unchecked Sendable {
     private let receivedResults = Locked([StreamResult<Output>]())
 
     override func handleResultFromServer(_ result: StreamResult<Output>) {

--- a/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/BidirectionalAsyncStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/BidirectionalAsyncStreamInterface.swift
@@ -16,7 +16,7 @@ import SwiftProtobuf
 
 /// Represents a bidirectional stream that can be interacted with using async/await.
 @available(iOS 13, *)
-public protocol BidirectionalAsyncStreamInterface<Input, Output> {
+public protocol BidirectionalAsyncStreamInterface<Input, Output>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage
 

--- a/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/ClientOnlyAsyncStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/ClientOnlyAsyncStreamInterface.swift
@@ -17,7 +17,7 @@ import SwiftProtobuf
 /// Represents a client-only stream (a stream where the client streams data to the server and
 /// eventually receives a response) that can be interacted with using async/await.
 @available(iOS 13, *)
-public protocol ClientOnlyAsyncStreamInterface<Input, Output> {
+public protocol ClientOnlyAsyncStreamInterface<Input, Output>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage
 

--- a/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/ServerOnlyAsyncStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/ServerOnlyAsyncStreamInterface.swift
@@ -17,7 +17,7 @@ import SwiftProtobuf
 /// Represents a server-only stream (a stream where the server streams data to the client after
 /// receiving an initial request) that can be interacted with using async/await.
 @available(iOS 13, *)
-public protocol ServerOnlyAsyncStreamInterface<Input, Output> {
+public protocol ServerOnlyAsyncStreamInterface<Input, Output>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage
 

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -15,7 +15,7 @@
 import Connect
 import Foundation
 import NIOConcurrencyHelpers
-import NIOCore
+@preconcurrency import NIOCore // TODO: Convert to normal import once `ChannelHandler` is `Sendable`
 import NIOHTTP1
 import NIOHTTP2
 import NIOPosix

--- a/Tests/ConformanceClient/Sources/ConformanceInvoker.swift
+++ b/Tests/ConformanceClient/Sources/ConformanceInvoker.swift
@@ -19,7 +19,7 @@ import SwiftProtobuf
 
 /// Class responsible for running a specific conformance test case against a service.
 @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
-final class ConformanceInvoker {
+final class ConformanceInvoker: Sendable {
     private let client: ConformanceClient
     private let context: ConformanceRequest
 


### PR DESCRIPTION
Resolves warnings that appear when compiling with Xcode 16 / Swift 6.