### PR TITLE
Migrate unit tests from XCTest to Swift Testing

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -117,3 +117,11 @@ custom_rules:
   spaces_over_tabs:
     name: "Use (4) spaces instead of tabs"
     regex: '\t'
+  swift_testing_over_xctest:
+    name: "Use Swift Testing rather than XCTest for writing tests"
+    message: "Import Testing and write tests with @Test/#expect instead of XCTest."
+    regex: '^\s*(@testable\s+)?import\s+XCTest\b'
+    match_kinds:
+      - attribute.builtin
+      - keyword
+      - identifier

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -120,8 +120,4 @@ custom_rules:
   swift_testing_over_xctest:
     name: "Use Swift Testing rather than XCTest for writing tests"
     message: "Import Testing and write tests with @Test/#expect instead of XCTest."
-    regex: '^\s*(@testable\s+)?import\s+XCTest\b'
-    match_kinds:
-      - attribute.builtin
-      - keyword
-      - identifier
+    regex: 'XCTest'

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -35,7 +35,6 @@ opt_in_rules:
   - empty_collection_literal
   - empty_count
   - empty_string
-  - empty_xctest_method
   - enum_case_associated_values_count
   - explicit_init
   - fallthrough
@@ -77,7 +76,6 @@ opt_in_rules:
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
-  - xct_specific_matcher
   - yoda_condition
 trailing_whitespace:
   ignores_comments: false
@@ -119,6 +117,3 @@ custom_rules:
   spaces_over_tabs:
     name: "Use (4) spaces instead of tabs"
     regex: '\t'
-  xctestcase:
-    name: "Use XCTestCase over XCTest to ensure tests run properly"
-    regex: ': XCTest[\s,]+'

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectMocksTests/ConnectMocksTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectMocksTests/ConnectMocksTests.swift
@@ -14,18 +14,20 @@
 
 @testable import Connect
 import ConnectMocks
+import Foundation
 import SwiftProtobuf
-import XCTest
+import Testing
 
 /// Test suite that validates the behavior of generated mock classes.
