### PR TITLE
Bump swift-protobuf minimum version to 1.31.0

### DIFF
--- a/Connect-Swift-Mocks.podspec
+++ b/Connect-Swift-Mocks.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
   spec.watchos.deployment_target = '6.0'
 
   spec.dependency 'Connect-Swift', "#{spec.version.to_s}"
-  spec.dependency 'SwiftProtobuf', '~> 1.30.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.31.0'
 
   spec.source_files = 'Libraries/ConnectMocks/**/*.swift'
 

--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '13.0'
   spec.watchos.deployment_target = '6.0'
 
-  spec.dependency 'SwiftProtobuf', '~> 1.30.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.31.0'
 
   spec.source_files = 'Libraries/Connect/**/*.swift'
 

--- a/Examples/ElizaCocoaPodsApp/Podfile.lock
+++ b/Examples/ElizaCocoaPodsApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Connect-Swift (1.2.1):
-    - SwiftProtobuf (~> 1.30.0)
-  - SwiftProtobuf (1.30.0)
+  - Connect-Swift (1.2.2):
+    - SwiftProtobuf (~> 1.31.0)
+  - SwiftProtobuf (1.31.2)
 
 DEPENDENCIES:
   - Connect-Swift (from `../..`)
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Connect-Swift: 8550afdb45aaea9f527d29c74f7224bf78e2bc26
-  SwiftProtobuf: 3697407f0d5b23bedeba9c2eaaf3ec6fdff69349
+  Connect-Swift: fa94a9c441420609d4b9b798bd5380b2f3d1fd15
+  SwiftProtobuf: ce756ec42f1ba5fb688642eb3e0bb28a02dde8e0
 
 PODFILE CHECKSUM: b598f373a6ab5add976b09c2ac79029bf2200d48
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Examples/ElizaSharedSources/GeneratedSources/connectrpc/eliza/v1/eliza.pb.swift
+++ b/Examples/ElizaSharedSources/GeneratedSources/connectrpc/eliza/v1/eliza.pb.swift
@@ -120,9 +120,7 @@ fileprivate let _protobuf_package = "connectrpc.eliza.v1"
 
 extension Connectrpc_Eliza_V1_SayRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SayRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sentence"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -152,9 +150,7 @@ extension Connectrpc_Eliza_V1_SayRequest: SwiftProtobuf.Message, SwiftProtobuf._
 
 extension Connectrpc_Eliza_V1_SayResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SayResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sentence"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -184,9 +180,7 @@ extension Connectrpc_Eliza_V1_SayResponse: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Connectrpc_Eliza_V1_ConverseRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConverseRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sentence"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -216,9 +210,7 @@ extension Connectrpc_Eliza_V1_ConverseRequest: SwiftProtobuf.Message, SwiftProto
 
 extension Connectrpc_Eliza_V1_ConverseResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConverseResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sentence"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -248,9 +240,7 @@ extension Connectrpc_Eliza_V1_ConverseResponse: SwiftProtobuf.Message, SwiftProt
 
 extension Connectrpc_Eliza_V1_IntroduceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IntroduceRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -280,9 +270,7 @@ extension Connectrpc_Eliza_V1_IntroduceRequest: SwiftProtobuf.Message, SwiftProt
 
 extension Connectrpc_Eliza_V1_IntroduceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IntroduceResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "sentence"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
-        "version" : "1.30.0"
+        "revision" : "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
+        "version" : "1.37.0"
       }
     },
     {

--- a/Examples/buf.gen.yaml
+++ b/Examples/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.30.0
+  - plugin: buf.build/apple/swift:v1.31.0
     opt: Visibility=Internal
     out: ./ElizaSharedSources/GeneratedSources
   - name: connect-swift

--- a/Libraries/Connect/Internal/GeneratedSources/proto/grpc/status/v1/status.pb.swift
+++ b/Libraries/Connect/Internal/GeneratedSources/proto/grpc/status/v1/status.pb.swift
@@ -62,11 +62,7 @@ fileprivate let _protobuf_package = "grpc.status.v1"
 
 extension Grpc_Status_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Status"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "code"),
-    2: .same(proto: "message"),
-    3: .same(proto: "details"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}details\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Libraries/Connect/buf.gen.yaml
+++ b/Libraries/Connect/buf.gen.yaml
@@ -1,5 +1,5 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.30.0
+  - plugin: buf.build/apple/swift:v1.31.0
     opt: Visibility=Internal
     out: ./Internal/GeneratedSources

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
-        "version" : "1.30.0"
+        "revision" : "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
+        "version" : "1.37.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
-            from: "1.30.0"
+            from: "1.31.0"
         ),
     ],
     targets: [

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
@@ -538,28 +538,7 @@ fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientCompatRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "test_name"),
-    2: .standard(proto: "http_version"),
-    3: .same(proto: "protocol"),
-    4: .same(proto: "codec"),
-    5: .same(proto: "compression"),
-    6: .same(proto: "host"),
-    7: .same(proto: "port"),
-    8: .standard(proto: "server_tls_cert"),
-    9: .standard(proto: "client_tls_creds"),
-    10: .standard(proto: "message_receive_limit"),
-    11: .same(proto: "service"),
-    12: .same(proto: "method"),
-    13: .standard(proto: "stream_type"),
-    14: .standard(proto: "use_get_http_method"),
-    15: .standard(proto: "request_headers"),
-    16: .standard(proto: "request_messages"),
-    17: .standard(proto: "timeout_ms"),
-    18: .standard(proto: "request_delay_ms"),
-    19: .same(proto: "cancel"),
-    20: .standard(proto: "raw_request"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}test_name\0\u{3}http_version\0\u{1}protocol\0\u{1}codec\0\u{1}compression\0\u{1}host\0\u{1}port\0\u{3}server_tls_cert\0\u{3}client_tls_creds\0\u{3}message_receive_limit\0\u{1}service\0\u{1}method\0\u{3}stream_type\0\u{3}use_get_http_method\0\u{3}request_headers\0\u{3}request_messages\0\u{3}timeout_ms\0\u{3}request_delay_ms\0\u{1}cancel\0\u{3}raw_request\0")
 
   fileprivate class _StorageClass {
     var _testName: String = String()
@@ -762,11 +741,7 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, 
 
 extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ClientCompatRequest.protoMessageName + ".Cancel"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "before_close_send"),
