### PR TITLE
Add `LocalizedError` conformance to `ConnectError`

### DIFF
--- a/Libraries/Connect/Public/Interfaces/ConnectError.swift
+++ b/Libraries/Connect/Public/Interfaces/ConnectError.swift
@@ -111,6 +111,12 @@ extension ConnectError: Decodable {
     }
 }
 
+extension ConnectError: LocalizedError {
+    public var errorDescription: String? {
+        return self.message ?? self.exception.map { "internal error: \($0.localizedDescription)" }
+    }
+}
+
 extension ConnectError {
     public static func from(
         code: Code, headers: Headers?, trailers: Trailers?, source: Data?


### PR DESCRIPTION
This improves how error messages are surfaced through `ConnectError`.

Before:
```
(lldb) po response.error?.localizedDescription
▿ Optional<String>
  - some : "The operation couldn’t be completed. (Connect.ConnectError error 1.)"
```

After:
```
(lldb) po response.error?.localizedDescription
▿ Optional<String>
  - some : "The Internet connection appears to be offline."
```