### PR TITLE
Add deprecation annotations for RPCs marked "deprecated=true"

### DIFF
--- a/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
+++ b/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
@@ -117,6 +117,9 @@ final class ConnectMockGenerator: Generator {
 
     private func printCallbackMethodMockImplementation(for method: MethodDescriptor) {
         self.printLine()
+        if let availabilityAnnotation = method.callbackAvailabilityAnnotation() {
+            self.printLine(availabilityAnnotation)
+        }
         if !method.serverStreaming && !method.clientStreaming {
             self.printLine("@discardableResult")
         }
@@ -150,7 +153,9 @@ final class ConnectMockGenerator: Generator {
 
     private func printAsyncAwaitMethodMockImplementation(for method: MethodDescriptor) {
         self.printLine()
-
+        if let availabilityAnnotation = method.asyncAwaitAvailabilityAnnotation() {
+            self.printLine(availabilityAnnotation)
+        }
         self.printLine(
             "\(self.typeVisibility) "
             + method.asyncAwaitSignature(
@@ -217,6 +222,30 @@ private extension MethodDescriptor {
             .init(result: .success(.init())) \
             }
             """
+        }
+    }
+
+    func callbackAvailabilityAnnotation() -> String? {
+        if self.options.deprecated {
+            // swiftlint:disable line_length
+            return """
+            @available(iOS, introduced: 12, deprecated: 12, message: "This function has been marked deprecated.")
+            @available(macOS, introduced: 10.15, deprecated: 10.15, message: "This function has been marked deprecated.")
+            @available(tvOS, introduced: 13, deprecated: 13, message: "This function has been marked deprecated.")
+            @available(watchOS, introduced: 6, deprecated: 6, message: "This function has been marked deprecated.")
+            """
+            // swiftlint:enable line_length
+        } else {
+            return nil
+        }
+    }
+
+    func asyncAwaitAvailabilityAnnotation() -> String? {
+        if self.options.deprecated {
+            // swiftlint:disable:next line_length
+            return "@available(iOS, introduced: 13, deprecated: 13, message: \"This function has been marked deprecated.\")"
+        } else {
+            return nil
         }
     }
 }

--- a/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
+++ b/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
@@ -229,10 +229,10 @@ private extension MethodDescriptor {
         if self.options.deprecated {
             // swiftlint:disable line_length
             return """
-            @available(iOS, introduced: 12, deprecated: 12, message: "This function has been marked deprecated.")
-            @available(macOS, introduced: 10.15, deprecated: 10.15, message: "This function has been marked deprecated.")
-            @available(tvOS, introduced: 13, deprecated: 13, message: "This function has been marked deprecated.")
-            @available(watchOS, introduced: 6, deprecated: 6, message: "This function has been marked deprecated.")
+            @available(iOS, introduced: 12, deprecated: 12, message: "This RPC has been marked as deprecated in its `.proto` file.")
+            @available(macOS, introduced: 10.15, deprecated: 10.15, message: "This RPC has been marked as deprecated in its `.proto` file.")
+            @available(tvOS, introduced: 13, deprecated: 13, message: "This RPC has been marked as deprecated in its `.proto` file.")
+            @available(watchOS, introduced: 6, deprecated: 6, message: "This RPC has been marked as deprecated in its `.proto` file.")
             """
             // swiftlint:enable line_length
         } else {
@@ -243,7 +243,7 @@ private extension MethodDescriptor {
     func asyncAwaitAvailabilityAnnotation() -> String? {
         if self.options.deprecated {
             // swiftlint:disable:next line_length
-            return "@available(iOS, introduced: 13, deprecated: 13, message: \"This function has been marked deprecated.\")"
+            return "@available(iOS, introduced: 13, deprecated: 13, message: \"This RPC has been marked as deprecated in its `.proto` file.\")"
         } else {
             return nil
         }

--- a/Plugins/ConnectSwiftPlugin/ConnectClientGenerator.swift
+++ b/Plugins/ConnectSwiftPlugin/ConnectClientGenerator.swift
@@ -211,10 +211,10 @@ private extension MethodDescriptor {
         if self.options.deprecated {
             // swiftlint:disable line_length
             return """
-            @available(iOS, introduced: 12, deprecated: 12, message: "This function has been marked deprecated.")
-            @available(macOS, introduced: 10.15, deprecated: 10.15, message: "This function has been marked deprecated.")
-            @available(tvOS, introduced: 13, deprecated: 13, message: "This function has been marked deprecated.")
-            @available(watchOS, introduced: 6, deprecated: 6, message: "This function has been marked deprecated.")
+            @available(iOS, introduced: 12, deprecated: 12, message: "This RPC has been marked as deprecated in its `.proto` file.")
+            @available(macOS, introduced: 10.15, deprecated: 10.15, message: "This RPC has been marked as deprecated in its `.proto` file.")
+            @available(tvOS, introduced: 13, deprecated: 13, message: "This RPC has been marked as deprecated in its `.proto` file.")
+            @available(watchOS, introduced: 6, deprecated: 6, message: "This RPC has been marked as deprecated in its `.proto` file.")
             """
             // swiftlint:enable line_length
         } else {
@@ -225,7 +225,7 @@ private extension MethodDescriptor {
     func asyncAwaitAvailabilityAnnotation() -> String {
         if self.options.deprecated {
             // swiftlint:disable:next line_length
-            return "@available(iOS, introduced: 13, deprecated: 13, message: \"This function has been marked deprecated.\")"
+            return "@available(iOS, introduced: 13, deprecated: 13, message: \"This RPC has been marked as deprecated in its `.proto` file.\")"
         } else {
             return "@available(iOS 13, *)"
         }


### PR DESCRIPTION
This enhances the `ConnectClientGenerator` to inspect the `deprecated` option and annotate the generated service functions accordingly.

- For async/await functions, the existing `@available` annotation, which only exists for iOS, is adjusted accordingly to introduce and deprecate the function at v13, since that is when concurrency was first made available.
  - @rebello95 should we consider adjusting both my deprecation annotation and the existing annotation to account for the other supported platforms of the library?
- Since no pattern was established for generated callback functions, I enhanced their generation to include `@available` annotations for all supported platforms. The "introduced" and "deprecated" versions for those platforms were determined by the minimum supported version of the respective platform defined in `Package.swift`.

Adding the following RPC...
```proto
rpc SayDeprecated(SayRequest) returns (SayResponse) {
  option idempotency_level = NO_SIDE_EFFECTS;
  option deprecated = true;
}
```
...to the ElizaService defined in the [examples-go repository](https://github.com/connectrpc/examples-go/blob/main/proto/connectrpc/eliza/v1/eliza.proto), from which the Eliza sample app sources are generated, and regenerating the Swift service (setting `GenerateCallbackMethods=true` to also demonstrate callback behavior) yields the following result:

```swift
@available(iOS, introduced: 12, deprecated: 12, message: "This function has been marked deprecated.")
@available(macOS, introduced: 10.15, deprecated: 10.15, message: "This function has been marked deprecated.")
@available(tvOS, introduced: 13, deprecated: 13, message: "This function has been marked deprecated.")
@available(watchOS, introduced: 6, deprecated: 6, message: "This function has been marked deprecated.")
@discardableResult
func `sayDeprecated`(request: Connectrpc_Eliza_V1_SayRequest, headers: Connect.Headers, completion: @escaping @Sendable (ResponseMessage<Connectrpc_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable

@available(iOS, introduced: 13, deprecated: 13, message: "This function has been marked deprecated.")
func `sayDeprecated`(request: Connectrpc_Eliza_V1_SayRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Eliza_V1_SayResponse>
```

The generated code for the existing `Say` RPC remains unchanged:

```swift
/// Say is a unary RPC. Eliza responds to the prompt with a single sentence.
@discardableResult
func `say`(request: Connectrpc_Eliza_V1_SayRequest, headers: Connect.Headers, completion: @escaping @Sendable (ResponseMessage<Connectrpc_Eliza_V1_SayResponse>) -> Void) -> Connect.Cancelable

/// Say is a unary RPC. Eliza responds to the prompt with a single sentence.
@available(iOS 13, *)
func `say`(request: Connectrpc_Eliza_V1_SayRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Eliza_V1_SayResponse>
```

The same additions have been made to the `ConnectMockGenerator`.

Closes #305 