-    2: .standard(proto: "after_close_send_ms"),
-    3: .standard(proto: "after_num_responses"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}before_close_send\0\u{3}after_close_send_ms\0\u{3}after_num_responses\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -840,11 +815,7 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Me
 
 extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientCompatResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "test_name"),
-    2: .same(proto: "response"),
-    3: .same(proto: "error"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}test_name\0\u{1}response\0\u{1}error\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -916,15 +887,7 @@ extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message,
 
 extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientResponseResult"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_headers"),
-    2: .same(proto: "payloads"),
-    3: .same(proto: "error"),
-    4: .standard(proto: "response_trailers"),
-    5: .standard(proto: "num_unsent_requests"),
-    6: .standard(proto: "http_status_code"),
-    7: .same(proto: "feedback"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{1}payloads\0\u{1}error\0\u{3}response_trailers\0\u{3}num_unsent_requests\0\u{3}http_status_code\0\u{1}feedback\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -988,9 +951,7 @@ extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message,
 
 extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientErrorResult"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "message"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}message\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1020,12 +981,7 @@ extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, Sw
 
 extension Connectrpc_Conformance_V1_WireDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WireDetails"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "actual_status_code"),
-    2: .standard(proto: "connect_error_raw"),
-    3: .standard(proto: "actual_http_trailers"),
-    4: .standard(proto: "actual_grpcweb_trailers"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}actual_status_code\0\u{3}connect_error_raw\0\u{3}actual_http_trailers\0\u{3}actual_grpcweb_trailers\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
@@ -595,7 +595,7 @@ struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
 /// TLSCreds represents credentials for TLS. It includes both a
 /// certificate and corresponding private key. Both are encoded
 /// in PEM format.
-struct Connectrpc_Conformance_V1_TLSCreds: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_TLSCreds: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -614,84 +614,32 @@ struct Connectrpc_Conformance_V1_TLSCreds: @unchecked Sendable {
 fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "HTTP_VERSION_UNSPECIFIED"),
-    1: .same(proto: "HTTP_VERSION_1"),
-    2: .same(proto: "HTTP_VERSION_2"),
-    3: .same(proto: "HTTP_VERSION_3"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0HTTP_VERSION_UNSPECIFIED\0\u{1}HTTP_VERSION_1\0\u{1}HTTP_VERSION_2\0\u{1}HTTP_VERSION_3\0")
 }
 
 extension Connectrpc_Conformance_V1_Protocol: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "PROTOCOL_UNSPECIFIED"),
-    1: .same(proto: "PROTOCOL_CONNECT"),
-    2: .same(proto: "PROTOCOL_GRPC"),
-    3: .same(proto: "PROTOCOL_GRPC_WEB"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PROTOCOL_UNSPECIFIED\0\u{1}PROTOCOL_CONNECT\0\u{1}PROTOCOL_GRPC\0\u{1}PROTOCOL_GRPC_WEB\0")
 }
 
 extension Connectrpc_Conformance_V1_Codec: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "CODEC_UNSPECIFIED"),
-    1: .same(proto: "CODEC_PROTO"),
-    2: .same(proto: "CODEC_JSON"),
-    3: .same(proto: "CODEC_TEXT"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CODEC_UNSPECIFIED\0\u{1}CODEC_PROTO\0\u{1}CODEC_JSON\0\u{1}CODEC_TEXT\0")
 }
 
 extension Connectrpc_Conformance_V1_Compression: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "COMPRESSION_UNSPECIFIED"),
-    1: .same(proto: "COMPRESSION_IDENTITY"),
-    2: .same(proto: "COMPRESSION_GZIP"),
-    3: .same(proto: "COMPRESSION_BR"),
-    4: .same(proto: "COMPRESSION_ZSTD"),
-    5: .same(proto: "COMPRESSION_DEFLATE"),
-    6: .same(proto: "COMPRESSION_SNAPPY"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0COMPRESSION_UNSPECIFIED\0\u{1}COMPRESSION_IDENTITY\0\u{1}COMPRESSION_GZIP\0\u{1}COMPRESSION_BR\0\u{1}COMPRESSION_ZSTD\0\u{1}COMPRESSION_DEFLATE\0\u{1}COMPRESSION_SNAPPY\0")
 }
 
 extension Connectrpc_Conformance_V1_StreamType: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "STREAM_TYPE_UNSPECIFIED"),
-    1: .same(proto: "STREAM_TYPE_UNARY"),
-    2: .same(proto: "STREAM_TYPE_CLIENT_STREAM"),
-    3: .same(proto: "STREAM_TYPE_SERVER_STREAM"),
-    4: .same(proto: "STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM"),
-    5: .same(proto: "STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STREAM_TYPE_UNSPECIFIED\0\u{1}STREAM_TYPE_UNARY\0\u{1}STREAM_TYPE_CLIENT_STREAM\0\u{1}STREAM_TYPE_SERVER_STREAM\0\u{1}STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM\0\u{1}STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM\0")
 }
 
 extension Connectrpc_Conformance_V1_Code: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "CODE_UNSPECIFIED"),
