### PR TITLE
Use dedicated serial OperationQueue instead of main queue for URLSession delegate callbacks

### DIFF
--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -34,11 +34,15 @@ open class URLSessionHTTPClient: NSObject, HTTPClientInterface, @unchecked Senda
     private var streams = [Int: URLSessionStream]()
 
     public init(configuration: URLSessionConfiguration = .default) {
+        let delegateQueue = OperationQueue()
+        delegateQueue.name = "com.connectrpc.connect.swift.urlsessionhttpclient"
+        delegateQueue.maxConcurrentOperationCount = 1
+        delegateQueue.qualityOfService = .userInitiated
         let delegate = URLSessionDelegateWrapper()
         self.session = URLSession(
             configuration: configuration,
             delegate: delegate,
-            delegateQueue: .main
+            delegateQueue: delegateQueue
         )
         super.init()
         delegate.client = self


### PR DESCRIPTION
`URLSessionHTTPClient` was previously initialized with delegateQueue: `.main`, causing all URLSession delegate callbacks (response handling, data delivery, task completion, metrics collection) to run on the main thread. 
This could block the UI when performing high-throughput or long-running network requests.

This change replaces the main queue with a dedicated OperationQueue that:

- Runs on a background thread with .userInitiated QoS

- Limits concurrency to 1 so that delegate callbacks remain ordered and serialized

- Uses a reverse-DNS name for easier debugging in Instruments and crash reports

⚠️ Breaking Change

1. ProtocolClient defaults to URLSessionHTTPClient — callers using ProtocolClient(config:) without a custom httpClient will see delegate callbacks on a background queue.
2. Subclasses of URLSessionHTTPClient that assumed delegate methods run on the main thread may break.

The Connect library does not guarantee main-thread delegate callbacks. If you need main thread execution, dispatch to DispatchQueue.main in your own code.