### PR TITLE
Prevent duplicate resume continuation on unary request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
   run-swiftlint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/realm/swiftlint:0.57.1
+      image: ghcr.io/realm/swiftlint:0.58.2
     steps:
       - uses: actions/checkout@v4
       - name: Run SwiftLint


### PR DESCRIPTION
Issue #333 reported an issue where the continuation in the `UnaryAsyncWrapper` was getting resumed twice, which results in a fatal error. Additional details are available in the issue, but the gist is -

When the client is configured to use the gRPC protocol (therefore using swift-nio for networking instead of URLSession), and it is configured with a short timeout internal, when the server responds in error at around the same time that the timeout occurs, the callback that resumes the continuation may fire twice.

I was able to replicate this issue by adjusting the Eliza app's `ProtocolClient` to have a timeout of 0.25s and to point Eliza at a different Connect server (my own team's), such that requests to the Eliza RPCs would result in 404 errors.

This change simply introduces a thread-safe `Bool` to track whether the continuation has been resumed, and if the callback attempts to fire twice, it will throw an `assertionFailure` and return instead of calling `resume` again and causing a fatal error.

Closes #333 