-    1: .same(proto: "CODE_CANCELED"),
-    2: .same(proto: "CODE_UNKNOWN"),
-    3: .same(proto: "CODE_INVALID_ARGUMENT"),
-    4: .same(proto: "CODE_DEADLINE_EXCEEDED"),
-    5: .same(proto: "CODE_NOT_FOUND"),
-    6: .same(proto: "CODE_ALREADY_EXISTS"),
-    7: .same(proto: "CODE_PERMISSION_DENIED"),
-    8: .same(proto: "CODE_RESOURCE_EXHAUSTED"),
-    9: .same(proto: "CODE_FAILED_PRECONDITION"),
-    10: .same(proto: "CODE_ABORTED"),
-    11: .same(proto: "CODE_OUT_OF_RANGE"),
-    12: .same(proto: "CODE_UNIMPLEMENTED"),
-    13: .same(proto: "CODE_INTERNAL"),
-    14: .same(proto: "CODE_UNAVAILABLE"),
-    15: .same(proto: "CODE_DATA_LOSS"),
-    16: .same(proto: "CODE_UNAUTHENTICATED"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CODE_UNSPECIFIED\0\u{1}CODE_CANCELED\0\u{1}CODE_UNKNOWN\0\u{1}CODE_INVALID_ARGUMENT\0\u{1}CODE_DEADLINE_EXCEEDED\0\u{1}CODE_NOT_FOUND\0\u{1}CODE_ALREADY_EXISTS\0\u{1}CODE_PERMISSION_DENIED\0\u{1}CODE_RESOURCE_EXHAUSTED\0\u{1}CODE_FAILED_PRECONDITION\0\u{1}CODE_ABORTED\0\u{1}CODE_OUT_OF_RANGE\0\u{1}CODE_UNIMPLEMENTED\0\u{1}CODE_INTERNAL\0\u{1}CODE_UNAVAILABLE\0\u{1}CODE_DATA_LOSS\0\u{1}CODE_UNAUTHENTICATED\0")
 }
 
 extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Config"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "features"),
-    2: .standard(proto: "include_cases"),
-    3: .standard(proto: "exclude_cases"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}features\0\u{3}include_cases\0\u{3}exclude_cases\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -735,20 +683,7 @@ extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf
 
 extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Features"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "versions"),
