### PR TITLE
Add deprecation warnings for package-internal APIs

### DIFF
--- a/Libraries/Connect/Internal/Interceptors/ConnectInterceptor.swift
+++ b/Libraries/Connect/Internal/Interceptors/ConnectInterceptor.swift
@@ -158,7 +158,7 @@ extension ConnectInterceptor: StreamInterceptor {
 
     @Sendable
     func handleStreamRawInput(_ input: Data, proceed: @escaping (Data) -> Void) {
-        proceed(Envelope.packMessage(input, using: self.config.requestCompression))
+        proceed(Envelope._packMessage(input, using: self.config.requestCompression))
     }
 
     @Sendable
@@ -190,7 +190,7 @@ extension ConnectInterceptor: StreamInterceptor {
                 let responseCompressionPool = self.streamResponseHeaders.value?[
                     HeaderConstants.connectStreamingContentEncoding
                 ]?.first.flatMap { self.config.responseCompressionPool(forName: $0) }
-                if responseCompressionPool == nil && Envelope.isCompressed(data) {
+                if responseCompressionPool == nil && Envelope._isCompressed(data) {
                     proceed(.complete(
                         code: .internalError, error: ConnectError(
                             code: .internalError, message: "received unexpected compressed message"
@@ -199,7 +199,7 @@ extension ConnectInterceptor: StreamInterceptor {
                     return
                 }
 
-                let (headerByte, message) = try Envelope.unpackMessage(
+                let (headerByte, message) = try Envelope._unpackMessage(
                     data, compressionPool: responseCompressionPool
                 )
                 let isEndStream = 0b00000010 & headerByte != 0

--- a/Libraries/Connect/PackageInternal/ConnectError+GRPC.swift
+++ b/Libraries/Connect/PackageInternal/ConnectError+GRPC.swift
@@ -25,6 +25,11 @@ extension ConnectError {
     ///                       passed in the headers block for gRPC-Web.
     ///
     /// - returns: A tuple containing the gRPC status code and an optional error.
+    @available(
+        swift,
+        deprecated: 100.0,
+        message: "This is an internal-only API which will be made package-private in Swift 6."
+    )
     public static func parseGRPCHeaders(
         _ headers: Headers?, trailers: Trailers?
     ) -> (grpcCode: Code, error: ConnectError?) {

--- a/Libraries/Connect/PackageInternal/ConnectError+GRPC.swift
+++ b/Libraries/Connect/PackageInternal/ConnectError+GRPC.swift
@@ -30,11 +30,11 @@ extension ConnectError {
         deprecated: 100.0,
         message: "This is an internal-only API which will be made package-private in Swift 6."
     )
-    public static func parseGRPCHeaders(
+    public static func _parseGRPCHeaders(
         _ headers: Headers?, trailers: Trailers?
     ) -> (grpcCode: Code, error: ConnectError?) {
         // "Trailers-only" responses can be sent in the headers or trailers block.
-        guard let grpcCode = trailers?.grpcStatus() ?? headers?.grpcStatus() else {
+        guard let grpcCode = trailers?._grpcStatus() ?? headers?._grpcStatus() else {
             return (.unknown, ConnectError(code: .unknown, message: "RPC response missing status"))
         }
 

--- a/Libraries/Connect/PackageInternal/Envelope.swift
+++ b/Libraries/Connect/PackageInternal/Envelope.swift
@@ -31,7 +31,7 @@ public enum Envelope {
         deprecated: 100.0,
         message: "This is an internal-only API which will be made package-private in Swift 6."
     )
-    public static var prefixLength: Int {
+    public static var _prefixLength: Int {
         return 5 // Header flags (1 byte) + message length (4 bytes)
     }
 
@@ -50,7 +50,7 @@ public enum Envelope {
         deprecated: 100.0,
         message: "This is an internal-only API which will be made package-private in Swift 6."
     )
-    public static func packMessage(
+    public static func _packMessage(
         _ source: Data, using compression: ProtocolClientConfig.RequestCompression?
     ) -> Data {
         var buffer = Data()
@@ -90,7 +90,7 @@ public enum Envelope {
         deprecated: 100.0,
         message: "This is an internal-only API which will be made package-private in Swift 6."
     )
-    public static func unpackMessage(
+    public static func _unpackMessage(
         _ source: Data, compressionPool: CompressionPool?
     ) throws -> (headerByte: UInt8, unpacked: Data) {
         if source.isEmpty {
@@ -99,7 +99,7 @@ public enum Envelope {
 
         let headerByte = source[0]
         let isCompressed = 0b00000001 & headerByte != 0
-        let messageData = Data(source.dropFirst(self.prefixLength))
+        let messageData = Data(source.dropFirst(self._prefixLength))
         if isCompressed {
             guard let compressionPool = compressionPool else {
                 throw Error.missingExpectedCompressionPool
@@ -121,7 +121,7 @@ public enum Envelope {
         deprecated: 100.0,
         message: "This is an internal-only API which will be made package-private in Swift 6."
     )
-    public static func isCompressed(_ packedData: Data) -> Bool {
+    public static func _isCompressed(_ packedData: Data) -> Bool {
         return !packedData.isEmpty && (0b00000001 & packedData[0] != 0)
     }
 
@@ -141,8 +141,8 @@ public enum Envelope {
         deprecated: 100.0,
         message: "This is an internal-only API which will be made package-private in Swift 6."
     )
-    public static func messageLength(forPackedData data: Data) -> Int {
-        guard data.count >= self.prefixLength else {
+    public static func _messageLength(forPackedData data: Data) -> Int {
+        guard data.count >= self._prefixLength else {
             return -1
         }
 

--- a/Libraries/Connect/PackageInternal/Envelope.swift
+++ b/Libraries/Connect/PackageInternal/Envelope.swift
@@ -19,8 +19,18 @@ import SwiftProtobuf
 /// to change. When the compiler supports it, this should be package-internal.**
 ///
 /// Provides functionality for packing and unpacking (headers and length prefixed) messages.
+@available(
+    swift,
+    deprecated: 100.0,
+    message: "This is an internal-only API which will be made package-private in Swift 6."
+)
 public enum Envelope {
     /// The total number of bytes that will prefix a message.
+    @available(
+        swift,
+        deprecated: 100.0,
+        message: "This is an internal-only API which will be made package-private in Swift 6."
+    )
     public static var prefixLength: Int {
         return 5 // Header flags (1 byte) + message length (4 bytes)
     }
@@ -35,6 +45,11 @@ public enum Envelope {
     /// - parameter compression: Configuration to use for compressing the message.
     ///
     /// - returns: Serialized/enveloped data for transmission.
+    @available(
+        swift,
+        deprecated: 100.0,
+        message: "This is an internal-only API which will be made package-private in Swift 6."
+    )
     public static func packMessage(
         _ source: Data, using compression: ProtocolClientConfig.RequestCompression?
     ) -> Data {
@@ -70,6 +85,11 @@ public enum Envelope {
     ///
     /// - returns: A tuple that includes the header byte and the un-prefixed and decompressed
     ///            message.
+    @available(
+        swift,
+        deprecated: 100.0,
+        message: "This is an internal-only API which will be made package-private in Swift 6."
+    )
     public static func unpackMessage(
         _ source: Data, compressionPool: CompressionPool?
     ) throws -> (headerByte: UInt8, unpacked: Data) {
@@ -96,6 +116,11 @@ public enum Envelope {
     /// - parameter packedData: The packed data to analyze.
     ///
     /// - returns: True if the data is compressed.
+    @available(
+        swift,
+        deprecated: 100.0,
+        message: "This is an internal-only API which will be made package-private in Swift 6."
+    )
     public static func isCompressed(_ packedData: Data) -> Bool {
         return !packedData.isEmpty && (0b00000001 & packedData[0] != 0)
     }
@@ -111,6 +136,11 @@ public enum Envelope {
     /// - returns: The length of the next expected message in the packed data. If multiple chunks
     ///            are specified, this will return the length of the first. Returns -1 if there is
     ///            not enough prefix data to determine the message length.
+    @available(
+        swift,
+        deprecated: 100.0,
+        message: "This is an internal-only API which will be made package-private in Swift 6."
+    )
     public static func messageLength(forPackedData data: Data) -> Int {
         guard data.count >= self.prefixLength else {
             return -1

--- a/Libraries/Connect/PackageInternal/Headers+GRPC.swift
+++ b/Libraries/Connect/PackageInternal/Headers+GRPC.swift
@@ -30,7 +30,7 @@ extension Headers {
         deprecated: 100.0,
         message: "This is an internal-only API which will be made package-private in Swift 6."
     )
-    public func addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
+    public func _addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
         var headers = self
         headers[HeaderConstants.grpcAcceptEncoding] = config
             .acceptCompressionPoolNames()

--- a/Libraries/Connect/PackageInternal/Headers+GRPC.swift
+++ b/Libraries/Connect/PackageInternal/Headers+GRPC.swift
@@ -25,6 +25,11 @@ extension Headers {
     /// - parameter grpcWeb: Should be true if using gRPC-Web, false if gRPC.
     ///
     /// - returns: A set of updated headers.
+    @available(
+        swift,
+        deprecated: 100.0,
+        message: "This is an internal-only API which will be made package-private in Swift 6."
+    )
     public func addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
         var headers = self
         headers[HeaderConstants.grpcAcceptEncoding] = config

--- a/Libraries/Connect/PackageInternal/Trailers+gRPC.swift
+++ b/Libraries/Connect/PackageInternal/Trailers+gRPC.swift
@@ -19,6 +19,11 @@ extension Trailers {
     /// Identifies the status code from gRPC and gRPC-Web trailers.
     ///
     /// - returns: The gRPC status code, if specified.
+    @available(
+        swift,
+        deprecated: 100.0,
+        message: "This is an internal-only API which will be made package-private in Swift 6."
+    )
     public func grpcStatus() -> Code? {
         return self[HeaderConstants.grpcStatus]?
             .first

--- a/Libraries/Connect/PackageInternal/Trailers+gRPC.swift
+++ b/Libraries/Connect/PackageInternal/Trailers+gRPC.swift
@@ -24,7 +24,7 @@ extension Trailers {
         deprecated: 100.0,
         message: "This is an internal-only API which will be made package-private in Swift 6."
     )
-    public func grpcStatus() -> Code? {
+    public func _grpcStatus() -> Code? {
         return self[HeaderConstants.grpcStatus]?
             .first
             .flatMap(Int.init)

--- a/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
@@ -299,12 +299,12 @@ extension ProtocolClient: ProtocolClientInterface {
                     // Handle cases where multiple messages are received in a single chunk.
                     responseBuffer += data
                     while true {
-                        let messageLength = Envelope.messageLength(forPackedData: responseBuffer)
+                        let messageLength = Envelope._messageLength(forPackedData: responseBuffer)
                         if messageLength < 0 {
                             return
                         }
 
-                        let prefixedMessageLength = Envelope.prefixLength + messageLength
+                        let prefixedMessageLength = Envelope._prefixLength + messageLength
                         guard responseBuffer.count >= prefixedMessageLength else {
                             return
                         }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
@@ -18,62 +18,62 @@ import XCTest
 final class EnvelopeTests: XCTestCase {
     func testPackingAndUnpackingCompressedMessage() throws {
         let originalData = Data(repeating: 0xa, count: 50)
-        let packed = Envelope.packMessage(
+        let packed = Envelope._packMessage(
             originalData, using: .init(minBytes: 10, pool: GzipCompressionPool())
         )
         let compressed = try GzipCompressionPool().compress(data: originalData)
         XCTAssertEqual(packed[0], 1) // Compression flag = true
-        XCTAssertTrue(Envelope.isCompressed(packed))
-        XCTAssertEqual(Envelope.messageLength(forPackedData: packed), compressed.count)
+        XCTAssertTrue(Envelope._isCompressed(packed))
+        XCTAssertEqual(Envelope._messageLength(forPackedData: packed), compressed.count)
         XCTAssertEqual(packed[5...], compressed) // Post-prefix data should match compressed value
 
-        let unpacked = try Envelope.unpackMessage(packed, compressionPool: GzipCompressionPool())
+        let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
         XCTAssertEqual(unpacked.unpacked, originalData)
         XCTAssertEqual(unpacked.headerByte, 1) // Compression flag = true
     }
 
     func testPackingAndUnpackingUncompressedMessageBecauseCompressionMinBytesIsNil() throws {
         let originalData = Data(repeating: 0xa, count: 50)
-        let packed = Envelope.packMessage(originalData, using: nil)
+        let packed = Envelope._packMessage(originalData, using: nil)
         XCTAssertEqual(packed[0], 0) // Compression flag = false
-        XCTAssertFalse(Envelope.isCompressed(packed))
-        XCTAssertEqual(Envelope.messageLength(forPackedData: packed), originalData.count)
+        XCTAssertFalse(Envelope._isCompressed(packed))
+        XCTAssertEqual(Envelope._messageLength(forPackedData: packed), originalData.count)
         XCTAssertEqual(packed[5...], originalData) // Post-prefix data should match compressed value
 
         // Compression pool should be ignored since the message is not compressed
-        let unpacked = try Envelope.unpackMessage(packed, compressionPool: GzipCompressionPool())
+        let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
         XCTAssertEqual(unpacked.unpacked, originalData)
         XCTAssertEqual(unpacked.headerByte, 0) // Compression flag = false
     }
 
     func testPackingAndUnpackingUncompressedMessageBecauseMessageIsTooSmall() throws {
         let originalData = Data(repeating: 0xa, count: 50)
-        let packed = Envelope.packMessage(
+        let packed = Envelope._packMessage(
             originalData, using: .init(minBytes: 100, pool: GzipCompressionPool())
         )
         XCTAssertEqual(packed[0], 0) // Compression flag = false
-        XCTAssertFalse(Envelope.isCompressed(packed))
-        XCTAssertEqual(Envelope.messageLength(forPackedData: packed), originalData.count)
+        XCTAssertFalse(Envelope._isCompressed(packed))
+        XCTAssertEqual(Envelope._messageLength(forPackedData: packed), originalData.count)
         XCTAssertEqual(packed[5...], originalData) // Post-prefix data should match compressed value
 
         // Compression pool should be ignored since the message is not compressed
-        let unpacked = try Envelope.unpackMessage(packed, compressionPool: GzipCompressionPool())
+        let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
         XCTAssertEqual(unpacked.unpacked, originalData)
         XCTAssertEqual(unpacked.headerByte, 0) // Compression flag = false
     }
 
     func testThrowsWhenUnpackingCompressedMessageWithoutDecompressionPool() throws {
         let originalData = Data(repeating: 0xa, count: 50)
-        let packed = Envelope.packMessage(
+        let packed = Envelope._packMessage(
             originalData, using: .init(minBytes: 10, pool: GzipCompressionPool())
         )
         let compressed = try GzipCompressionPool().compress(data: originalData)
         XCTAssertEqual(packed[0], 1) // Compression flag = true
-        XCTAssertTrue(Envelope.isCompressed(packed))
-        XCTAssertEqual(Envelope.messageLength(forPackedData: packed), compressed.count)
+        XCTAssertTrue(Envelope._isCompressed(packed))
+        XCTAssertEqual(Envelope._messageLength(forPackedData: packed), compressed.count)
         XCTAssertEqual(packed[5...], compressed) // Post-prefix data should match compressed value
 
-        XCTAssertThrowsError(try Envelope.unpackMessage(packed, compressionPool: nil)) { error in
+        XCTAssertThrowsError(try Envelope._unpackMessage(packed, compressionPool: nil)) { error in
             XCTAssertEqual(error as? Envelope.Error, .missingExpectedCompressionPool)
         }
     }
@@ -82,7 +82,7 @@ final class EnvelopeTests: XCTestCase {
         // Messages are incomplete if they do not contain enough data for the 5-byte prefix
         for length in 0..<5 {
             let data = Data(repeating: 0xa, count: length)
-            XCTAssertEqual(Envelope.messageLength(forPackedData: data), -1)
+            XCTAssertEqual(Envelope._messageLength(forPackedData: data), -1)
         }
     }
 }


### PR DESCRIPTION
This PR adds deprecation warnings to APIs that are considered package-internal but cannot yet be marked as `package` instead of `public` until we adopt Swift 6 (see https://github.com/connectrpc/connect-swift/issues/310). We can't make these APIs _currently_ deprecated since that will introduce deprecation warnings where they're used within the library, but we can at least add _future deprecation_ warnings which will show up in the IDE as shown below:

<img width="684" alt="Screenshot 2024-10-16 at 11 27 45 AM" src="https://github.com/user-attachments/assets/be489f7f-bf32-466d-8aa3-1fc999bba0c6">

The goal of doing this is to help enable us to tag a 1.0 before adopting Swift 6 so we can mark those APIs as `package` afterwards and reasonably consider it a non-breaking change.