### PR TITLE
Use native Foundation base64url encoding on Swift 6.3+

### DIFF
--- a/Libraries/Connect/Internal/Interceptors/ConnectInterceptor.swift
+++ b/Libraries/Connect/Internal/Interceptors/ConnectInterceptor.swift
@@ -253,10 +253,7 @@ extension ProtocolClientConfig {
             URLQueryItem(name: "base64", value: "1"),
             URLQueryItem(name: "connect", value: "v\(ConnectInterceptor.protocolVersion)"),
             URLQueryItem(name: "encoding", value: self.codec.name()),
-            URLQueryItem(name: "message", value: request.message?.base64EncodedString()
-                .replacingOccurrences(of: "+", with: "-")
-                .replacingOccurrences(of: "/", with: "_")
-                .replacingOccurrences(of: "=", with: "")),
+            URLQueryItem(name: "message", value: request.message?.urlSafeBase64EncodedString()),
         ]
 
         if let contentEncoding = request.headers[HeaderConstants.contentEncoding]?.first {

--- a/Libraries/Connect/Internal/Utilities/Data+URLSafeBase64.swift
+++ b/Libraries/Connect/Internal/Utilities/Data+URLSafeBase64.swift
@@ -1,0 +1,40 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension Data {
+    /// Returns a raw URL-safe base64 encoded string (RFC 4648 §5).
+    ///
+    /// Uses native `base64URLAlphabet` + `omitPaddingCharacter` when compiled
+    /// with Swift 6.3+ and running on platforms that support it (iOS 26.4+,
+    /// macOS 26.4+), with a string-replacement fallback otherwise.
+    func urlSafeBase64EncodedString() -> String {
+#if compiler(>=6.3)
+        if #available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *) {
+            return self.base64EncodedString(options: [.base64URLAlphabet, .omitPaddingCharacter])
+        } else {
+            return self.base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        }
+#else
+        return self.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+#endif
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #388. Swift 6.3 (Xcode 26.4, released March 24, 2026) ships Foundation's native [`.base64URLAlphabet` and `.omitPaddingCharacter`](https://forums.swift.org/t/pitch-adding-base64-urlencoding-and-omitting-padding-options-to-base64-encoding-and-decoding/77659) options, making the string-replacement workaround unnecessary on newer platforms.

- Extract encoding logic into `Data.urlSafeBase64EncodedString()` helper
- Use native `base64EncodedString(options: [.base64URLAlphabet, .omitPaddingCharacter])` on iOS/macOS/watchOS/tvOS/visionOS 26.4+
- Fall back to existing `replacingOccurrences` approach on older OS versions
- Guard with `#if compiler(>=6.3)` so the code compiles on older Swift toolchains (e.g., Xcode 26.1.1 / Swift 6.2)

**Before:**
```swift
request.message?.base64EncodedString()
    .replacingOccurrences(of: "+", with: "-")
    .replacingOccurrences(of: "/", with: "_")
    .replacingOccurrences(of: "=", with: "")
```

**After:**
```swift
request.message?.urlSafeBase64EncodedString()
```

## Test plan

- [x] `swift build` succeeds
- [x] `testTransformToGETUsesURLSafeBase64` passes (validates `Pj-__w` output)
- [x] Verified native API produces correct output: `Data([0x3E, 0x3F, 0xBF, 0xFF])` → `Pj-__w`
- [x] Compiles on Swift 6.2 (Xcode 26.1.1) — `#if compiler(>=6.3)` skips the native API block
- Backward compatible: `#available` check ensures older platforms use the fallback