-@available(iOS 13, *)
-final class ConnectMocksTests: XCTestCase {
+struct ConnectMocksTests {
     // MARK: - Unary
 
-    func testMockUnaryCallbacks() {
+    @available(iOS 13, *)
+    @Test
+    func mockUnaryCallbacks() {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
         client.mockUnary = { request in
-            XCTAssertTrue(request.hasResponseDefinition)
+            #expect(request.hasResponseDefinition)
             return ResponseMessage(result: .success(.with { $0.payload.data = Data([0x0]) }))
         }
 
@@ -33,23 +35,27 @@ final class ConnectMocksTests: XCTestCase {
         client.unary(request: .with { $0.responseDefinition = .init() }) { response in
             receivedMessage.value = response.message
         }
-        XCTAssertEqual(receivedMessage.value?.payload.data.count, 1)
+        #expect(receivedMessage.value?.payload.data.count == 1)
     }
 
-    func testMockUnaryAsyncAwait() async {
+    @available(iOS 13, *)
+    @Test
+    func mockUnaryAsyncAwait() async {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
         client.mockAsyncUnary = { request in
-            XCTAssertTrue(request.hasResponseDefinition)
+            #expect(request.hasResponseDefinition)
             return ResponseMessage(result: .success(.with { $0.payload.data = Data([0x0]) }))
         }
 
         let response = await client.unary(request: .with { $0.responseDefinition = .init() })
-        XCTAssertEqual(response.message?.payload.data.count, 1)
+        #expect(response.message?.payload.data.count == 1)
     }
 
     // MARK: - Bidirectional stream
 
-    func testMockBidirectionalStreamCallbacks() {
+    @available(iOS 13, *)
+    @Test
+    func mockBidirectionalStreamCallbacks() {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
         let expectedInputs: [Connectrpc_Conformance_V1_BidiStreamRequest] = [
             .with { $0.responseDefinition.responseData = [Data(repeating: 0, count: 123)] },
@@ -62,7 +68,7 @@ final class ConnectMocksTests: XCTestCase {
             .message(.with { $0.payload.data = Data(repeating: 0, count: 456) }),
             .complete(code: .ok, error: nil, trailers: nil),
         ]
-        XCTAssertFalse(client.mockBidiStream.isClosed)
+        #expect(!client.mockBidiStream.isClosed)
 
         var sentInputs = [Connectrpc_Conformance_V1_BidiStreamRequest]()
         var closeCalled = false
@@ -80,14 +86,16 @@ final class ConnectMocksTests: XCTestCase {
         stream.send(expectedInputs[1])
         stream.close()
 
-        XCTAssertEqual(sentInputs, expectedInputs)
-        XCTAssertEqual(client.mockBidiStream.inputs, expectedInputs)
-        XCTAssertEqual(receivedResults.value, expectedResults)
-        XCTAssertTrue(closeCalled)
-        XCTAssertTrue(client.mockBidiStream.isClosed)
+        #expect(sentInputs == expectedInputs)
+        #expect(client.mockBidiStream.inputs == expectedInputs)
+        #expect(receivedResults.value == expectedResults)
+        #expect(closeCalled)
+        #expect(client.mockBidiStream.isClosed)
     }
 
-    func testMockBidirectionalStreamAsyncAwait() async throws {
+    @available(iOS 13, *)
+    @Test
+    func mockBidirectionalStreamAsyncAwait() async throws {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
         let expectedInputs: [Connectrpc_Conformance_V1_BidiStreamRequest] = [
             .with { $0.responseDefinition.responseData = [Data(repeating: 0, count: 123)] },
@@ -100,7 +108,7 @@ final class ConnectMocksTests: XCTestCase {
             .message(.with { $0.payload.data = Data(repeating: 0, count: 456) }),
             .complete(code: .ok, error: nil, trailers: nil),
         ]
-        XCTAssertFalse(client.mockAsyncBidiStream.isClosed)
+        #expect(!client.mockAsyncBidiStream.isClosed)
 
         var sentInputs = [Connectrpc_Conformance_V1_BidiStreamRequest]()
         var closeCalled = false
@@ -114,19 +122,21 @@ final class ConnectMocksTests: XCTestCase {
         stream.close()
 
         for await result in stream.results() {
-            XCTAssertEqual(result, expectedResults.removeFirst())
+            #expect(result == expectedResults.removeFirst())
         }
 
-        XCTAssertEqual(sentInputs, expectedInputs)
-        XCTAssertEqual(client.mockAsyncBidiStream.inputs, expectedInputs)
-        XCTAssertTrue(expectedResults.isEmpty)
-        XCTAssertTrue(closeCalled)
-        XCTAssertTrue(client.mockAsyncBidiStream.isClosed)
+        #expect(sentInputs == expectedInputs)
+        #expect(client.mockAsyncBidiStream.inputs == expectedInputs)
+        #expect(expectedResults.isEmpty)
+        #expect(closeCalled)
+        #expect(client.mockAsyncBidiStream.isClosed)
     }
 
     // MARK: - Server-only stream
 
-    func testMockServerOnlyStreamCallbacks() {
+    @available(iOS 13, *)
+    @Test
+    func mockServerOnlyStreamCallbacks() {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
         let expectedInputs: [Connectrpc_Conformance_V1_ServerStreamRequest] = [
             .with { $0.responseDefinition.responseData = [Data(repeating: 0, count: 123)] },
@@ -150,12 +160,14 @@ final class ConnectMocksTests: XCTestCase {
         }
         stream.send(expectedInputs[0])
 
-        XCTAssertEqual(sentInputs, expectedInputs)
-        XCTAssertEqual(client.mockServerStream.inputs, expectedInputs)
-        XCTAssertEqual(receivedResults.value, expectedResults)
+        #expect(sentInputs == expectedInputs)
+        #expect(client.mockServerStream.inputs == expectedInputs)
+        #expect(receivedResults.value == expectedResults)
     }
 
-    func testMockServerOnlyStreamAsyncAwait() async throws {
+    @available(iOS 13, *)
+    @Test
+    func mockServerOnlyStreamAsyncAwait() async throws {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
         let expectedInputs: [Connectrpc_Conformance_V1_ServerStreamRequest] = [
             .with { $0.responseDefinition.responseData = [Data(repeating: 0, count: 123)] },
@@ -176,11 +188,11 @@ final class ConnectMocksTests: XCTestCase {
         try stream.send(expectedInputs[0])
 
         for await result in stream.results() {
-            XCTAssertEqual(result, expectedResults.removeFirst())
+            #expect(result == expectedResults.removeFirst())
         }
 
-        XCTAssertEqual(sentInputs, expectedInputs)
-        XCTAssertEqual(client.mockAsyncServerStream.inputs, expectedInputs)
-        XCTAssertTrue(expectedResults.isEmpty)
+        #expect(sentInputs == expectedInputs)
+        #expect(client.mockAsyncServerStream.inputs == expectedInputs)
+        #expect(expectedResults.isEmpty)
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectMocksTests/ConnectMocksTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectMocksTests/ConnectMocksTests.swift
@@ -68,7 +68,7 @@ struct ConnectMocksTests {
             .message(.with { $0.payload.data = Data(repeating: 0, count: 456) }),
             .complete(code: .ok, error: nil, trailers: nil),
         ]
-        #expect(!client.mockBidiStream.isClosed)
+        #expect(client.mockBidiStream.isClosed == false)
 
         var sentInputs = [Connectrpc_Conformance_V1_BidiStreamRequest]()
         var closeCalled = false
@@ -108,7 +108,7 @@ struct ConnectMocksTests {
             .message(.with { $0.payload.data = Data(repeating: 0, count: 456) }),
             .complete(code: .ok, error: nil, trailers: nil),
         ]
-        #expect(!client.mockAsyncBidiStream.isClosed)
+        #expect(client.mockAsyncBidiStream.isClosed == false)
 
         var sentInputs = [Connectrpc_Conformance_V1_BidiStreamRequest]()
         var closeCalled = false

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ConnectEndStreamResponseTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ConnectEndStreamResponseTests.swift
@@ -14,10 +14,12 @@
 
 @testable import Connect
 import Foundation
-import XCTest
+import Testing
 
-final class ConnectEndStreamResponseTests: XCTestCase {
-    func testLowercasesAllHeaderKeys() throws {
+struct ConnectEndStreamResponseTests {
+    @available(iOS 13, *)
+    @Test
+    func lowercasesAllHeaderKeys() throws {
         let dictionary = [
             "metadata": [
                 "sOmEkEy": ["foo"],
@@ -26,18 +28,22 @@ final class ConnectEndStreamResponseTests: XCTestCase {
         ]
         let data = try JSONSerialization.data(withJSONObject: dictionary)
         let response = try JSONDecoder().decode(ConnectEndStreamResponse.self, from: data)
-        XCTAssertNil(response.error)
-        XCTAssertEqual(response.metadata, ["somekey": ["foo"], "otherkey1": ["BAR", "bAz"]])
+        #expect(response.error == nil)
+        #expect(response.metadata == ["somekey": ["foo"], "otherkey1": ["BAR", "bAz"]])
     }
 
-    func testAllowsOmittedErrorAndMetadata() throws {
+    @available(iOS 13, *)
+    @Test
+    func allowsOmittedErrorAndMetadata() throws {
         let data = try JSONSerialization.data(withJSONObject: [String: Any]())
         let response = try JSONDecoder().decode(ConnectEndStreamResponse.self, from: data)
-        XCTAssertNil(response.error)
-        XCTAssertNil(response.metadata)
+        #expect(response.error == nil)
+        #expect(response.metadata == nil)
     }
 
-    func testDeserializesError() throws {
+    @available(iOS 13, *)
+    @Test
+    func deserializesError() throws {
         let dictionary = [
             "error": [
                 "code": "permission_denied",
@@ -45,6 +51,6 @@ final class ConnectEndStreamResponseTests: XCTestCase {
         ]
         let data = try JSONSerialization.data(withJSONObject: dictionary)
         let response = try JSONDecoder().decode(ConnectEndStreamResponse.self, from: data)
-        XCTAssertEqual(response.error?.code, .permissionDenied)
+        #expect(response.error?.code == .permissionDenied)
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift
@@ -15,47 +15,55 @@
 @testable import Connect
 import Foundation
 import SwiftProtobuf
-import XCTest
+import Testing
 
-final class ConnectErrorTests: XCTestCase {
-    func testDeserializingFullErrorAndUnpackingDetails() throws {
+struct ConnectErrorTests {
+    @available(iOS 13, *)
+    @Test
+    func deserializingFullErrorAndUnpackingDetails() throws {
         let expectedDetails = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "foo/bar" }
         let errorData = try self.errorData(expectedDetails: [expectedDetails])
         let error = try JSONDecoder().decode(ConnectError.self, from: errorData)
-        XCTAssertEqual(error.code, .unavailable)
-        XCTAssertEqual(error.message, "overloaded: back off and retry")
-        XCTAssertNil(error.exception)
-        XCTAssertEqual(error.details.count, 1)
-        XCTAssertEqual(error.unpackedDetails(), [expectedDetails])
-        XCTAssertTrue(error.metadata.isEmpty)
+        #expect(error.code == .unavailable)
+        #expect(error.message == "overloaded: back off and retry")
+        #expect(error.exception == nil)
+        #expect(error.details.count == 1)
+        #expect(error.unpackedDetails() == [expectedDetails])
+        #expect(error.metadata.isEmpty)
     }
 
-    func testDeserializingFullErrorAndUnpackingDetailsWithUnpaddedBase64() throws {
+    @available(iOS 13, *)
+    @Test
+    func deserializingFullErrorAndUnpackingDetailsWithUnpaddedBase64() throws {
         let expectedDetails = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "foo/bar" }
         let errorData = try self.errorData(expectedDetails: [expectedDetails], pad: false)
         let error = try JSONDecoder().decode(ConnectError.self, from: errorData)
-        XCTAssertEqual(error.code, .unavailable)
-        XCTAssertEqual(error.message, "overloaded: back off and retry")
-        XCTAssertNil(error.exception)
-        XCTAssertEqual(error.details.count, 1)
-        XCTAssertEqual(error.unpackedDetails(), [expectedDetails])
-        XCTAssertTrue(error.metadata.isEmpty)
+        #expect(error.code == .unavailable)
+        #expect(error.message == "overloaded: back off and retry")
+        #expect(error.exception == nil)
+        #expect(error.details.count == 1)
+        #expect(error.unpackedDetails() == [expectedDetails])
+        #expect(error.metadata.isEmpty)
     }
 
-    func testDeserializingFullErrorAndUnpackingMultipleDetails() throws {
+    @available(iOS 13, *)
+    @Test
+    func deserializingFullErrorAndUnpackingMultipleDetails() throws {
         let expectedDetails1 = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "foo/bar" }
         let expectedDetails2 = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "bar/baz" }
         let errorData = try self.errorData(expectedDetails: [expectedDetails1, expectedDetails2])
         let error = try JSONDecoder().decode(ConnectError.self, from: errorData)
-        XCTAssertEqual(error.code, .unavailable)
-        XCTAssertEqual(error.message, "overloaded: back off and retry")
-        XCTAssertNil(error.exception)
-        XCTAssertEqual(error.details.count, 2)
-        XCTAssertEqual(error.unpackedDetails(), [expectedDetails1, expectedDetails2])
-        XCTAssertTrue(error.metadata.isEmpty)
+        #expect(error.code == .unavailable)
+        #expect(error.message == "overloaded: back off and retry")
+        #expect(error.exception == nil)
+        #expect(error.details.count == 2)
+        #expect(error.unpackedDetails() == [expectedDetails1, expectedDetails2])
+        #expect(error.metadata.isEmpty)
     }
 
-    func testDeserializingErrorUsingHelperFunctionLowercasesHeaderKeys() throws {
+    @available(iOS 13, *)
+    @Test
+    func deserializingErrorUsingHelperFunctionLowercasesHeaderKeys() throws {
         let expectedDetails = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "a/b/c" }
         let errorData = try self.errorData(expectedDetails: [expectedDetails])
         let error = ConnectError.from(
@@ -67,15 +75,17 @@ final class ConnectErrorTests: XCTestCase {
             trailers: nil,
             source: errorData
         )
-        XCTAssertEqual(error.code, .unavailable) // Respects the code from the error body
-        XCTAssertEqual(error.message, "overloaded: back off and retry")
-        XCTAssertNil(error.exception)
-        XCTAssertEqual(error.details.count, 1)
-        XCTAssertEqual(error.unpackedDetails(), [expectedDetails])
-        XCTAssertEqual(error.metadata, ["somekey": ["foo"], "otherkey1": ["BAR", "bAz"]])
+        #expect(error.code == .unavailable) // Respects the code from the error body
+        #expect(error.message == "overloaded: back off and retry")
+        #expect(error.exception == nil)
+        #expect(error.details.count == 1)
+        #expect(error.unpackedDetails() == [expectedDetails])
+        #expect(error.metadata == ["somekey": ["foo"], "otherkey1": ["BAR", "bAz"]])
     }
 
-    func testDeserializingErrorUsingHelperFunctionCombinesHeadersAndTrailers() throws {
+    @available(iOS 13, *)
+    @Test
+    func deserializingErrorUsingHelperFunctionCombinesHeadersAndTrailers() throws {
         let expectedDetails = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "a/b/c" }
         let errorData = try self.errorData(expectedDetails: [expectedDetails])
         let error = ConnectError.from(
@@ -90,30 +100,32 @@ final class ConnectErrorTests: XCTestCase {
             ],
             source: errorData
         )
-        XCTAssertEqual(error.code, .unavailable) // Respects the code from the error body
-        XCTAssertEqual(error.message, "overloaded: back off and retry")
-        XCTAssertNil(error.exception)
-        XCTAssertEqual(error.details.count, 1)
-        XCTAssertEqual(error.unpackedDetails(), [expectedDetails])
-        XCTAssertEqual(error.metadata, [
+        #expect(error.code == .unavailable) // Respects the code from the error body
+        #expect(error.message == "overloaded: back off and retry")
+        #expect(error.exception == nil)
+        #expect(error.details.count == 1)
+        #expect(error.unpackedDetails() == [expectedDetails])
+        #expect(error.metadata == [
             "duplicatedkey": ["trailers"],
             "otherkey1": ["BAR", "bAz"],
             "anotherkey": ["foo"],
         ])
     }
 
-    func testDeserializingSimpleError() throws {
+    @available(iOS 13, *)
+    @Test
+    func deserializingSimpleError() throws {
         let errorDictionary = [
             "code": "unavailable",
         ]
         let errorData = try JSONSerialization.data(withJSONObject: errorDictionary)
         let error = try JSONDecoder().decode(ConnectError.self, from: errorData)
-        XCTAssertEqual(error.code, .unavailable)
-        XCTAssertNil(error.message)
-        XCTAssertNil(error.exception)
-        XCTAssertTrue(error.details.isEmpty)
-        XCTAssertEqual(error.unpackedDetails(), [Connectrpc_Conformance_V1_RawHTTPRequest]())
-        XCTAssertTrue(error.metadata.isEmpty)
+        #expect(error.code == .unavailable)
+        #expect(error.message == nil)
+        #expect(error.exception == nil)
+        #expect(error.details.isEmpty)
+        #expect(error.unpackedDetails() == [Connectrpc_Conformance_V1_RawHTTPRequest]())
+        #expect(error.metadata.isEmpty)
     }
 
     // MARK: - Private

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
@@ -13,76 +13,87 @@
 // limitations under the License.
 
 @testable import Connect
-import XCTest
+import Foundation
+import Testing
 
-final class EnvelopeTests: XCTestCase {
-    func testPackingAndUnpackingCompressedMessage() throws {
+struct EnvelopeTests {
+    @available(iOS 13, *)
+    @Test
+    func packingAndUnpackingCompressedMessage() throws {
         let originalData = Data(repeating: 0xa, count: 50)
         let packed = Envelope._packMessage(
             originalData, using: .init(minBytes: 10, pool: GzipCompressionPool())
         )
         let compressed = try GzipCompressionPool().compress(data: originalData)
-        XCTAssertEqual(packed[0], 1) // Compression flag = true
-        XCTAssertTrue(Envelope._isCompressed(packed))
-        XCTAssertEqual(Envelope._messageLength(forPackedData: packed), compressed.count)
-        XCTAssertEqual(packed[5...], compressed) // Post-prefix data should match compressed value
+        #expect(packed[0] == 1) // Compression flag = true
+        #expect(Envelope._isCompressed(packed))
+        #expect(Envelope._messageLength(forPackedData: packed) == compressed.count)
+        #expect(packed[5...] == compressed) // Post-prefix data should match compressed value
 
         let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
-        XCTAssertEqual(unpacked.unpacked, originalData)
-        XCTAssertEqual(unpacked.headerByte, 1) // Compression flag = true
+        #expect(unpacked.unpacked == originalData)
+        #expect(unpacked.headerByte == 1) // Compression flag = true
     }
 
-    func testPackingAndUnpackingUncompressedMessageBecauseCompressionMinBytesIsNil() throws {
+    @available(iOS 13, *)
+    @Test
+    func packingAndUnpackingUncompressedMessageBecauseCompressionMinBytesIsNil() throws {
         let originalData = Data(repeating: 0xa, count: 50)
         let packed = Envelope._packMessage(originalData, using: nil)
-        XCTAssertEqual(packed[0], 0) // Compression flag = false
-        XCTAssertFalse(Envelope._isCompressed(packed))
-        XCTAssertEqual(Envelope._messageLength(forPackedData: packed), originalData.count)
-        XCTAssertEqual(packed[5...], originalData) // Post-prefix data should match compressed value
+        #expect(packed[0] == 0) // Compression flag = false
+        #expect(!Envelope._isCompressed(packed))
+        #expect(Envelope._messageLength(forPackedData: packed) == originalData.count)
+        #expect(packed[5...] == originalData) // Post-prefix data should match compressed value
 
         // Compression pool should be ignored since the message is not compressed
         let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
-        XCTAssertEqual(unpacked.unpacked, originalData)
-        XCTAssertEqual(unpacked.headerByte, 0) // Compression flag = false
+        #expect(unpacked.unpacked == originalData)
+        #expect(unpacked.headerByte == 0) // Compression flag = false
     }
 
-    func testPackingAndUnpackingUncompressedMessageBecauseMessageIsTooSmall() throws {
+    @available(iOS 13, *)
+    @Test
+    func packingAndUnpackingUncompressedMessageBecauseMessageIsTooSmall() throws {
         let originalData = Data(repeating: 0xa, count: 50)
         let packed = Envelope._packMessage(
             originalData, using: .init(minBytes: 100, pool: GzipCompressionPool())
         )
-        XCTAssertEqual(packed[0], 0) // Compression flag = false
-        XCTAssertFalse(Envelope._isCompressed(packed))
-        XCTAssertEqual(Envelope._messageLength(forPackedData: packed), originalData.count)
-        XCTAssertEqual(packed[5...], originalData) // Post-prefix data should match compressed value
+        #expect(packed[0] == 0) // Compression flag = false
+        #expect(!Envelope._isCompressed(packed))
+        #expect(Envelope._messageLength(forPackedData: packed) == originalData.count)
+        #expect(packed[5...] == originalData) // Post-prefix data should match compressed value
 
         // Compression pool should be ignored since the message is not compressed
         let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
-        XCTAssertEqual(unpacked.unpacked, originalData)
-        XCTAssertEqual(unpacked.headerByte, 0) // Compression flag = false
+        #expect(unpacked.unpacked == originalData)
+        #expect(unpacked.headerByte == 0) // Compression flag = false
     }
 
-    func testThrowsWhenUnpackingCompressedMessageWithoutDecompressionPool() throws {
+    @available(iOS 13, *)
+    @Test
+    func throwsWhenUnpackingCompressedMessageWithoutDecompressionPool() throws {
         let originalData = Data(repeating: 0xa, count: 50)
         let packed = Envelope._packMessage(
             originalData, using: .init(minBytes: 10, pool: GzipCompressionPool())
         )
         let compressed = try GzipCompressionPool().compress(data: originalData)
-        XCTAssertEqual(packed[0], 1) // Compression flag = true
-        XCTAssertTrue(Envelope._isCompressed(packed))
-        XCTAssertEqual(Envelope._messageLength(forPackedData: packed), compressed.count)
-        XCTAssertEqual(packed[5...], compressed) // Post-prefix data should match compressed value
+        #expect(packed[0] == 1) // Compression flag = true
+        #expect(Envelope._isCompressed(packed))
+        #expect(Envelope._messageLength(forPackedData: packed) == compressed.count)
+        #expect(packed[5...] == compressed) // Post-prefix data should match compressed value
 
-        XCTAssertThrowsError(try Envelope._unpackMessage(packed, compressionPool: nil)) { error in
-            XCTAssertEqual(error as? Envelope.Error, .missingExpectedCompressionPool)
+        #expect(throws: Envelope.Error.missingExpectedCompressionPool) {
+            try Envelope._unpackMessage(packed, compressionPool: nil)
         }
     }
 
-    func testMessageLengthOfIncompleteData() {
+    @available(iOS 13, *)
+    @Test
+    func messageLengthOfIncompleteData() {
         // Messages are incomplete if they do not contain enough data for the 5-byte prefix
         for length in 0..<5 {
             let data = Data(repeating: 0xa, count: length)
-            XCTAssertEqual(Envelope._messageLength(forPackedData: data), -1)
+            #expect(Envelope._messageLength(forPackedData: data) == -1)
         }
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
@@ -41,7 +41,7 @@ struct EnvelopeTests {
         let originalData = Data(repeating: 0xa, count: 50)
         let packed = Envelope._packMessage(originalData, using: nil)
         #expect(packed[0] == 0) // Compression flag = false
-        #expect(!Envelope._isCompressed(packed))
+        #expect(Envelope._isCompressed(packed) == false)
         #expect(Envelope._messageLength(forPackedData: packed) == originalData.count)
         #expect(packed[5...] == originalData) // Post-prefix data should match compressed value
 
@@ -59,7 +59,7 @@ struct EnvelopeTests {
             originalData, using: .init(minBytes: 100, pool: GzipCompressionPool())
         )
         #expect(packed[0] == 0) // Compression flag = false
-        #expect(!Envelope._isCompressed(packed))
+        #expect(Envelope._isCompressed(packed) == false)
         #expect(Envelope._messageLength(forPackedData: packed) == originalData.count)
         #expect(packed[5...] == originalData) // Post-prefix data should match compressed value
 

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/GzipCompressionPoolTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/GzipCompressionPoolTests.swift
@@ -14,32 +14,38 @@
 
 import Connect
 import Foundation
-import XCTest
+import Testing
 
-final class GzipCompressionPoolTests: XCTestCase {
-    func testDecompressingGzippedFile() throws {
+struct GzipCompressionPoolTests {
+    @available(iOS 13, *)
+    @Test
+    func decompressingGzippedFile() throws {
         let compressedData = try self.gzippedFileData()
-        let decompressedText = try XCTUnwrap(String(
+        let decompressedText = try #require(String(
             data: try GzipCompressionPool().decompress(data: compressedData),
             encoding: .utf8
         ))
-        XCTAssertEqual(decompressedText, self.expectedUnzippedFileText())
+        #expect(decompressedText == self.expectedUnzippedFileText())
     }
 
-    func testCompressingAndDecompressingData() throws {
-        let original = try XCTUnwrap(self.expectedUnzippedFileText().data(using: .utf8))
+    @available(iOS 13, *)
+    @Test
+    func compressingAndDecompressingData() throws {
+        let original = try #require(self.expectedUnzippedFileText().data(using: .utf8))
         let compressionPool = GzipCompressionPool()
         let compressed = try compressionPool.compress(data: original)
-        XCTAssertTrue(compressed.starts(with: [0x1f, 0x8b])) // Indicates gzip
-        XCTAssertNotEqual(compressed.count, original.count)
+        #expect(compressed.starts(with: [0x1f, 0x8b])) // Indicates gzip
+        #expect(compressed.count != original.count)
 
         let decompressed = try compressionPool.decompress(data: compressed)
-        XCTAssertEqual(decompressed, original)
+        #expect(decompressed == original)
     }
 
-    func testDoesNotGzipDataThatIsAlreadyGzipped() throws {
+    @available(iOS 13, *)
+    @Test
+    func doesNotGzipDataThatIsAlreadyGzipped() throws {
         let compressed = try self.gzippedFileData()
-        XCTAssertEqual(compressed, try GzipCompressionPool().compress(data: compressed))
+        #expect(try compressed == GzipCompressionPool().compress(data: compressed))
     }
 
     // MARK: - Private
@@ -49,7 +55,7 @@ final class GzipCompressionPoolTests: XCTestCase {
     }
 
     private func gzippedFileData() throws -> Data {
-        let gzippedFileURL = try XCTUnwrap(
+        let gzippedFileURL = try #require(
             Bundle.module.url(
                 forResource: "gzip-test.txt.gz", withExtension: nil, subdirectory: "TestResources"
             )

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorChainIterationTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorChainIterationTests.swift
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 @testable import Connect
-import XCTest
+import Testing
 
-final class InterceptorChainIterationTests: XCTestCase {
-    func testExecutingNonFailing() {
+struct InterceptorChainIterationTests {
+    @available(iOS 13, *)
+    @Test
+    func executingNonFailing() {
         let initialValue = ""
         let result = Locked(initialValue)
         let chain = InterceptorChain([Void]())
@@ -29,10 +31,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             initial: initialValue,
             finish: { result.value = $0 }
         )
-        XCTAssertEqual(result.value, "ab")
+        #expect(result.value == "ab")
     }
 
-    func testExecutingNonFailingReversed() {
+    @available(iOS 13, *)
+    @Test
+    func executingNonFailingReversed() {
         let initialValue = ""
         let result = Locked(initialValue)
         let chain = InterceptorChain([Void]())
@@ -45,10 +49,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             initial: initialValue,
             finish: { result.value = $0 }
         )
-        XCTAssertEqual(result.value, "ba")
+        #expect(result.value == "ba")
     }
 
-    func testExecutingLinkedNonFailing() {
+    @available(iOS 13, *)
+    @Test
+    func executingLinkedNonFailing() {
         let result = Locked(0)
         let chain = InterceptorChain([Void]())
         chain.executeLinkedInterceptors(
@@ -65,10 +71,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             ],
             finish: { result.value = $0 }
         )
-        XCTAssertEqual(result.value, 12 + 1 + 3)
+        #expect(result.value == 12 + 1 + 3)
     }
 
-    func testExecutingFailableWithoutError() {
+    @available(iOS 13, *)
+    @Test
+    func executingFailableWithoutError() {
         let result = Locked<Result<String, ConnectError>?>(nil)
         let chain = InterceptorChain([Void]())
         chain.executeInterceptorsAndStopOnFailure(
@@ -80,10 +88,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             initial: "",
             finish: { result.value = $0 }
         )
-        XCTAssertEqual(try? result.value?.get(), "ab")
+        #expect((try? result.value?.get()) == "ab")
     }
 
-    func testExecutingFailableWithoutErrorReversed() {
+    @available(iOS 13, *)
+    @Test
+    func executingFailableWithoutErrorReversed() {
         let result = Locked<Result<String, ConnectError>?>(nil)
         let chain = InterceptorChain([Void]())
         chain.executeInterceptorsAndStopOnFailure(
@@ -95,10 +105,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             initial: "",
             finish: { result.value = $0 }
         )
-        XCTAssertEqual(try? result.value?.get(), "ba")
+        #expect((try? result.value?.get()) == "ba")
     }
 
-    func testExecutingFailableWithError() {
+    @available(iOS 13, *)
+    @Test
+    func executingFailableWithError() {
         let result = Locked<Result<String, ConnectError>?>(nil)
         let chain = InterceptorChain([Void]())
         chain.executeInterceptorsAndStopOnFailure(
@@ -114,10 +126,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             initial: "",
             finish: { result.value = $0 }
         )
-        XCTAssertThrowsError(try result.value?.get())
+        #expect(throws: ConnectError.self) { try result.value?.get() }
     }
 
-    func testExecutingLinkedFailableWithoutError() {
+    @available(iOS 13, *)
+    @Test
+    func executingLinkedFailableWithoutError() {
         let result = Locked<Result<Int, ConnectError>?>(nil)
         let chain = InterceptorChain([Void]())
         chain.executeLinkedInterceptorsAndStopOnFailure(
@@ -134,10 +148,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             ],
             finish: { result.value = $0 }
         )
-        XCTAssertEqual(try? result.value?.get(), 12 + 1 + 3)
+        #expect((try? result.value?.get()) == 12 + 1 + 3)
     }
 
-    func testExecutingLinkedFailableWithErrorOnFirstIteration() {
+    @available(iOS 13, *)
+    @Test
+    func executingLinkedFailableWithErrorOnFirstIteration() {
         let result = Locked<Result<Int, ConnectError>?>(nil)
         let chain = InterceptorChain([Void]())
         chain.executeLinkedInterceptorsAndStopOnFailure(
@@ -158,10 +174,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             ],
             finish: { result.value = $0 }
         )
-        XCTAssertThrowsError(try result.value?.get())
+        #expect(throws: ConnectError.self) { try result.value?.get() }
     }
 
-    func testExecutingLinkedFailableWithErrorOnTransform() {
+    @available(iOS 13, *)
+    @Test
+    func executingLinkedFailableWithErrorOnTransform() {
         let result = Locked<Result<Int, ConnectError>?>(nil)
         let chain = InterceptorChain([Void]())
         chain.executeLinkedInterceptorsAndStopOnFailure(
@@ -182,10 +200,12 @@ final class InterceptorChainIterationTests: XCTestCase {
             ],
             finish: { result.value = $0 }
         )
-        XCTAssertThrowsError(try result.value?.get())
+        #expect(throws: ConnectError.self) { try result.value?.get() }
     }
 
-    func testExecutingLinkedFailableWithErrorOnSecondIteration() {
+    @available(iOS 13, *)
+    @Test
+    func executingLinkedFailableWithErrorOnSecondIteration() {
         let result = Locked<Result<Int, ConnectError>?>(nil)
         let chain = InterceptorChain([Void]())
         chain.executeLinkedInterceptorsAndStopOnFailure(
@@ -206,6 +226,6 @@ final class InterceptorChainIterationTests: XCTestCase {
             ],
             finish: { result.value = $0 }
         )
-        XCTAssertThrowsError(try result.value?.get())
+        #expect(throws: ConnectError.self) { try result.value?.get() }
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorFactoryTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorFactoryTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 @testable import Connect
-import XCTest
+import Testing
 
 private final class MockUnaryInterceptor: UnaryInterceptor {}
 
@@ -21,40 +21,50 @@ private final class MockStreamInterceptor: StreamInterceptor {}
 
 private final class MockUnaryAndStreamInterceptor: UnaryInterceptor, StreamInterceptor {}
 
-final class InterceptorFactoryTests: XCTestCase {
+struct InterceptorFactoryTests {
     private let config = ProtocolClientConfig(host: "localhost")
 
-    func testInstantiatesUnaryInterceptorForUnary() {
+    @available(iOS 13, *)
+    @Test
+    func instantiatesUnaryInterceptorForUnary() {
         let factory = InterceptorFactory { _ in MockUnaryInterceptor() }
-        XCTAssertTrue(
+        #expect(
             factory.createUnary(with: self.config) is MockUnaryInterceptor
         )
     }
 
-    func testInstantiatesStreamInterceptorForStream() {
+    @available(iOS 13, *)
+    @Test
+    func instantiatesStreamInterceptorForStream() {
         let factory = InterceptorFactory { _ in MockStreamInterceptor() }
-        XCTAssertTrue(
+        #expect(
             factory.createStream(with: self.config) is MockStreamInterceptor
         )
     }
 
-    func testInstantiatesCombinedInterceptorForStreamAndUnary() {
+    @available(iOS 13, *)
+    @Test
+    func instantiatesCombinedInterceptorForStreamAndUnary() {
         let factory = InterceptorFactory { _ in MockUnaryAndStreamInterceptor() }
-        XCTAssertTrue(
+        #expect(
             factory.createUnary(with: self.config) is MockUnaryAndStreamInterceptor
         )
-        XCTAssertTrue(
+        #expect(
             factory.createStream(with: self.config) is MockUnaryAndStreamInterceptor
         )
     }
 
-    func testDoesNotInstantiateUnaryInterceptorForStream() {
+    @available(iOS 13, *)
+    @Test
+    func doesNotInstantiateUnaryInterceptorForStream() {
         let factory = InterceptorFactory { _ in MockUnaryInterceptor() }
-        XCTAssertNil(factory.createStream(with: self.config))
+        #expect(factory.createStream(with: self.config) == nil)
     }
 
-    func testDoesNotInstantiateStreamInterceptorForUnary() {
+    @available(iOS 13, *)
+    @Test
+    func doesNotInstantiateStreamInterceptorForUnary() {
         let factory = InterceptorFactory { _ in MockStreamInterceptor() }
-        XCTAssertNil(factory.createUnary(with: self.config))
+        #expect(factory.createUnary(with: self.config) == nil)
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorIntegrationTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorIntegrationTests.swift
@@ -13,12 +13,19 @@
 // limitations under the License.
 
 @testable import Connect
+import Foundation
 import SwiftProtobuf
-import XCTest
+import Testing
 
-@available(iOS 13, *)
-final class InterceptorIntegrationTests: XCTestCase {
-    func testUnaryInterceptorSuccess() async {
+/// Tests are serialized because they all hit the same local conformance reference server and
+/// validate timing-sensitive behaviors (e.g., URLSession metrics callbacks). Note that
+/// `.serialized` only serializes tests within this suite - other suites (such as
+/// `TimeoutTests`, which also performs live networking) still run concurrently with it.
+@Suite(.serialized)
+struct InterceptorIntegrationTests {
+    @available(iOS 13, *)
+    @Test
+    func unaryInterceptorSuccess() async {
         let trackedSteps = Locked([InterceptorStep]())
         let client = self.createClient(interceptors: [
             InterceptorFactory { _ in
@@ -39,8 +46,8 @@ final class InterceptorIntegrationTests: XCTestCase {
                 response.responseData = Data(repeating: 0, count: 10)
             }
         })
-        XCTAssertNil(response.error)
-        XCTAssertEqual(trackedSteps.value, [
+        #expect(response.error == nil)
+        #expect(trackedSteps.value == [
             .unaryRequest(id: "a"),
             .unaryRequest(id: "b"),
             .unaryRawRequest(id: "a"),
@@ -52,7 +59,9 @@ final class InterceptorIntegrationTests: XCTestCase {
         ])
     }
 
-    func testStreamInterceptorSuccess() async throws {
+    @available(iOS 13, *)
+    @Test
+    func streamInterceptorSuccess() async throws {
         let trackedSteps = Locked([InterceptorStep]())
         let client = self.createClient(interceptors: [
             InterceptorFactory { _ in
@@ -78,18 +87,18 @@ final class InterceptorIntegrationTests: XCTestCase {
             }
         })
         if let firstResponse = await stream.results().first(where: { $0.messageValue != nil }) {
-            XCTAssertEqual(firstResponse.messageValue?.payload.data.count, 100)
+            #expect(firstResponse.messageValue?.payload.data.count == 100)
         }
         if let secondResponse = await stream.results().first(where: { $0.messageValue != nil }) {
-            XCTAssertEqual(secondResponse.messageValue?.payload.data.count, 200)
+            #expect(secondResponse.messageValue?.payload.data.count == 200)
         }
         for await result in stream.results() {
             if case .complete(let code, _, _) = result {
-                XCTAssertEqual(code, .ok)
+                #expect(code == .ok)
             }
         }
 
-        XCTAssertEqual(trackedSteps.value, [
+        #expect(trackedSteps.value == [
             .streamStart(id: "a"),
             .streamStart(id: "b"),
             .streamInput(id: "a"),
@@ -116,7 +125,8 @@ final class InterceptorIntegrationTests: XCTestCase {
     }
 
     @available(macOS 13, iOS 16, watchOS 9, tvOS 16, *) // Required for .contains()
-    func testUnaryInterceptorIsCalledWithMetrics() async {
+    @Test(.timeLimit(.minutes(1)))
+    func unaryInterceptorIsCalledWithMetrics() async {
         let trackedSteps = Locked([InterceptorStep]())
         let client = self.createClient(interceptors: [
             InterceptorFactory { _ in
@@ -139,16 +149,17 @@ final class InterceptorIntegrationTests: XCTestCase {
                 response.responseData = Data(repeating: 0, count: 10)
             }
         })
-        XCTAssertNil(response.error)
+        #expect(response.error == nil)
 
         // Subset of steps is tested since URLSession does not guarantee metric callback ordering.
-        XCTAssertTrue(trackedSteps.value.contains(
+        #expect(trackedSteps.value.contains(
             [.responseMetrics(id: "b"), .responseMetrics(id: "a")]
         ))
     }
 
     @available(macOS 13, iOS 16, watchOS 9, tvOS 16, *) // Required for .contains()
-    func testStreamInterceptorIsCalledWithMetrics() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func streamInterceptorIsCalledWithMetrics() async throws {
         let trackedSteps = Locked([InterceptorStep]())
         let client = self.createClient(interceptors: [
             InterceptorFactory { _ in
@@ -174,18 +185,21 @@ final class InterceptorIntegrationTests: XCTestCase {
         })
         for await result in stream.results() {
             if case .complete(let code, _, _) = result {
-                XCTAssertEqual(code, .ok)
+                #expect(code == .ok)
             }
-            sleep(1) // URLSession sometimes produces metrics information late.
+            // URLSession sometimes produces metrics information late.
+            try await Task.sleep(for: .seconds(1))
         }
 
         // Subset of steps is tested since URLSession does not guarantee metric callback ordering.
-        XCTAssertTrue(trackedSteps.value.contains(
+        #expect(trackedSteps.value.contains(
             [.responseMetrics(id: "b"), .responseMetrics(id: "a")]
         ))
     }
 
-    func testUnaryInterceptorCanFailOutboundRequest() async {
+    @available(iOS 13, *)
+    @Test
+    func unaryInterceptorCanFailOutboundRequest() async {
         let trackedSteps = Locked([InterceptorStep]())
         let client = self.createClient(interceptors: [
             InterceptorFactory { _ in
@@ -210,14 +224,16 @@ final class InterceptorIntegrationTests: XCTestCase {
                 response.responseData = Data(repeating: 0, count: 10)
             }
         })
-        XCTAssertNotNil(response.error) // Interceptor failed the request.
-        XCTAssertEqual(trackedSteps.value, [
+        #expect(response.error != nil) // Interceptor failed the request.
+        #expect(trackedSteps.value == [
             .unaryRequest(id: "a"),
             // Second interceptor is never called.
         ])
     }
 
-    func testStreamInterceptorCanFailOutboundRequest() async {
+    @available(iOS 13, *)
+    @Test
+    func streamInterceptorCanFailOutboundRequest() async {
         let trackedSteps = Locked([InterceptorStep]())
         let client = self.createClient(interceptors: [
             InterceptorFactory { _ in
@@ -240,18 +256,20 @@ final class InterceptorIntegrationTests: XCTestCase {
         for await result in client.serverStream().results() {
             switch result {
             case .complete(_, let error, _):
-                XCTAssertNotNil(error) // Interceptor failed the request.
+                #expect(error != nil) // Interceptor failed the request.
             default:
-                XCTFail("Unexpected result")
+                Issue.record("Unexpected result")
             }
         }
-        XCTAssertEqual(trackedSteps.value, [
+        #expect(trackedSteps.value == [
             .streamStart(id: "a"),
             // Second interceptor is never called.
         ])
     }
 
-    func testStreamDoesNotPassRequestDataToInterceptorsUntilRequestHeadersAreSent() async throws {
+    @available(iOS 13, *)
+    @Test
+    func streamDoesNotPassRequestDataToInterceptorsUntilRequestHeadersAreSent() async throws {
         let trackedSteps = Locked([InterceptorStep]())
         let client = self.createClient(interceptors: [
             InterceptorFactory { _ in
@@ -279,13 +297,13 @@ final class InterceptorIntegrationTests: XCTestCase {
         })
         for await result in stream.results() {
             if case .complete(let code, _, _) = result {
-                XCTAssertEqual(code, .ok)
+                #expect(code == .ok)
             }
         }
 
         // The client should wait for all interceptors to finish processing headers before it
         // passes any data through the chain.
-        XCTAssertEqual(trackedSteps.value, [
+        #expect(trackedSteps.value == [
             .streamStart(id: "a"),
             .streamStart(id: "b"),
             .streamInput(id: "a"),

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/JSONCodecTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/JSONCodecTests.swift
@@ -15,9 +15,9 @@
 import Connect
 import Foundation
 import SwiftProtobuf
-import XCTest
+import Testing
 
-final class JSONCodecTests: XCTestCase {
+struct JSONCodecTests {
     private let message: Connectrpc_Conformance_V1_RawHTTPRequest = .with { proto in
         proto.body = .unary(Connectrpc_Conformance_V1_MessageContents.with { message in
             message.binary = Data([0x0, 0x1, 0x2, 0x3])
@@ -33,61 +33,71 @@ final class JSONCodecTests: XCTestCase {
         proto.rawQueryParams = [.init()]
     }
 
-    func testSerializingAndDeserializingWithDefaultOptions() throws {
+    @available(iOS 13, *)
+    @Test
+    func serializingAndDeserializingWithDefaultOptions() throws {
         let codec = JSONCodec()
         let serialized = try codec.serialize(message: self.message)
-        XCTAssertEqual(try codec.deserialize(source: serialized), self.message)
+        #expect(try codec.deserialize(source: serialized) == self.message)
     }
 
-    func testSerializingAndDeserializingWithEnumsAsInts() throws {
+    @available(iOS 13, *)
+    @Test
+    func serializingAndDeserializingWithEnumsAsInts() throws {
         let codec = JSONCodec(alwaysEncodeEnumsAsInts: true, preserveProtobufFieldNames: false)
         let serialized = try codec.serialize(message: self.message)
-        let dictionary = try XCTUnwrap(
+        let dictionary = try #require(
             try JSONSerialization.jsonObject(with: serialized) as? [String: Any]
         )
-        XCTAssertEqual((dictionary["unary"] as? [String: Any])?["compression"] as? Int, 2)
-        XCTAssertEqual(try codec.deserialize(source: serialized), self.message)
+        #expect((dictionary["unary"] as? [String: Any])?["compression"] as? Int == 2)
+        #expect(try codec.deserialize(source: serialized) == self.message)
     }
 
-    func testSerializingAndDeserializingWithEnumsAsStrings() throws {
+    @available(iOS 13, *)
+    @Test
+    func serializingAndDeserializingWithEnumsAsStrings() throws {
         let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: false)
         let serialized = try codec.serialize(message: self.message)
-        let dictionary = try XCTUnwrap(
+        let dictionary = try #require(
             try JSONSerialization.jsonObject(with: serialized) as? [String: Any]
         )
-        XCTAssertEqual(
-            (dictionary["unary"] as? [String: Any])?["compression"] as? String, "COMPRESSION_GZIP"
+        #expect(
+            (dictionary["unary"] as? [String: Any])?["compression"] as? String == "COMPRESSION_GZIP"
         )
-        XCTAssertEqual(try codec.deserialize(source: serialized), self.message)
+        #expect(try codec.deserialize(source: serialized) == self.message)
     }
 
-    func testSerializingAndDeserializingWithProtobufFieldNames() throws {
+    @available(iOS 13, *)
+    @Test
+    func serializingAndDeserializingWithProtobufFieldNames() throws {
         let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: true)
         let serialized = try codec.serialize(message: self.message)
-        let dictionary = try XCTUnwrap(
+        let dictionary = try #require(
             try JSONSerialization.jsonObject(with: serialized) as? [String: Any]
         )
-        XCTAssertTrue(Set(dictionary.keys).isSuperset(of: [
+        #expect(Set(dictionary.keys).isSuperset(of: [
             "headers",
             "unary",
             "uri",
             "raw_query_params",
         ]))
-        XCTAssertEqual(try codec.deserialize(source: serialized), self.message)
+        #expect(try codec.deserialize(source: serialized) == self.message)
     }
 
-    func testSerializingAndDeserializingWithCamelCaseFieldNames() throws {
+    @available(iOS 13, *)
+    @Test
+    func serializingAndDeserializingWithCamelCaseFieldNames() throws {
         let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: false)
         let serialized = try codec.serialize(message: self.message)
-        let dictionary = try XCTUnwrap(
+        let dictionary = try #require(
             try JSONSerialization.jsonObject(with: serialized) as? [String: Any]
         )
-        XCTAssertTrue(Set(dictionary.keys).isSuperset(of: [
+        #expect(Set(dictionary.keys).isSuperset(of: [
             "headers",
             "unary",
             "uri",
             "rawQueryParams",
         ]))
-        XCTAssertEqual(try codec.deserialize(source: serialized), self.message)
+        #expect(try codec.deserialize(source: serialized) == self.message)
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtoCodecTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtoCodecTests.swift
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 import Connect
+import Foundation
 import SwiftProtobuf
-import XCTest
+import Testing
 
-final class ProtoCodecTests: XCTestCase {
+struct ProtoCodecTests {
     private let message: Connectrpc_Conformance_V1_RawHTTPRequest = .with { proto in
         proto.body = .unary(Connectrpc_Conformance_V1_MessageContents.with { message in
             message.binary = Data([0x0, 0x1, 0x2, 0x3])
@@ -30,9 +31,11 @@ final class ProtoCodecTests: XCTestCase {
         ]
     }
 
-    func testSerializingAndDeserializing() throws {
+    @available(iOS 13, *)
+    @Test
+    func serializingAndDeserializing() throws {
         let codec = ProtoCodec()
         let serialized = try codec.serialize(message: self.message)
-        XCTAssertEqual(try codec.deserialize(source: serialized), self.message)
+        #expect(try codec.deserialize(source: serialized) == self.message)
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -14,100 +14,114 @@
 
 @testable import Connect
 import Foundation
-import XCTest
+import Testing
 
 private final class NoopInterceptor1: UnaryInterceptor, StreamInterceptor {}
 
 private final class NoopInterceptor2: UnaryInterceptor, StreamInterceptor {}
 
-final class ProtocolClientConfigTests: XCTestCase {
-    func testDefaultResponseCompressionPoolIncludesGzip() {
+struct ProtocolClientConfigTests {
+    @available(iOS 13, *)
+    @Test
+    func defaultResponseCompressionPoolIncludesGzip() {
         let config = ProtocolClientConfig(host: "https://connectrpc.com")
-        XCTAssertTrue(config.responseCompressionPools[0] is GzipCompressionPool)
-        XCTAssertEqual(config.acceptCompressionPoolNames(), ["gzip"])
+        #expect(config.responseCompressionPools[0] is GzipCompressionPool)
+        #expect(config.acceptCompressionPoolNames() == ["gzip"])
     }
 
-    func testShouldCompressDataLargerThanMinBytes() {
+    @available(iOS 13, *)
+    @Test
+    func shouldCompressDataLargerThanMinBytes() {
         let data = Data(repeating: 0xa, count: 50)
         let compression = ProtocolClientConfig.RequestCompression(
             minBytes: 10, pool: GzipCompressionPool()
         )
-        XCTAssertTrue(compression.shouldCompress(data))
+        #expect(compression.shouldCompress(data))
     }
 
-    func testShouldNotCompressDataSmallerThanMinBytes() {
+    @available(iOS 13, *)
+    @Test
+    func shouldNotCompressDataSmallerThanMinBytes() {
         let data = Data(repeating: 0xa, count: 50)
         let compression = ProtocolClientConfig.RequestCompression(
             minBytes: 100, pool: GzipCompressionPool()
         )
-        XCTAssertFalse(compression.shouldCompress(data))
+        #expect(!compression.shouldCompress(data))
     }
 
-    func testCreatingURLsWithVariousHosts() {
+    @available(iOS 13, *)
+    @Test
+    func creatingURLsWithVariousHosts() {
         let rpcPath = Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.unary.path
 
-        XCTAssertEqual(
+        #expect(
             ProtocolClientConfig(host: "https://connectrpc.com")
-                .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/connectrpc.conformance.v1.ConformanceService/Unary"
+                .createURL(forPath: rpcPath).absoluteString
+            == "https://connectrpc.com/connectrpc.conformance.v1.ConformanceService/Unary"
         )
-        XCTAssertEqual(
+        #expect(
             ProtocolClientConfig(host: "https://connectrpc.com/")
-                .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/connectrpc.conformance.v1.ConformanceService/Unary"
+                .createURL(forPath: rpcPath).absoluteString
+            == "https://connectrpc.com/connectrpc.conformance.v1.ConformanceService/Unary"
         )
-        XCTAssertEqual(
+        #expect(
             ProtocolClientConfig(host: "https://connectrpc.com/a")
-                .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/a/connectrpc.conformance.v1.ConformanceService/Unary"
+                .createURL(forPath: rpcPath).absoluteString
+            == "https://connectrpc.com/a/connectrpc.conformance.v1.ConformanceService/Unary"
         )
-        XCTAssertEqual(
+        #expect(
             ProtocolClientConfig(host: "https://connectrpc.com/a/")
-                .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/a/connectrpc.conformance.v1.ConformanceService/Unary"
+                .createURL(forPath: rpcPath).absoluteString
+            == "https://connectrpc.com/a/connectrpc.conformance.v1.ConformanceService/Unary"
         )
-        XCTAssertEqual(
+        #expect(
             ProtocolClientConfig(host: "https://connectrpc.com/a/b/c")
-                .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
+                .createURL(forPath: rpcPath).absoluteString
+            == "https://connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
         )
-        XCTAssertEqual(
+        #expect(
             ProtocolClientConfig(host: "https://connectrpc.com/a/b/c/")
-                .createURL(forPath: rpcPath).absoluteString,
-            "https://connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
+                .createURL(forPath: rpcPath).absoluteString
+            == "https://connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
         )
-        XCTAssertEqual(
+        #expect(
             ProtocolClientConfig(host: "connectrpc.com/a/b/c")
-                .createURL(forPath: rpcPath).absoluteString,
-            "connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
+                .createURL(forPath: rpcPath).absoluteString
+            == "connectrpc.com/a/b/c/connectrpc.conformance.v1.ConformanceService/Unary"
         )
     }
 
-    func testAddsConnectInterceptorLastWhenUsingConnectProtocol() {
+    @available(iOS 13, *)
+    @Test
+    func addsConnectInterceptorLastWhenUsingConnectProtocol() {
         let config = ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             interceptors: [InterceptorFactory { _ in NoopInterceptor1() }]
         )
-        XCTAssertTrue(config.interceptors[0].createUnary(with: config) is NoopInterceptor1)
-        XCTAssertTrue(config.interceptors[1].createUnary(with: config) is ConnectInterceptor)
-        XCTAssertTrue(config.interceptors[0].createStream(with: config) is NoopInterceptor1)
-        XCTAssertTrue(config.interceptors[1].createStream(with: config) is ConnectInterceptor)
+        #expect(config.interceptors[0].createUnary(with: config) is NoopInterceptor1)
+        #expect(config.interceptors[1].createUnary(with: config) is ConnectInterceptor)
+        #expect(config.interceptors[0].createStream(with: config) is NoopInterceptor1)
+        #expect(config.interceptors[1].createStream(with: config) is ConnectInterceptor)
     }
 
-    func testAddsGRPCWebInterceptorLastWhenUsingGRPCWebProtocol() {
+    @available(iOS 13, *)
+    @Test
+    func addsGRPCWebInterceptorLastWhenUsingGRPCWebProtocol() {
         let config = ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .grpcWeb,
             interceptors: [InterceptorFactory { _ in NoopInterceptor1() }]
         )
-        XCTAssertTrue(config.interceptors[0].createUnary(with: config) is NoopInterceptor1)
-        XCTAssertTrue(config.interceptors[1].createUnary(with: config) is GRPCWebInterceptor)
-        XCTAssertTrue(config.interceptors[0].createStream(with: config) is NoopInterceptor1)
-        XCTAssertTrue(config.interceptors[1].createStream(with: config) is GRPCWebInterceptor)
+        #expect(config.interceptors[0].createUnary(with: config) is NoopInterceptor1)
+        #expect(config.interceptors[1].createUnary(with: config) is GRPCWebInterceptor)
+        #expect(config.interceptors[0].createStream(with: config) is NoopInterceptor1)
+        #expect(config.interceptors[1].createStream(with: config) is GRPCWebInterceptor)
     }
 
-    func testAddsProtocolInterceptorLastWhenUsingOtherProtocol() {
+    @available(iOS 13, *)
+    @Test
+    func addsProtocolInterceptorLastWhenUsingOtherProtocol() {
         let config = ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .custom(
@@ -115,13 +129,15 @@ final class ProtocolClientConfigTests: XCTestCase {
             ),
             interceptors: [InterceptorFactory { _ in NoopInterceptor1() }]
         )
-        XCTAssertTrue(config.interceptors[0].createUnary(with: config) is NoopInterceptor1)
-        XCTAssertTrue(config.interceptors[1].createUnary(with: config) is NoopInterceptor2)
-        XCTAssertTrue(config.interceptors[0].createStream(with: config) is NoopInterceptor1)
-        XCTAssertTrue(config.interceptors[1].createStream(with: config) is NoopInterceptor2)
+        #expect(config.interceptors[0].createUnary(with: config) is NoopInterceptor1)
+        #expect(config.interceptors[1].createUnary(with: config) is NoopInterceptor2)
+        #expect(config.interceptors[0].createStream(with: config) is NoopInterceptor1)
+        #expect(config.interceptors[1].createStream(with: config) is NoopInterceptor2)
     }
 
-    func testUnaryGETRequestWithNoSideEffects() {
+    @available(iOS 13, *)
+    @Test
+    func unaryGETRequestWithNoSideEffects() {
         let request = HTTPRequest<Data?>(
             url: URL(string: "https://connectrpc.com")!,
             headers: Headers(),
@@ -130,29 +146,31 @@ final class ProtocolClientConfigTests: XCTestCase {
             trailers: nil,
             idempotencyLevel: .noSideEffects
         )
-        XCTAssertTrue(ProtocolClientConfig(
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .alwaysEnabled
         ).shouldUseUnaryGET(for: request))
-        XCTAssertTrue(ProtocolClientConfig(
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 100)
         ).shouldUseUnaryGET(for: request))
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 2)
         ).shouldUseUnaryGET(for: request))
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .disabled
         ).shouldUseUnaryGET(for: request))
     }
 
-    func testUnaryGETRequestWithIdempotentSideEffects() {
+    @available(iOS 13, *)
+    @Test
+    func unaryGETRequestWithIdempotentSideEffects() {
         let request = HTTPRequest<Data?>(
             url: URL(string: "https://connectrpc.com")!,
             headers: Headers(),
@@ -161,29 +179,31 @@ final class ProtocolClientConfigTests: XCTestCase {
             trailers: nil,
             idempotencyLevel: .idempotent
         )
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .alwaysEnabled
         ).shouldUseUnaryGET(for: request))
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 100)
         ).shouldUseUnaryGET(for: request))
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 2)
         ).shouldUseUnaryGET(for: request))
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .disabled
         ).shouldUseUnaryGET(for: request))
     }
 
-    func testUnaryGETRequestWithUnknownSideEffects() {
+    @available(iOS 13, *)
+    @Test
+    func unaryGETRequestWithUnknownSideEffects() {
         let request = HTTPRequest<Data?>(
             url: URL(string: "https://connectrpc.com")!,
             headers: Headers(),
@@ -192,29 +212,31 @@ final class ProtocolClientConfigTests: XCTestCase {
             trailers: nil,
             idempotencyLevel: .unknown
         )
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .alwaysEnabled
         ).shouldUseUnaryGET(for: request))
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 100)
         ).shouldUseUnaryGET(for: request))
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 2)
         ).shouldUseUnaryGET(for: request))
-        XCTAssertFalse(ProtocolClientConfig(
+        #expect(!ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .disabled
         ).shouldUseUnaryGET(for: request))
     }
 
-    func testTransformToGETWithoutRequestCompression() {
+    @available(iOS 13, *)
+    @Test
+    func transformToGETWithoutRequestCompression() {
         let request = HTTPRequest<Data?>(
             url: URL(string: "https://connectrpc.com")!,
             headers: Headers(),
@@ -232,14 +254,16 @@ final class ProtocolClientConfigTests: XCTestCase {
 
         let requestWithoutCompression = config.transformToGETIfNeeded(request)
 
-        XCTAssertEqual(requestWithoutCompression.method, .get)
-        XCTAssertEqual(
-            requestWithoutCompression.url.absoluteString,
-            "https://connectrpc.com?connect=v1&base64=1&encoding=json&message=AAEC"
+        #expect(requestWithoutCompression.method == .get)
+        #expect(
+            requestWithoutCompression.url.absoluteString
+            == "https://connectrpc.com?connect=v1&base64=1&encoding=json&message=AAEC"
         )
     }
 
-    func testTransformToGETUsesURLSafeBase64() {
+    @available(iOS 13, *)
+    @Test
+    func transformToGETUsesURLSafeBase64() {
         // Data bytes [0x3E, 0x3F, 0xBF, 0xFF] produce "+P+//w==" in standard base64
         // and "Pj-_vw" in raw URL-safe base64 (RFC 4648 §5)
         let request = HTTPRequest<Data?>(
@@ -258,13 +282,15 @@ final class ProtocolClientConfigTests: XCTestCase {
         let getRequest = config.transformToGETIfNeeded(request)
         let url = getRequest.url.absoluteString
         // Must NOT contain + or / (standard base64 chars)
-        XCTAssertFalse(url.contains("+"), "URL must use URL-safe base64, not standard base64")
-        XCTAssertFalse(url.contains("/message/"), "URL must use URL-safe base64")
+        #expect(!url.contains("+"), "URL must use URL-safe base64, not standard base64")
+        #expect(!url.contains("/message/"), "URL must use URL-safe base64")
         // Must contain the URL-safe base64 encoded message
-        XCTAssertTrue(url.contains("message=Pj-__w"), "Expected raw URL-safe base64 encoding")
+        #expect(url.contains("message=Pj-__w"), "Expected raw URL-safe base64 encoding")
     }
 
-    func testTransformToGETWithRequestCompression() {
+    @available(iOS 13, *)
+    @Test
+    func transformToGETWithRequestCompression() {
         let compressedRequest = HTTPRequest<Data?>(
             url: URL(string: "https://connectrpc.com")!,
             headers: [HeaderConstants.contentEncoding: ["gzip"]], // mimics inceptor behavior
@@ -282,10 +308,9 @@ final class ProtocolClientConfigTests: XCTestCase {
 
         let requestWithCompression = config.transformToGETIfNeeded(compressedRequest)
 
-        XCTAssertEqual(requestWithCompression.method, .get)
-        XCTAssertEqual(
-            requestWithCompression.url.absoluteString,
+        #expect(requestWithCompression.method == .get)
+        let expectedURL =
             "https://connectrpc.com?connect=v1&base64=1&compression=gzip&encoding=json&message=AAEC"
-        )
+        #expect(requestWithCompression.url.absoluteString == expectedURL)
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -46,7 +46,7 @@ struct ProtocolClientConfigTests {
         let compression = ProtocolClientConfig.RequestCompression(
             minBytes: 100, pool: GzipCompressionPool()
         )
-        #expect(!compression.shouldCompress(data))
+        #expect(compression.shouldCompress(data) == false)
     }
 
     @available(iOS 13, *)
@@ -156,16 +156,16 @@ struct ProtocolClientConfigTests {
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 100)
         ).shouldUseUnaryGET(for: request))
-        #expect(!ProtocolClientConfig(
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 2)
-        ).shouldUseUnaryGET(for: request))
-        #expect(!ProtocolClientConfig(
+        ).shouldUseUnaryGET(for: request) == false)
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .disabled
-        ).shouldUseUnaryGET(for: request))
+        ).shouldUseUnaryGET(for: request) == false)
     }
 
     @available(iOS 13, *)
@@ -179,26 +179,26 @@ struct ProtocolClientConfigTests {
             trailers: nil,
             idempotencyLevel: .idempotent
         )
-        #expect(!ProtocolClientConfig(
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .alwaysEnabled
-        ).shouldUseUnaryGET(for: request))
-        #expect(!ProtocolClientConfig(
+        ).shouldUseUnaryGET(for: request) == false)
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 100)
-        ).shouldUseUnaryGET(for: request))
-        #expect(!ProtocolClientConfig(
+        ).shouldUseUnaryGET(for: request) == false)
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 2)
-        ).shouldUseUnaryGET(for: request))
-        #expect(!ProtocolClientConfig(
+        ).shouldUseUnaryGET(for: request) == false)
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .disabled
-        ).shouldUseUnaryGET(for: request))
+        ).shouldUseUnaryGET(for: request) == false)
     }
 
     @available(iOS 13, *)
@@ -212,26 +212,26 @@ struct ProtocolClientConfigTests {
             trailers: nil,
             idempotencyLevel: .unknown
         )
-        #expect(!ProtocolClientConfig(
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .alwaysEnabled
-        ).shouldUseUnaryGET(for: request))
-        #expect(!ProtocolClientConfig(
+        ).shouldUseUnaryGET(for: request) == false)
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 100)
-        ).shouldUseUnaryGET(for: request))
-        #expect(!ProtocolClientConfig(
+        ).shouldUseUnaryGET(for: request) == false)
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .enabledForLimitedPayloadSizes(maxBytes: 2)
-        ).shouldUseUnaryGET(for: request))
-        #expect(!ProtocolClientConfig(
+        ).shouldUseUnaryGET(for: request) == false)
+        #expect(ProtocolClientConfig(
             host: "https://connectrpc.com",
             networkProtocol: .connect,
             unaryGET: .disabled
-        ).shouldUseUnaryGET(for: request))
+        ).shouldUseUnaryGET(for: request) == false)
     }
 
     @available(iOS 13, *)
@@ -282,8 +282,8 @@ struct ProtocolClientConfigTests {
         let getRequest = config.transformToGETIfNeeded(request)
         let url = getRequest.url.absoluteString
         // Must NOT contain + or / (standard base64 chars)
-        #expect(!url.contains("+"), "URL must use URL-safe base64, not standard base64")
-        #expect(!url.contains("/message/"), "URL must use URL-safe base64")
+        #expect(url.contains("+") == false, "URL must use URL-safe base64, not standard base64")
+        #expect(url.contains("/message/") == false, "URL must use URL-safe base64")
         // Must contain the URL-safe base64 encoded message
         #expect(url.contains("message=Pj-__w"), "Expected raw URL-safe base64 encoding")
     }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ServiceMetadataTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ServiceMetadataTests.swift
@@ -13,60 +13,62 @@
 // limitations under the License.
 
 import Connect
-import XCTest
+import Testing
 
-final class ServiceMetadataTests: XCTestCase {
-    func testMethodSpecsAreGeneratedCorrectlyForService() {
-        XCTAssertEqual(
-            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.unary,
-            MethodSpec(
+struct ServiceMetadataTests {
+    @available(iOS 13, *)
+    @Test
+    func methodSpecsAreGeneratedCorrectlyForService() {
+        #expect(
+            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.unary
+            == MethodSpec(
                 name: "Unary",
                 service: "connectrpc.conformance.v1.ConformanceService",
                 type: .unary
             )
         )
-        XCTAssertEqual(
-            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.unary.path,
-            "connectrpc.conformance.v1.ConformanceService/Unary"
+        #expect(
+            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.unary.path
+            == "connectrpc.conformance.v1.ConformanceService/Unary"
         )
 
-        XCTAssertEqual(
-            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.serverStream,
-            MethodSpec(
+        #expect(
+            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.serverStream
+            == MethodSpec(
                 name: "ServerStream",
                 service: "connectrpc.conformance.v1.ConformanceService",
                 type: .serverStream
             )
         )
-        XCTAssertEqual(
-            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.serverStream.path,
-            "connectrpc.conformance.v1.ConformanceService/ServerStream"
+        #expect(
+            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.serverStream.path
+            == "connectrpc.conformance.v1.ConformanceService/ServerStream"
         )
 
-        XCTAssertEqual(
-            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.clientStream,
-            MethodSpec(
+        #expect(
+            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.clientStream
+            == MethodSpec(
                 name: "ClientStream",
                 service: "connectrpc.conformance.v1.ConformanceService",
                 type: .clientStream
             )
         )
-        XCTAssertEqual(
-            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.clientStream.path,
-            "connectrpc.conformance.v1.ConformanceService/ClientStream"
+        #expect(
+            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.clientStream.path
+            == "connectrpc.conformance.v1.ConformanceService/ClientStream"
         )
 
-        XCTAssertEqual(
-            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.bidiStream,
-            MethodSpec(
+        #expect(
+            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.bidiStream
+            == MethodSpec(
                 name: "BidiStream",
                 service: "connectrpc.conformance.v1.ConformanceService",
                 type: .bidirectionalStream
             )
         )
-        XCTAssertEqual(
-            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.bidiStream.path,
-            "connectrpc.conformance.v1.ConformanceService/BidiStream"
+        #expect(
+            Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.bidiStream.path
+            == "connectrpc.conformance.v1.ConformanceService/BidiStream"
         )
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTests.swift
@@ -14,22 +14,25 @@
 
 @testable import Connect
 import Foundation
-import XCTest
+import Testing
 
-@available(iOS 13, *)
-final class TimeoutTests: XCTestCase {
-    func testUnaryRequestTimesOut() async {
+struct TimeoutTests {
+    @available(iOS 13, *)
+    @Test
+    func unaryRequestTimesOut() async {
         let client = self.makeClient()
         let response = await client.unary(request: .with { request in
             request.responseDefinition = .with { _ in }
         })
 
-        XCTAssertEqual(response.code, .deadlineExceeded)
-        XCTAssertEqual(response.error?.code, .deadlineExceeded)
-        XCTAssertEqual(response.error?.message, "request exceeded allowed timeout")
+        #expect(response.code == .deadlineExceeded)
+        #expect(response.error?.code == .deadlineExceeded)
+        #expect(response.error?.message == "request exceeded allowed timeout")
     }
 
-    func testStreamRequestTimesOut() async throws {
+    @available(iOS 13, *)
+    @Test
+    func streamRequestTimesOut() async throws {
         let client = self.makeClient()
         let stream = client.serverStream()
         try stream.send(.with { request in
@@ -42,12 +45,13 @@ final class TimeoutTests: XCTestCase {
         }
 
         guard case .complete(let code, let error, _) = completion else {
-            return XCTFail("Expected stream to complete with a timeout error.")
+            Issue.record("Expected stream to complete with a timeout error.")
+            return
         }
 
-        XCTAssertEqual(code, .deadlineExceeded)
-        XCTAssertEqual((error as? ConnectError)?.code, .deadlineExceeded)
-        XCTAssertEqual((error as? ConnectError)?.message, "request exceeded allowed timeout")
+        #expect(code == .deadlineExceeded)
+        #expect((error as? ConnectError)?.code == .deadlineExceeded)
+        #expect((error as? ConnectError)?.message == "request exceeded allowed timeout")
     }
 
     private func makeClient() -> Connectrpc_Conformance_V1_ConformanceServiceClient {

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/URLSessionStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/URLSessionStreamTests.swift
@@ -14,14 +14,16 @@
 
 @testable import Connect
 import Foundation
-import XCTest
+import Testing
 
-final class URLSessionStreamTests: XCTestCase {
+struct URLSessionStreamTests {
     /// `URLSession` requests a body stream via `urlSession(_:task:needNewBodyStream:)` both for the
     /// initial send and when it resends a request after a recoverable error. A streamed request
     /// body cannot be replayed, and returning the same already-opened stream on a resend crashes
     /// CFNetwork. The stream must therefore be vended only once.
-    func testVendsRequestBodyStreamOnlyOnce() {
+    @available(iOS 13, *)
+    @Test
+    func vendsRequestBodyStreamOnlyOnce() {
         let stream = URLSessionStream(
             request: URLRequest(url: URL(string: "https://connectrpc.com")!),
             session: URLSession(configuration: .ephemeral),
@@ -34,9 +36,9 @@ final class URLSessionStreamTests: XCTestCase {
         )
         defer { stream.cancel() }
 
-        XCTAssertNotNil(stream.requestBodyStream, "The initial body stream should be vended.")
-        XCTAssertNil(
-            stream.requestBodyStream,
+        #expect(stream.requestBodyStream != nil, "The initial body stream should be vended.")
+        #expect(
+            stream.requestBodyStream == nil,
             "A resend must not reuse the already-opened body stream."
         )
     }

--- a/Tests/UnitTests/ConnectPluginUtilitiesTests/FilePathComponentsTests.swift
+++ b/Tests/UnitTests/ConnectPluginUtilitiesTests/FilePathComponentsTests.swift
@@ -14,82 +14,83 @@
 
 @testable import ConnectPluginUtilities
 import Foundation
-import XCTest
+import Testing
 
-final class FilePathComponentsTests: XCTestCase {
-    func testProtoFilePathWithLeadingSlash() {
-        let components = FilePathComponents(path: "/foo/bar/baz.proto")
-        XCTAssertEqual(components.directory, "/foo/bar")
-        XCTAssertEqual(components.base, "baz")
-        XCTAssertEqual(components.suffix, ".proto")
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .fullPath),
-            "/foo/bar/baz.connect.swift"
-        )
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .dropPath),
-            "baz.connect.swift"
-        )
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .pathToUnderscores),
-            "foo_bar_baz.connect.swift"
-        )
+struct FilePathComponentsTests {
+    struct TestCase: Sendable {
+        let path: String
+        let expectedDirectory: String
+        let expectedBase: String
+        let expectedSuffix: String
+        let expectedFullPathOutput: String
+        let expectedDropPathOutput: String
+        let expectedPathToUnderscoresOutput: String
     }
 
-    func testProtoFilePathWithoutLeadingSlash() {
-        let components = FilePathComponents(path: "foo/bar/baz.proto")
-        XCTAssertEqual(components.directory, "foo/bar")
-        XCTAssertEqual(components.base, "baz")
-        XCTAssertEqual(components.suffix, ".proto")
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .fullPath),
-            "foo/bar/baz.connect.swift"
+    static let testCases: [TestCase] = [
+        TestCase(
+            path: "/foo/bar/baz.proto",
+            expectedDirectory: "/foo/bar",
+            expectedBase: "baz",
+            expectedSuffix: ".proto",
+            expectedFullPathOutput: "/foo/bar/baz.connect.swift",
+            expectedDropPathOutput: "baz.connect.swift",
+            expectedPathToUnderscoresOutput: "foo_bar_baz.connect.swift"
+        ),
+        TestCase(
+            path: "foo/bar/baz.proto",
+            expectedDirectory: "foo/bar",
+            expectedBase: "baz",
+            expectedSuffix: ".proto",
+            expectedFullPathOutput: "foo/bar/baz.connect.swift",
+            expectedDropPathOutput: "baz.connect.swift",
+            expectedPathToUnderscoresOutput: "foo_bar_baz.connect.swift"
+        ),
+        TestCase(
+            path: "baz.proto",
+            expectedDirectory: "",
+            expectedBase: "baz",
+            expectedSuffix: ".proto",
+            expectedFullPathOutput: "baz.connect.swift",
+            expectedDropPathOutput: "baz.connect.swift",
+            expectedPathToUnderscoresOutput: "baz.connect.swift"
+        ),
+        TestCase(
+            path: "/baz.proto",
+            expectedDirectory: "",
+            expectedBase: "baz",
+            expectedSuffix: ".proto",
+            expectedFullPathOutput: "baz.connect.swift",
+            expectedDropPathOutput: "baz.connect.swift",
+            expectedPathToUnderscoresOutput: "baz.connect.swift"
+        ),
+    ]
+
+    @available(iOS 13, *)
+    @Test(arguments: Self.testCases)
+    func splitsProtoFilePath(testCase: TestCase) {
+        let components = FilePathComponents(path: testCase.path)
+        #expect(components.directory == testCase.expectedDirectory)
+        #expect(components.base == testCase.expectedBase)
+        #expect(components.suffix == testCase.expectedSuffix)
+        #expect(
+            components.outputFilePath(withExtension: ".connect.swift", using: .fullPath)
+            == testCase.expectedFullPathOutput
         )
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .dropPath),
-            "baz.connect.swift"
+        #expect(
+            components.outputFilePath(withExtension: ".connect.swift", using: .dropPath)
+            == testCase.expectedDropPathOutput
         )
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .pathToUnderscores),
-            "foo_bar_baz.connect.swift"
+        #expect(
+            components.outputFilePath(withExtension: ".connect.swift", using: .pathToUnderscores)
+            == testCase.expectedPathToUnderscoresOutput
         )
     }
+}
 
-    func testProtoFilePathWithoutDirectoryOrLeadingSlash() {
-        let components = FilePathComponents(path: "baz.proto")
-        XCTAssertEqual(components.directory, "")
-        XCTAssertEqual(components.base, "baz")
-        XCTAssertEqual(components.suffix, ".proto")
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .fullPath),
-            "baz.connect.swift"
-        )
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .dropPath),
-            "baz.connect.swift"
-        )
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .pathToUnderscores),
-            "baz.connect.swift"
-        )
-    }
-
-    func testProtoFilePathWithoutDirectoryButWithLeadingSlash() {
-        let components = FilePathComponents(path: "/baz.proto")
-        XCTAssertEqual(components.directory, "")
-        XCTAssertEqual(components.base, "baz")
-        XCTAssertEqual(components.suffix, ".proto")
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .fullPath),
-            "baz.connect.swift"
-        )
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .dropPath),
-            "baz.connect.swift"
-        )
-        XCTAssertEqual(
-            components.outputFilePath(withExtension: ".connect.swift", using: .pathToUnderscores),
-            "baz.connect.swift"
-        )
+@available(iOS 13, *)
+extension FilePathComponentsTests.TestCase: CustomTestStringConvertible {
+    var testDescription: String {
+        self.path
     }
 }

--- a/Tests/UnitTests/README.md
+++ b/Tests/UnitTests/README.md
@@ -1,4 +1,4 @@
 # UnitTests
 
-This directory contains categorizations of `XCTestCase` classes to validate
+This directory contains categorizations of Swift Testing suites to validate
 various library and plugin behaviors.


### PR DESCRIPTION
**Contribution guide:** read and followed per https://github.com/connectrpc/connect-swift/blob/main/.github/CONTRIBUTING.md

## Summary

Migrates all 15 unit test suites under `Tests/UnitTests` (`ConnectLibraryTests` and `ConnectPluginUtilitiesTests`) from XCTest to [Swift Testing](https://developer.apple.com/documentation/testing), one suite per commit for reviewability. No `Package.swift`, CI, or Makefile changes were needed — `swift test` discovers Swift Testing tests as-is.

**Mechanical conversions:** `XCTestCase` classes → struct suites; `XCTAssert*` → `#expect`; `XCTUnwrap` → `#require`; `XCTFail` → `Issue.record`; `XCTAssertThrowsError` → typed `#expect(throws:)`.

**Notable decisions:**
- The four near-identical `FilePathComponentsTests` methods are collapsed into one parameterized `@Test(arguments:)` (72 original methods → 69 discovered tests; no coverage lost).
- Each `@Test` function carries `@available(iOS 13, *)` because the package's iOS floor is 12, below Swift Testing's iOS 13 minimum. The annotation must be per-function: the `@Test` macro rejects test functions inside `@available` types.
- `InterceptorIntegrationTests` is `@Suite(.serialized)` (documented in-source): Swift Testing parallelizes by default, and these tests share the live conformance reference server on port 52107 and assert timing-sensitive URLSession metrics. Its blocking `sleep(1)` is now a cooperative `Task.sleep`. The iOS 16+ metrics tests also carry a one-minute `.timeLimit` so a hung reference server fails CI instead of hanging it.

**Lint changes (`.swiftlint.yml`):** removes the now-dead XCTest rules (`empty_xctest_method`, `xct_specific_matcher`, custom `xctestcase`). No Swift Testing–specific lint rules are added; `@Test` attributes follow the existing `attributes` opt-in rule (own line above the function).

## Test plan

- [x] `swift test` via `make testunit` (against the conformance reference server): 69 tests in 15 suites pass.
- [x] `xcodebuild test` on iOS Simulator (iPhone 17 Pro) with the reference server running: all tests pass, confirming the iOS 12 deployment target compiles with the availability annotations.
- [x] `make testconformance`: 966/966 (URLSession) and 1681/1681 (NIO) conformance cases pass.
- [x] `swiftlint lint --strict`: 0 violations.
