### PR TITLE
Fix leak in internal implementation of a lock

### DIFF
--- a/Libraries/Connect/Internal/Utilities/Lock.swift
+++ b/Libraries/Connect/Internal/Utilities/Lock.swift
@@ -25,6 +25,11 @@ final class Lock: @unchecked Sendable {
         self.underlyingLock.initialize(to: os_unfair_lock())
     }
 
+    deinit {
+        self.underlyingLock.deinitialize(count: 1)
+        self.underlyingLock.deallocate()
+    }
+
     /// Perform an action within the context of the lock.
     ///
     /// - parameter action: Closure to be executed in the context of the lock.


### PR DESCRIPTION
While debugging a memory issue in one of our applications, we found a large number of leaked lock instances. This PR fixes the small but rapidly accumulating leak in the internal `Lock` implementation.