-    2: .same(proto: "protocols"),
-    3: .same(proto: "codecs"),
-    4: .same(proto: "compressions"),
-    5: .standard(proto: "stream_types"),
-    6: .standard(proto: "supports_h2c"),
-    7: .standard(proto: "supports_tls"),
-    8: .standard(proto: "supports_tls_client_certs"),
-    9: .standard(proto: "supports_trailers"),
-    10: .standard(proto: "supports_half_duplex_bidi_over_http1"),
-    11: .standard(proto: "supports_connect_get"),
-    12: .standard(proto: "supports_message_receive_limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}versions\0\u{1}protocols\0\u{1}codecs\0\u{1}compressions\0\u{3}stream_types\0\u{3}supports_h2c\0\u{3}supports_tls\0\u{3}supports_tls_client_certs\0\u{3}supports_trailers\0\u{3}supports_half_duplex_bidi_over_http1\0\u{3}supports_connect_get\0\u{3}supports_message_receive_limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -837,16 +772,7 @@ extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtob
 
 extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConfigCase"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "version"),
-    2: .same(proto: "protocol"),
-    3: .same(proto: "codec"),
-    4: .same(proto: "compression"),
-    5: .standard(proto: "stream_type"),
-    6: .standard(proto: "use_tls"),
-    7: .standard(proto: "use_tls_client_certs"),
-    8: .standard(proto: "use_message_receive_limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{1}protocol\0\u{1}codec\0\u{1}compression\0\u{3}stream_type\0\u{3}use_tls\0\u{3}use_tls_client_certs\0\u{3}use_message_receive_limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -915,10 +841,7 @@ extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProt
 
 extension Connectrpc_Conformance_V1_TLSCreds: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TLSCreds"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "cert"),
-    2: .same(proto: "key"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cert\0\u{1}key\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
@@ -49,7 +49,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// Each test process is expected to start only one RPC server.
 /// When testing multiple configurations, multiple test processes
 /// will be started, each with different properties.
-struct Connectrpc_Conformance_V1_ServerCompatRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -121,7 +121,7 @@ struct Connectrpc_Conformance_V1_ServerCompatRequest: @unchecked Sendable {
 }
 
 /// The outcome of one ServerCompatRequest.
-struct Connectrpc_Conformance_V1_ServerCompatResponse: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ServerCompatResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -150,14 +150,7 @@ fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerCompatRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "protocol"),
-    2: .standard(proto: "http_version"),
-    4: .standard(proto: "use_tls"),
-    5: .standard(proto: "client_tls_cert"),
-    6: .standard(proto: "message_receive_limit"),
-    7: .standard(proto: "server_creds"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}protocol\0\u{3}http_version\0\u{4}\u{2}use_tls\0\u{3}client_tls_cert\0\u{3}message_receive_limit\0\u{3}server_creds\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -216,11 +209,7 @@ extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, 
 
 extension Connectrpc_Conformance_V1_ServerCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerCompatResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "host"),
-    2: .same(proto: "port"),
-    3: .standard(proto: "pem_cert"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}host\0\u{1}port\0\u{3}pem_cert\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
@@ -37,7 +37,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 /// A definition of a response to be sent from a single-response endpoint.
 /// Can be used to define a response for unary or client-streaming calls.
-struct Connectrpc_Conformance_V1_UnaryResponseDefinition: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -89,7 +89,7 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Response: Equatable, @unchecked Sendable {
+  enum OneOf_Response: Equatable, Sendable {
     /// Response data to send
     case responseData(Data)
     /// Error to raise instead of response message
@@ -106,7 +106,7 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition: @unchecked Sendable {
 
 /// A definition of responses to be sent from a streaming endpoint.
 /// Can be used to define responses for server-streaming or bidi-streaming calls.
-struct Connectrpc_Conformance_V1_StreamResponseDefinition: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -159,7 +159,7 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition: @unchecked Sendable {
   fileprivate var _rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnaryRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_UnaryRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -206,7 +206,7 @@ struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -253,7 +253,7 @@ struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ServerStreamRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ServerStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -300,7 +300,7 @@ struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ClientStreamRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -350,7 +350,7 @@ struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_BidiStreamRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -434,7 +434,7 @@ struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_ConformancePayload: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -667,7 +667,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 }
 
 /// MessageContents represents a message in a request body.
-struct Connectrpc_Conformance_V1_MessageContents: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_MessageContents: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -711,7 +711,7 @@ struct Connectrpc_Conformance_V1_MessageContents: @unchecked Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The message data can be defined in one of three ways.
-  enum OneOf_Data: Equatable, @unchecked Sendable {
+  enum OneOf_Data: Equatable, Sendable {
     /// Arbitrary bytes.
     case binary(Data)
     /// Arbitrary text.
@@ -833,14 +833,7 @@ fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryResponseDefinition"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_headers"),
-    2: .standard(proto: "response_data"),
-    3: .same(proto: "error"),
-    4: .standard(proto: "response_trailers"),
-    6: .standard(proto: "response_delay_ms"),
-    5: .standard(proto: "raw_response"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{3}response_data\0\u{1}error\0\u{3}response_trailers\0\u{3}raw_response\0\u{3}response_delay_ms\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -922,14 +915,7 @@ extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Messa
 
 extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamResponseDefinition"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_headers"),
-    2: .standard(proto: "response_data"),
-    3: .standard(proto: "response_delay_ms"),
-    4: .same(proto: "error"),
-    5: .standard(proto: "response_trailers"),
-    6: .standard(proto: "raw_response"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{3}response_data\0\u{3}response_delay_ms\0\u{1}error\0\u{3}response_trailers\0\u{3}raw_response\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -988,10 +974,7 @@ extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Mess
 
 extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1030,9 +1013,7 @@ extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftPr
 
 extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1066,10 +1047,7 @@ extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftP
 
 extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IdempotentUnaryRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1108,9 +1086,7 @@ extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Messag
 
 extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IdempotentUnaryResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1144,10 +1120,7 @@ extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Messa
 
 extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerStreamRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1186,9 +1159,7 @@ extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, 
 
 extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerStreamResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1222,10 +1193,7 @@ extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message,
 
 extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientStreamRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1264,9 +1232,7 @@ extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, 
 
 extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientStreamResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1300,11 +1266,7 @@ extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message,
 
 extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BidiStreamRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "full_duplex"),
-    3: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}full_duplex\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1348,9 +1310,7 @@ extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, Sw
 
 extension Connectrpc_Conformance_V1_BidiStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BidiStreamResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1422,10 +1382,7 @@ extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message
 
 extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConformancePayload"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "data"),
-    2: .standard(proto: "request_info"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0\u{3}request_info\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1464,12 +1421,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, S
 
 extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ConformancePayload.protoMessageName + ".RequestInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "request_headers"),
-    2: .standard(proto: "timeout_ms"),
-    3: .same(proto: "requests"),
-    4: .standard(proto: "connect_get_info"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_headers\0\u{3}timeout_ms\0\u{1}requests\0\u{3}connect_get_info\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1518,9 +1470,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobu
 
 extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ConformancePayload.protoMessageName + ".ConnectGetInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "query_params"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_params\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1550,11 +1500,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProt
 
 extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Error"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "code"),
-    2: .same(proto: "message"),
-    3: .same(proto: "details"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}details\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1598,10 +1544,7 @@ extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Header"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-    2: .same(proto: "value"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1636,15 +1579,7 @@ extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf
 
 extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawHTTPRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "verb"),
-    2: .same(proto: "uri"),
-    3: .same(proto: "headers"),
-    4: .standard(proto: "raw_query_params"),
-    5: .standard(proto: "encoded_query_params"),
-    6: .same(proto: "unary"),
-    7: .same(proto: "stream"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}verb\0\u{1}uri\0\u{1}headers\0\u{3}raw_query_params\0\u{3}encoded_query_params\0\u{1}unary\0\u{1}stream\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1736,11 +1671,7 @@ extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, Swift
 
 extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_RawHTTPRequest.protoMessageName + ".EncodedQueryParam"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-    2: .same(proto: "value"),
-    3: .standard(proto: "base64_encode"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0\u{3}base64_encode\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1784,12 +1715,7 @@ extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProto
 
 extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MessageContents"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "binary"),
-    2: .same(proto: "text"),
-    3: .standard(proto: "binary_message"),
-    4: .same(proto: "compression"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}binary\0\u{1}text\0\u{3}binary_message\0\u{1}compression\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1868,9 +1794,7 @@ extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, Swif
 
 extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamContents"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "items"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}items\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1900,11 +1824,7 @@ extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, Swift
 
 extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_StreamContents.protoMessageName + ".StreamItem"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "flags"),
-    2: .same(proto: "length"),
-    3: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}flags\0\u{1}length\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1948,13 +1868,7 @@ extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Mes
 
 extension Connectrpc_Conformance_V1_RawHTTPResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawHTTPResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "status_code"),
-    2: .same(proto: "headers"),
-    3: .same(proto: "unary"),
-    4: .same(proto: "stream"),
-    5: .same(proto: "trailers"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}status_code\0\u{1}headers\0\u{1}unary\0\u{1}stream\0\u{1}trailers\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
@@ -305,20 +305,7 @@ fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestSuite"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-    2: .same(proto: "mode"),
-    3: .standard(proto: "test_cases"),
-    4: .standard(proto: "relevant_protocols"),
-    5: .standard(proto: "relevant_http_versions"),
-    6: .standard(proto: "relevant_codecs"),
-    7: .standard(proto: "relevant_compressions"),
-    8: .standard(proto: "connect_version_mode"),
-    9: .standard(proto: "relies_on_tls"),
-    10: .standard(proto: "relies_on_tls_client_certs"),
-    11: .standard(proto: "relies_on_connect_get"),
-    12: .standard(proto: "relies_on_message_receive_limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}mode\0\u{3}test_cases\0\u{3}relevant_protocols\0\u{3}relevant_http_versions\0\u{3}relevant_codecs\0\u{3}relevant_compressions\0\u{3}connect_version_mode\0\u{3}relies_on_tls\0\u{3}relies_on_tls_client_certs\0\u{3}relies_on_connect_get\0\u{3}relies_on_message_receive_limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -402,29 +389,16 @@ extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProto
 }
 
 extension Connectrpc_Conformance_V1_TestSuite.TestMode: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "TEST_MODE_UNSPECIFIED"),
-    1: .same(proto: "TEST_MODE_CLIENT"),
-    2: .same(proto: "TEST_MODE_SERVER"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0TEST_MODE_UNSPECIFIED\0\u{1}TEST_MODE_CLIENT\0\u{1}TEST_MODE_SERVER\0")
 }
 
 extension Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "CONNECT_VERSION_MODE_UNSPECIFIED"),
-    1: .same(proto: "CONNECT_VERSION_MODE_REQUIRE"),
-    2: .same(proto: "CONNECT_VERSION_MODE_IGNORE"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CONNECT_VERSION_MODE_UNSPECIFIED\0\u{1}CONNECT_VERSION_MODE_REQUIRE\0\u{1}CONNECT_VERSION_MODE_IGNORE\0")
 }
 
 extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestCase"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "request"),
-    2: .standard(proto: "expand_requests"),
-    3: .standard(proto: "expected_response"),
-    4: .standard(proto: "other_allowed_error_codes"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}request\0\u{3}expand_requests\0\u{3}expected_response\0\u{3}other_allowed_error_codes\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -473,9 +447,7 @@ extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtob
 
 extension Connectrpc_Conformance_V1_TestCase.ExpandedSize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_TestCase.protoMessageName + ".ExpandedSize"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "size_relative_to_limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}size_relative_to_limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/ConformanceClient/buf.gen.yaml
+++ b/Tests/ConformanceClient/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.30.0
+  - plugin: buf.build/apple/swift:v1.31.0
     opt: Visibility=Internal
     out: ./GeneratedSources
   - name: connect-swift

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
@@ -538,28 +538,7 @@ fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientCompatRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "test_name"),
-    2: .standard(proto: "http_version"),
-    3: .same(proto: "protocol"),
-    4: .same(proto: "codec"),
-    5: .same(proto: "compression"),
-    6: .same(proto: "host"),
-    7: .same(proto: "port"),
-    8: .standard(proto: "server_tls_cert"),
-    9: .standard(proto: "client_tls_creds"),
-    10: .standard(proto: "message_receive_limit"),
-    11: .same(proto: "service"),
-    12: .same(proto: "method"),
-    13: .standard(proto: "stream_type"),
-    14: .standard(proto: "use_get_http_method"),
-    15: .standard(proto: "request_headers"),
-    16: .standard(proto: "request_messages"),
-    17: .standard(proto: "timeout_ms"),
-    18: .standard(proto: "request_delay_ms"),
-    19: .same(proto: "cancel"),
-    20: .standard(proto: "raw_request"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}test_name\0\u{3}http_version\0\u{1}protocol\0\u{1}codec\0\u{1}compression\0\u{1}host\0\u{1}port\0\u{3}server_tls_cert\0\u{3}client_tls_creds\0\u{3}message_receive_limit\0\u{1}service\0\u{1}method\0\u{3}stream_type\0\u{3}use_get_http_method\0\u{3}request_headers\0\u{3}request_messages\0\u{3}timeout_ms\0\u{3}request_delay_ms\0\u{1}cancel\0\u{3}raw_request\0")
 
   fileprivate class _StorageClass {
     var _testName: String = String()
@@ -762,11 +741,7 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, 
 
 extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ClientCompatRequest.protoMessageName + ".Cancel"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "before_close_send"),
