### PR TITLE
Fix crash when URLSession resends a streaming request body

### DIFF
--- a/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
+++ b/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
@@ -21,6 +21,7 @@ import Foundation
 final class URLSessionStream: NSObject, @unchecked Sendable {
     private let closedByServer = Locked(false)
     private let readStream: Foundation.InputStream
+    private let requestBodyStreamVended = Locked(false)
     private let responseCallbacks: ResponseCallbacks
     private let task: URLSessionUploadTask
     private let writeStream: Foundation.OutputStream
@@ -30,8 +31,27 @@ final class URLSessionStream: NSObject, @unchecked Sendable {
         case unableToWriteData
     }
 
-    var requestBodyStream: Foundation.InputStream {
-        return self.readStream
+    /// The bound input stream to provide to `URLSession` as the request body.
+    ///
+    /// `URLSession` asks for a body stream via `urlSession(_:task:needNewBodyStream:)` both to
+    /// obtain the initial stream and to resend the request after a recoverable error (for example,
+    /// a dropped connection that is retried when the network path changes). A streamed request body
+    /// cannot be replayed, and the bound input stream may only be opened once. Returning the same,
+    /// already-opened stream on a resend causes `URLSession`/CFNetwork to abort the process with:
+    ///
+    /// `Assertion failed: (CFReadStreamGetStatus(_stream.get()) == kCFStreamStatusNotOpen),`
+    /// `function _onqueue_setupStream_block_invoke, file HTTPRequestBody.cpp`
+    ///
+    /// To avoid the crash, the stream is vended only once. Subsequent requests return `nil`, which
+    /// fails the task with an error that is surfaced through the normal stream-close path instead.
+    var requestBodyStream: Foundation.InputStream? {
+        return self.requestBodyStreamVended.perform { vended in
+            guard !vended else {
+                return nil
+            }
+            vended = true
+            return self.readStream
+        }
     }
 
     var taskID: Int {

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/URLSessionStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/URLSessionStreamTests.swift
@@ -1,0 +1,43 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import Connect
+import Foundation
+import XCTest
+
+final class URLSessionStreamTests: XCTestCase {
+    /// `URLSession` requests a body stream via `urlSession(_:task:needNewBodyStream:)` both for the
+    /// initial send and when it resends a request after a recoverable error. A streamed request
+    /// body cannot be replayed, and returning the same already-opened stream on a resend crashes
+    /// CFNetwork. The stream must therefore be vended only once.
+    func testVendsRequestBodyStreamOnlyOnce() {
+        let stream = URLSessionStream(
+            request: URLRequest(url: URL(string: "https://connectrpc.com")!),
+            session: URLSession(configuration: .ephemeral),
+            responseCallbacks: ResponseCallbacks(
+                receiveResponseHeaders: { _ in },
+                receiveResponseData: { _ in },
+                receiveResponseMetrics: { _ in },
+                receiveClose: { _, _, _ in }
+            )
+        )
+        defer { stream.cancel() }
+
+        XCTAssertNotNil(stream.requestBodyStream, "The initial body stream should be vended.")
+        XCTAssertNil(
+            stream.requestBodyStream,
+            "A resend must not reuse the already-opened body stream."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

`urlSession(_:task:needNewBodyStream:)` is called by `URLSession` both to obtain the initial body stream for a streamed upload task **and** to resend a request that has a body stream after a recoverable error (per [Apple's docs](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/urlsession(_:task:neednewbodystream:))). In practice the resend path is hit when an in-flight streaming connection drops and is retried — commonly on a background → foreground transition when the network path changes.

`URLSessionStream` always returned the same bound `InputStream`. On the resend, `URLSession` receives an input stream that has already been opened, and CFNetwork aborts the process:

```
Assertion failed: (CFReadStreamGetStatus(_stream.get()) == kCFStreamStatusNotOpen),
function _onqueue_setupStream_block_invoke, file HTTPRequestBody.cpp
```

A streamed request body cannot be replayed, so this vends the bound input stream **only once**. Subsequent requests return `nil`, which fails the task and is surfaced through the normal stream-close path instead of crashing. (`URLSessionHTTPClient.needNewBodyStream` already forwards the value via optional chaining, so no change is needed there.)

Fixes #398.

## Changes

- `URLSessionStream.requestBodyStream` is now `InputStream?` and vends the bound stream only once (guarded by a `Locked` flag), returning `nil` thereafter.
- Adds `URLSessionStreamTests.testVendsRequestBodyStreamOnlyOnce`.

## Testing

- `swift build --target Connect`
- `swift test --filter URLSessionStreamTests` (passes)
- `swiftlint lint` clean on changed files

## Notes

- Backward compatible: `requestBodyStream` is `internal`, so the visible behavior change is only that a streamed request body is no longer replayed (which previously crashed).