### PR TITLE
Use `ConnectError.unavailable` when client is offline

### DIFF
--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -207,6 +207,15 @@ extension Code {
             return .deadlineExceeded
         case URLError.unsupportedURL.rawValue:
             return .unimplemented
+        case NSURLErrorCannotConnectToHost,
+            NSURLErrorCannotFindHost,
+            NSURLErrorDataNotAllowed,
+            NSURLErrorInternationalRoamingOff,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorNotConnectedToInternet,
+            NSURLErrorSecureConnectionFailed,
+            NSURLErrorTimedOut:
+            return .unavailable
         case ...100: // URLSession can return errors in this range
             return .unknown
         default:

--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -203,7 +203,7 @@ extension Code {
             return .canceled
         case URLError.badURL.rawValue:
             return .invalidArgument
-        case URLError.timedOut.rawValue:
+        case URLError.timedOut.rawValue, NSURLErrorTimedOut:
             return .deadlineExceeded
         case URLError.unsupportedURL.rawValue:
             return .unimplemented
@@ -213,8 +213,7 @@ extension Code {
             NSURLErrorInternationalRoamingOff,
             NSURLErrorNetworkConnectionLost,
             NSURLErrorNotConnectedToInternet,
-            NSURLErrorSecureConnectionFailed,
-            NSURLErrorTimedOut:
+            NSURLErrorSecureConnectionFailed:
             return .unavailable
         case ...100: // URLSession can return errors in this range
             return .unknown


### PR DESCRIPTION
Resolves https://github.com/connectrpc/connect-swift/issues/325.

When turning the device's wifi off, the following was observed with URLSession:

Before:

```
▿ Optional<ConnectError>
  ▿ some : ConnectError
    - code : Connect.Code.unknown
    ▿ message : Optional<String>
      - some : "The Internet connection appears to be offline."
    ▿ exception : Optional<Error>
      - some : Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline." 
```

Based on the discussion in the issue linked above, this PR updates the code to be `.unavailable`:

```
▿ Optional<ConnectError>
  ▿ some : ConnectError
    - code : Connect.Code.unavailable
    ▿ message : Optional<String>
      - some : "The Internet connection appears to be offline."
    ▿ exception : Optional<Error>
      - some : Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline." 
```

The NIO client has also been updated to return the `.unavailable` status code:

```
▿ Optional<ConnectError>
  ▿ some : ConnectError
    - code : Connect.Code.unavailable
    ▿ message : Optional<String>
      - some : "client is not connected"
    - exception : nil
```