-    2: .standard(proto: "after_close_send_ms"),
-    3: .standard(proto: "after_num_responses"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}before_close_send\0\u{3}after_close_send_ms\0\u{3}after_num_responses\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -840,11 +815,7 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Me
 
 extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientCompatResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "test_name"),
-    2: .same(proto: "response"),
-    3: .same(proto: "error"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}test_name\0\u{1}response\0\u{1}error\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -916,15 +887,7 @@ extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message,
 
 extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientResponseResult"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_headers"),
-    2: .same(proto: "payloads"),
-    3: .same(proto: "error"),
-    4: .standard(proto: "response_trailers"),
-    5: .standard(proto: "num_unsent_requests"),
-    6: .standard(proto: "http_status_code"),
-    7: .same(proto: "feedback"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{1}payloads\0\u{1}error\0\u{3}response_trailers\0\u{3}num_unsent_requests\0\u{3}http_status_code\0\u{1}feedback\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -988,9 +951,7 @@ extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message,
 
 extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientErrorResult"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "message"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}message\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1020,12 +981,7 @@ extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, Sw
 
 extension Connectrpc_Conformance_V1_WireDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WireDetails"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "actual_status_code"),
-    2: .standard(proto: "connect_error_raw"),
-    3: .standard(proto: "actual_http_trailers"),
-    4: .standard(proto: "actual_grpcweb_trailers"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}actual_status_code\0\u{3}connect_error_raw\0\u{3}actual_http_trailers\0\u{3}actual_grpcweb_trailers\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
@@ -595,7 +595,7 @@ struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
 /// TLSCreds represents credentials for TLS. It includes both a
 /// certificate and corresponding private key. Both are encoded
 /// in PEM format.
-struct Connectrpc_Conformance_V1_TLSCreds: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_TLSCreds: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -614,84 +614,32 @@ struct Connectrpc_Conformance_V1_TLSCreds: @unchecked Sendable {
 fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "HTTP_VERSION_UNSPECIFIED"),
-    1: .same(proto: "HTTP_VERSION_1"),
-    2: .same(proto: "HTTP_VERSION_2"),
-    3: .same(proto: "HTTP_VERSION_3"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0HTTP_VERSION_UNSPECIFIED\0\u{1}HTTP_VERSION_1\0\u{1}HTTP_VERSION_2\0\u{1}HTTP_VERSION_3\0")
 }
 
 extension Connectrpc_Conformance_V1_Protocol: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "PROTOCOL_UNSPECIFIED"),
-    1: .same(proto: "PROTOCOL_CONNECT"),
-    2: .same(proto: "PROTOCOL_GRPC"),
-    3: .same(proto: "PROTOCOL_GRPC_WEB"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PROTOCOL_UNSPECIFIED\0\u{1}PROTOCOL_CONNECT\0\u{1}PROTOCOL_GRPC\0\u{1}PROTOCOL_GRPC_WEB\0")
 }
 
 extension Connectrpc_Conformance_V1_Codec: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "CODEC_UNSPECIFIED"),
