### PR TITLE
Upgrade SwiftProtobuf dependency

### DIFF
--- a/Connect-Swift-Mocks.podspec
+++ b/Connect-Swift-Mocks.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
   spec.watchos.deployment_target = '6.0'
 
   spec.dependency 'Connect-Swift', "#{spec.version.to_s}"
-  spec.dependency 'SwiftProtobuf', '~> 1.28.2'
+  spec.dependency 'SwiftProtobuf', '~> 1.30.0'
 
   spec.source_files = 'Libraries/ConnectMocks/**/*.swift'
 

--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '13.0'
   spec.watchos.deployment_target = '6.0'
 
-  spec.dependency 'SwiftProtobuf', '~> 1.28.2'
+  spec.dependency 'SwiftProtobuf', '~> 1.30.0'
 
   spec.source_files = 'Libraries/Connect/**/*.swift'
 

--- a/Examples/ElizaCocoaPodsApp/Podfile.lock
+++ b/Examples/ElizaCocoaPodsApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Connect-Swift (1.0.4):
-    - SwiftProtobuf (~> 1.28.2)
-  - SwiftProtobuf (1.28.2)
+    - SwiftProtobuf (~> 1.30.0)
+  - SwiftProtobuf (1.30.0)
 
 DEPENDENCIES:
   - Connect-Swift (from `../..`)

--- a/Examples/ElizaCocoaPodsApp/Podfile.lock
+++ b/Examples/ElizaCocoaPodsApp/Podfile.lock
@@ -15,8 +15,8 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Connect-Swift: 5d888f34286e7aab1652b531503e106cc8bdbbaf
-  SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
+  Connect-Swift: d9d98ea6a5eb46ba26dd5ba3199104f29f86be2c
+  SwiftProtobuf: 3697407f0d5b23bedeba9c2eaaf3ec6fdff69349
 
 PODFILE CHECKSUM: b598f373a6ab5add976b09c2ac79029bf2200d48
 

--- a/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
       }
     },
     {

--- a/Examples/buf.gen.yaml
+++ b/Examples/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.28.2
+  - plugin: buf.build/apple/swift:v1.30.0
     opt: Visibility=Internal
     out: ./ElizaSharedSources/GeneratedSources
   - name: connect-swift

--- a/Libraries/Connect/buf.gen.yaml
+++ b/Libraries/Connect/buf.gen.yaml
@@ -1,5 +1,5 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.28.2
+  - plugin: buf.build/apple/swift:v1.30.0
     opt: Visibility=Internal
     out: ./Internal/GeneratedSources

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
-            from: "1.28.2"
+            from: "1.30.0"
         ),
     ],
     targets: [

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
@@ -583,15 +583,11 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, 
     var _cancel: Connectrpc_Conformance_V1_ClientCompatRequest.Cancel? = nil
     var _rawRequest: Connectrpc_Conformance_V1_RawHTTPRequest? = nil
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 

--- a/Tests/ConformanceClient/buf.gen.yaml
+++ b/Tests/ConformanceClient/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.28.2
+  - plugin: buf.build/apple/swift:v1.30.0
     opt: Visibility=Internal
     out: ./GeneratedSources
   - name: connect-swift

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
@@ -583,15 +583,11 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, 
     var _cancel: Connectrpc_Conformance_V1_ClientCompatRequest.Cancel? = nil
     var _rawRequest: Connectrpc_Conformance_V1_RawHTTPRequest? = nil
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 

--- a/Tests/UnitTests/ConnectLibraryTests/buf.gen.yaml
+++ b/Tests/UnitTests/ConnectLibraryTests/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.28.2
+  - plugin: buf.build/apple/swift:v1.30.0
     opt: Visibility=Internal
     out: ./GeneratedSources
   - name: connect-swift


### PR DESCRIPTION
I noticed the SwiftProtobuf dependency hasn't been updated in a while. This PR aims to update to the latest [1.30.0 release](https://github.com/apple/swift-protobuf/releases/tag/1.30.0).

ps. Not sure if any other files need to be updated, and I hope tests will catch any incompatibilities upgrading from `1.28.2`