### PR TITLE
Update CI to use Xcode 26.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   # Sets the Xcode version to use for the CI.
   # Available versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode
   # Ref: https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
-  DEVELOPER_DIR: /Applications/Xcode_26.1.0.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.1.1.app/Contents/Developer
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   # Sets the Xcode version to use for the CI.
   # Available versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode
   # Ref: https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
-  DEVELOPER_DIR: /Applications/Xcode_26.1.0.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.1.1.app/Contents/Developer
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
GitHub Actions changed from under us again, causing these failures: https://github.com/connectrpc/connect-swift/actions/runs/19789723223/job/56746140584