-    1: .same(proto: "CODEC_PROTO"),
-    2: .same(proto: "CODEC_JSON"),
-    3: .same(proto: "CODEC_TEXT"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CODEC_UNSPECIFIED\0\u{1}CODEC_PROTO\0\u{1}CODEC_JSON\0\u{1}CODEC_TEXT\0")
 }
 
 extension Connectrpc_Conformance_V1_Compression: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "COMPRESSION_UNSPECIFIED"),
-    1: .same(proto: "COMPRESSION_IDENTITY"),
-    2: .same(proto: "COMPRESSION_GZIP"),
-    3: .same(proto: "COMPRESSION_BR"),
-    4: .same(proto: "COMPRESSION_ZSTD"),
-    5: .same(proto: "COMPRESSION_DEFLATE"),
-    6: .same(proto: "COMPRESSION_SNAPPY"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0COMPRESSION_UNSPECIFIED\0\u{1}COMPRESSION_IDENTITY\0\u{1}COMPRESSION_GZIP\0\u{1}COMPRESSION_BR\0\u{1}COMPRESSION_ZSTD\0\u{1}COMPRESSION_DEFLATE\0\u{1}COMPRESSION_SNAPPY\0")
 }
 
 extension Connectrpc_Conformance_V1_StreamType: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "STREAM_TYPE_UNSPECIFIED"),
-    1: .same(proto: "STREAM_TYPE_UNARY"),
-    2: .same(proto: "STREAM_TYPE_CLIENT_STREAM"),
-    3: .same(proto: "STREAM_TYPE_SERVER_STREAM"),
-    4: .same(proto: "STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM"),
-    5: .same(proto: "STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STREAM_TYPE_UNSPECIFIED\0\u{1}STREAM_TYPE_UNARY\0\u{1}STREAM_TYPE_CLIENT_STREAM\0\u{1}STREAM_TYPE_SERVER_STREAM\0\u{1}STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM\0\u{1}STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM\0")
 }
 
 extension Connectrpc_Conformance_V1_Code: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "CODE_UNSPECIFIED"),
-    1: .same(proto: "CODE_CANCELED"),
-    2: .same(proto: "CODE_UNKNOWN"),
-    3: .same(proto: "CODE_INVALID_ARGUMENT"),
-    4: .same(proto: "CODE_DEADLINE_EXCEEDED"),
-    5: .same(proto: "CODE_NOT_FOUND"),
-    6: .same(proto: "CODE_ALREADY_EXISTS"),
-    7: .same(proto: "CODE_PERMISSION_DENIED"),
-    8: .same(proto: "CODE_RESOURCE_EXHAUSTED"),
-    9: .same(proto: "CODE_FAILED_PRECONDITION"),
-    10: .same(proto: "CODE_ABORTED"),
-    11: .same(proto: "CODE_OUT_OF_RANGE"),
-    12: .same(proto: "CODE_UNIMPLEMENTED"),
-    13: .same(proto: "CODE_INTERNAL"),
-    14: .same(proto: "CODE_UNAVAILABLE"),
-    15: .same(proto: "CODE_DATA_LOSS"),
-    16: .same(proto: "CODE_UNAUTHENTICATED"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CODE_UNSPECIFIED\0\u{1}CODE_CANCELED\0\u{1}CODE_UNKNOWN\0\u{1}CODE_INVALID_ARGUMENT\0\u{1}CODE_DEADLINE_EXCEEDED\0\u{1}CODE_NOT_FOUND\0\u{1}CODE_ALREADY_EXISTS\0\u{1}CODE_PERMISSION_DENIED\0\u{1}CODE_RESOURCE_EXHAUSTED\0\u{1}CODE_FAILED_PRECONDITION\0\u{1}CODE_ABORTED\0\u{1}CODE_OUT_OF_RANGE\0\u{1}CODE_UNIMPLEMENTED\0\u{1}CODE_INTERNAL\0\u{1}CODE_UNAVAILABLE\0\u{1}CODE_DATA_LOSS\0\u{1}CODE_UNAUTHENTICATED\0")
 }
 
 extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Config"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "features"),
-    2: .standard(proto: "include_cases"),
-    3: .standard(proto: "exclude_cases"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}features\0\u{3}include_cases\0\u{3}exclude_cases\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -735,20 +683,7 @@ extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf
 
 extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Features"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "versions"),
