### PR TITLE
Update CI Xcode version to 26.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   # Sets the Xcode version to use for the CI.
   # Available versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode
   # Ref: https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
-  DEVELOPER_DIR: /Applications/Xcode_26.1.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   # Sets the Xcode version to use for the CI.
   # Available versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode
   # Ref: https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
-  DEVELOPER_DIR: /Applications/Xcode_26.1.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
## Summary

- Updates `DEVELOPER_DIR` from Xcode 26.1.1 to 26.4.1 in both `ci.yml` and `release.yml`
- Xcode 26.1.1 on the `macos-26` runner does not have iOS/tvOS/watchOS simulator runtimes pre-installed, causing simulator-based build jobs to fail
- Xcode 26.4.1 is the default Xcode on the runner and includes the required simulator runtimes

## Test plan

CI