### PR TITLE
Add package visibility option to code generators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   # Sets the Xcode version to use for the CI.
   # Available Versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md#xcode
   # Ref: https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
-  DEVELOPER_DIR: /Applications/Xcode_16.3.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
 permissions:
   contents: read
 jobs:
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build Connect iOS library
-        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' | xcbeautify
   build-library-macos:
     runs-on: macos-15
     steps:
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build Connect tvOS library
-        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.4' | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.5' | xcbeautify
   build-library-watchos:
     runs-on: macos-15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   # Sets the Xcode version to use for the CI.
   # Available Versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md#xcode
   # Ref: https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
-  DEVELOPER_DIR: /Applications/Xcode_16.3.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
 permissions:
   contents: write
 jobs:

--- a/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
+++ b/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
@@ -36,6 +36,9 @@ final class ConnectMockGenerator: Generator {
         case .public:
             self.propertyVisibility = "public"
             self.typeVisibility = "open"
+        case .package:
+            self.propertyVisibility = "package"
+            self.typeVisibility = "package"
         }
 
         if self.options.generateCallbackMethods {

--- a/Plugins/ConnectPluginUtilities/GeneratorOptions.swift
+++ b/Plugins/ConnectPluginUtilities/GeneratorOptions.swift
@@ -65,6 +65,7 @@ public struct GeneratorOptions {
     public enum Visibility: String {
         case `internal` = "Internal"
         case `public` = "Public"
+        case `package` = "Package"
     }
 
     static func empty() -> Self {

--- a/Plugins/ConnectSwiftPlugin/ConnectClientGenerator.swift
+++ b/Plugins/ConnectSwiftPlugin/ConnectClientGenerator.swift
@@ -33,6 +33,8 @@ final class ConnectClientGenerator: Generator {
             self.visibility = "internal"
         case .public:
             self.visibility = "public"
+        case .package:
+            self.visibility = "package"
         }
 
         self.printModuleImports()


### PR DESCRIPTION
The `package` access modifier was introduced in Swift 5.9 ([proposal 0386](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0386-package-access-modifier.md)) to bridge the gap between `internal` and `public` in Swift packages.

[Support for this modifier in generated code](https://github.com/apple/swift-protobuf/pull/1472) was added to SwiftProtobuf in September 2023.

This change adds the `Package` visibility option to the Connect generators. This is particularly useful when developing a Swift package, and you want to vend your generated models and mocks from a specific target to other targets of your package but not to dependent applications.
