### PR TITLE
Add Timo Stamm to maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,3 +6,4 @@ Maintainers
 * [Michael Rebello](https://github.com/rebello95), [Airbnb](https://airbnb.com)
 * [Josh Humphries](https://github.com/jhump), [Buf](https://buf.build)
 * [Eddie Seay](https://github.com/eseay), [Chick-fil-A](https://www.chick-fil-a.com/)
+* [Timo Stamm](https://github.com/timostamm), [Buf](https://buf.build)


### PR DESCRIPTION
This adds @timostamm to the set of maintainers in this repo. Timo is the primary author and maintainer of [protobuf-es](https://github.com/bufbuild/protobuf-es) and [connect-es](https://github.com/connectrpc/connect-es). He has demonstrated a clear mastery of ConnectRPC, gRPC, and Protobuf and would be valuable as an additional asset for improving and reviewing improvements for all implementations, including Swift.