### PR TITLE
Fix CI failures resulting from missing simulators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build Connect iOS library
-        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=iOS Simulator,name=Any iOS Simulator Device' | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=iOS Simulator,OS=26.0' | xcbeautify
   build-library-macos:
     runs-on: macos-26
     steps:
@@ -47,13 +47,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build Connect tvOS library
-        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=tvOS Simulator,name=Any tvOS Simulator Device' | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=tvOS Simulator,OS=26.0' | xcbeautify
   build-library-watchos:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v5
       - name: Build Connect watchOS library
-        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=watchOS Simulator,name=Any watchOS Simulator Device' | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=watchOS Simulator,OS=26.0' | xcbeautify
   build-plugin-and-generate:
     runs-on: macos-26
     steps:


### PR DESCRIPTION
GitHub Actions keeps changing supported simulators on our CI machines from underneath us, breaking CI checks (example here: https://github.com/connectrpc/connect-swift/actions/runs/19645507500/job/56271087929?pr=373).

This PR removes the simulator/OS pinning - I think this will result in fewer net CI failures since we can generally continue using the defaults on the machines (note that we are still pinning macOS versions on the machines, as well as Xcode versions).