-    2: .same(proto: "protocols"),
-    3: .same(proto: "codecs"),
-    4: .same(proto: "compressions"),
-    5: .standard(proto: "stream_types"),
-    6: .standard(proto: "supports_h2c"),
-    7: .standard(proto: "supports_tls"),
-    8: .standard(proto: "supports_tls_client_certs"),
-    9: .standard(proto: "supports_trailers"),
-    10: .standard(proto: "supports_half_duplex_bidi_over_http1"),
-    11: .standard(proto: "supports_connect_get"),
-    12: .standard(proto: "supports_message_receive_limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}versions\0\u{1}protocols\0\u{1}codecs\0\u{1}compressions\0\u{3}stream_types\0\u{3}supports_h2c\0\u{3}supports_tls\0\u{3}supports_tls_client_certs\0\u{3}supports_trailers\0\u{3}supports_half_duplex_bidi_over_http1\0\u{3}supports_connect_get\0\u{3}supports_message_receive_limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -837,16 +772,7 @@ extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtob
 
 extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConfigCase"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "version"),
-    2: .same(proto: "protocol"),
-    3: .same(proto: "codec"),
-    4: .same(proto: "compression"),
-    5: .standard(proto: "stream_type"),
-    6: .standard(proto: "use_tls"),
-    7: .standard(proto: "use_tls_client_certs"),
-    8: .standard(proto: "use_message_receive_limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{1}protocol\0\u{1}codec\0\u{1}compression\0\u{3}stream_type\0\u{3}use_tls\0\u{3}use_tls_client_certs\0\u{3}use_message_receive_limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -915,10 +841,7 @@ extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProt
 
 extension Connectrpc_Conformance_V1_TLSCreds: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TLSCreds"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "cert"),
-    2: .same(proto: "key"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cert\0\u{1}key\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
@@ -49,7 +49,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// Each test process is expected to start only one RPC server.
 /// When testing multiple configurations, multiple test processes
 /// will be started, each with different properties.
-struct Connectrpc_Conformance_V1_ServerCompatRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -121,7 +121,7 @@ struct Connectrpc_Conformance_V1_ServerCompatRequest: @unchecked Sendable {
 }
 
 /// The outcome of one ServerCompatRequest.
-struct Connectrpc_Conformance_V1_ServerCompatResponse: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ServerCompatResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -150,14 +150,7 @@ fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerCompatRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "protocol"),
-    2: .standard(proto: "http_version"),
-    4: .standard(proto: "use_tls"),
-    5: .standard(proto: "client_tls_cert"),
-    6: .standard(proto: "message_receive_limit"),
-    7: .standard(proto: "server_creds"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}protocol\0\u{3}http_version\0\u{4}\u{2}use_tls\0\u{3}client_tls_cert\0\u{3}message_receive_limit\0\u{3}server_creds\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -216,11 +209,7 @@ extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, 
 
 extension Connectrpc_Conformance_V1_ServerCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerCompatResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "host"),
-    2: .same(proto: "port"),
-    3: .standard(proto: "pem_cert"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}host\0\u{1}port\0\u{3}pem_cert\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
@@ -37,7 +37,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 /// A definition of a response to be sent from a single-response endpoint.
 /// Can be used to define a response for unary or client-streaming calls.
-struct Connectrpc_Conformance_V1_UnaryResponseDefinition: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -89,7 +89,7 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Response: Equatable, @unchecked Sendable {
+  enum OneOf_Response: Equatable, Sendable {
     /// Response data to send
     case responseData(Data)
     /// Error to raise instead of response message
@@ -106,7 +106,7 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition: @unchecked Sendable {
 
 /// A definition of responses to be sent from a streaming endpoint.
 /// Can be used to define responses for server-streaming or bidi-streaming calls.
-struct Connectrpc_Conformance_V1_StreamResponseDefinition: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -159,7 +159,7 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition: @unchecked Sendable {
   fileprivate var _rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnaryRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_UnaryRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -206,7 +206,7 @@ struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -253,7 +253,7 @@ struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ServerStreamRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ServerStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -300,7 +300,7 @@ struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ClientStreamRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -350,7 +350,7 @@ struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_BidiStreamRequest: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -434,7 +434,7 @@ struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_ConformancePayload: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -667,7 +667,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 }
 
 /// MessageContents represents a message in a request body.
-struct Connectrpc_Conformance_V1_MessageContents: @unchecked Sendable {
+struct Connectrpc_Conformance_V1_MessageContents: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -711,7 +711,7 @@ struct Connectrpc_Conformance_V1_MessageContents: @unchecked Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The message data can be defined in one of three ways.
-  enum OneOf_Data: Equatable, @unchecked Sendable {
+  enum OneOf_Data: Equatable, Sendable {
     /// Arbitrary bytes.
     case binary(Data)
     /// Arbitrary text.
@@ -833,14 +833,7 @@ fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryResponseDefinition"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_headers"),
-    2: .standard(proto: "response_data"),
-    3: .same(proto: "error"),
-    4: .standard(proto: "response_trailers"),
-    6: .standard(proto: "response_delay_ms"),
-    5: .standard(proto: "raw_response"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{3}response_data\0\u{1}error\0\u{3}response_trailers\0\u{3}raw_response\0\u{3}response_delay_ms\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -922,14 +915,7 @@ extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Messa
 
 extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamResponseDefinition"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_headers"),
-    2: .standard(proto: "response_data"),
-    3: .standard(proto: "response_delay_ms"),
-    4: .same(proto: "error"),
-    5: .standard(proto: "response_trailers"),
-    6: .standard(proto: "raw_response"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{3}response_data\0\u{3}response_delay_ms\0\u{1}error\0\u{3}response_trailers\0\u{3}raw_response\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -988,10 +974,7 @@ extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Mess
 
 extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1030,9 +1013,7 @@ extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftPr
 
 extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1066,10 +1047,7 @@ extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftP
 
 extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IdempotentUnaryRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1108,9 +1086,7 @@ extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Messag
 
 extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IdempotentUnaryResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1144,10 +1120,7 @@ extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Messa
 
 extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerStreamRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1186,9 +1159,7 @@ extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, 
 
 extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerStreamResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1222,10 +1193,7 @@ extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message,
 
 extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientStreamRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1264,9 +1232,7 @@ extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, 
 
 extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientStreamResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1300,11 +1266,7 @@ extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message,
 
 extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BidiStreamRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "response_definition"),
-    2: .standard(proto: "full_duplex"),
-    3: .standard(proto: "request_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}full_duplex\0\u{3}request_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1348,9 +1310,7 @@ extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, Sw
 
 extension Connectrpc_Conformance_V1_BidiStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BidiStreamResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1422,10 +1382,7 @@ extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message
 
 extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConformancePayload"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "data"),
-    2: .standard(proto: "request_info"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0\u{3}request_info\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1464,12 +1421,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, S
 
 extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ConformancePayload.protoMessageName + ".RequestInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "request_headers"),
-    2: .standard(proto: "timeout_ms"),
-    3: .same(proto: "requests"),
-    4: .standard(proto: "connect_get_info"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_headers\0\u{3}timeout_ms\0\u{1}requests\0\u{3}connect_get_info\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1518,9 +1470,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobu
 
 extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ConformancePayload.protoMessageName + ".ConnectGetInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "query_params"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_params\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1550,11 +1500,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProt
 
 extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Error"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "code"),
-    2: .same(proto: "message"),
-    3: .same(proto: "details"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}details\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1598,10 +1544,7 @@ extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Header"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-    2: .same(proto: "value"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1636,15 +1579,7 @@ extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf
 
 extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawHTTPRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "verb"),
-    2: .same(proto: "uri"),
-    3: .same(proto: "headers"),
-    4: .standard(proto: "raw_query_params"),
-    5: .standard(proto: "encoded_query_params"),
-    6: .same(proto: "unary"),
-    7: .same(proto: "stream"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}verb\0\u{1}uri\0\u{1}headers\0\u{3}raw_query_params\0\u{3}encoded_query_params\0\u{1}unary\0\u{1}stream\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1736,11 +1671,7 @@ extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, Swift
 
 extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_RawHTTPRequest.protoMessageName + ".EncodedQueryParam"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-    2: .same(proto: "value"),
-    3: .standard(proto: "base64_encode"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0\u{3}base64_encode\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1784,12 +1715,7 @@ extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProto
 
 extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MessageContents"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "binary"),
-    2: .same(proto: "text"),
-    3: .standard(proto: "binary_message"),
-    4: .same(proto: "compression"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}binary\0\u{1}text\0\u{3}binary_message\0\u{1}compression\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1868,9 +1794,7 @@ extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, Swif
 
 extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamContents"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "items"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}items\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1900,11 +1824,7 @@ extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, Swift
 
 extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_StreamContents.protoMessageName + ".StreamItem"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "flags"),
-    2: .same(proto: "length"),
-    3: .same(proto: "payload"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}flags\0\u{1}length\0\u{1}payload\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1948,13 +1868,7 @@ extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Mes
 
 extension Connectrpc_Conformance_V1_RawHTTPResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawHTTPResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "status_code"),
-    2: .same(proto: "headers"),
-    3: .same(proto: "unary"),
-    4: .same(proto: "stream"),
-    5: .same(proto: "trailers"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}status_code\0\u{1}headers\0\u{1}unary\0\u{1}stream\0\u{1}trailers\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
@@ -305,20 +305,7 @@ fileprivate let _protobuf_package = "connectrpc.conformance.v1"
 
 extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestSuite"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-    2: .same(proto: "mode"),
-    3: .standard(proto: "test_cases"),
-    4: .standard(proto: "relevant_protocols"),
-    5: .standard(proto: "relevant_http_versions"),
-    6: .standard(proto: "relevant_codecs"),
-    7: .standard(proto: "relevant_compressions"),
-    8: .standard(proto: "connect_version_mode"),
-    9: .standard(proto: "relies_on_tls"),
-    10: .standard(proto: "relies_on_tls_client_certs"),
-    11: .standard(proto: "relies_on_connect_get"),
-    12: .standard(proto: "relies_on_message_receive_limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}mode\0\u{3}test_cases\0\u{3}relevant_protocols\0\u{3}relevant_http_versions\0\u{3}relevant_codecs\0\u{3}relevant_compressions\0\u{3}connect_version_mode\0\u{3}relies_on_tls\0\u{3}relies_on_tls_client_certs\0\u{3}relies_on_connect_get\0\u{3}relies_on_message_receive_limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -402,29 +389,16 @@ extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProto
 }
 
 extension Connectrpc_Conformance_V1_TestSuite.TestMode: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "TEST_MODE_UNSPECIFIED"),
-    1: .same(proto: "TEST_MODE_CLIENT"),
-    2: .same(proto: "TEST_MODE_SERVER"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0TEST_MODE_UNSPECIFIED\0\u{1}TEST_MODE_CLIENT\0\u{1}TEST_MODE_SERVER\0")
 }
 
 extension Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "CONNECT_VERSION_MODE_UNSPECIFIED"),
-    1: .same(proto: "CONNECT_VERSION_MODE_REQUIRE"),
-    2: .same(proto: "CONNECT_VERSION_MODE_IGNORE"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CONNECT_VERSION_MODE_UNSPECIFIED\0\u{1}CONNECT_VERSION_MODE_REQUIRE\0\u{1}CONNECT_VERSION_MODE_IGNORE\0")
 }
 
 extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestCase"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "request"),
-    2: .standard(proto: "expand_requests"),
-    3: .standard(proto: "expected_response"),
-    4: .standard(proto: "other_allowed_error_codes"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}request\0\u{3}expand_requests\0\u{3}expected_response\0\u{3}other_allowed_error_codes\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -473,9 +447,7 @@ extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtob
 
 extension Connectrpc_Conformance_V1_TestCase.ExpandedSize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_TestCase.protoMessageName + ".ExpandedSize"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "size_relative_to_limit"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}size_relative_to_limit\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/UnitTests/ConnectLibraryTests/buf.gen.yaml
+++ b/Tests/UnitTests/ConnectLibraryTests/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.30.0
+  - plugin: buf.build/apple/swift:v1.31.0
     opt: Visibility=Internal
     out: ./GeneratedSources
   - name: connect-swift


### PR DESCRIPTION
## Summary

- Bumps the minimum `swift-protobuf` version from `1.30.0` to `1.31.0` to add support for protobuf `edition = 2024`
- Updates `buf.build/apple/swift` plugin pin to `v1.31.0` in all `buf.gen.yaml` files
- Updates `Package.resolved`, `Podfile.lock`, and regenerates all `.pb.swift` outputs

## Motivation

Fixes #393.

Running `buf generate` against a `.proto` file with `edition = 2024` currently fails with:

```
SwiftProtobufPluginLibrary/Descriptor.swift:333: Fatal error: Failed to make a
FeatureResolver for path/example.proto: Edition edition2024 is not in the
supported range (proto2...edition2023)
```

Support for `edition = 2024` was added in [swift-protobuf v1.31.0](https://github.com/apple/swift-protobuf/releases/tag/1.31.0).

## Test plan

- [x] `make buildplugins && make generate` produces the checked-in diffs
- [x] `make testunit` passes (71 tests)
- [x] `make testconformance` passes (966 URLSession + 1681 NIO)

---

I made this with the help of Claude but manually verified `make buildplugins && make generate`, `make testunit` and `make testconformance` locally. Given this is a minor bump version I thought that's ok. If this is not, we can close it and follow-up. Thanks!

