### PR TITLE
Update CI actions + Xcode versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   # Sets the Xcode version to use for the CI.
   # Available versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode
   # Ref: https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
-  DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
 permissions:
   contents: read
 jobs:
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.24.x
       - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
   run-swiftlint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/realm/swiftlint:0.58.2
+      image: ghcr.io/realm/swiftlint:0.65.0
     steps:
       - uses: actions/checkout@v7
       - name: Run SwiftLint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   # Sets the Xcode version to use for the CI.
   # Available versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode
   # Ref: https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/
-  DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
 permissions:
   contents: write
 jobs:

--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -280,7 +280,7 @@ extension Code {
         case ...100: // URLSession can return errors in this range
             return .unknown
         default:
-            return Code.fromHTTPStatus(code)
+            return Self.fromHTTPStatus(code)
         }
     }
 }

--- a/Libraries/Connect/Public/Interfaces/ConnectError.swift
+++ b/Libraries/Connect/Public/Interfaces/ConnectError.swift
@@ -138,7 +138,7 @@ extension ConnectError {
         }
 
         do {
-            return try ConnectError.decode(from: source, defaultCode: code, metadata: metadata)
+            return try Self.decode(from: source, defaultCode: code, metadata: metadata)
         } catch let error {
             return .init(
                 code: code, message: String(data: source, encoding: .utf8),


### PR DESCRIPTION
- Targets Xcode 26.6, which is the latest available on GitHub runners at the time of writing
- Bumps our `setup-go` action to the latest major version
- Bumps our pinned SwiftLint version to 0.65.0 and fixes the two `prefer_self_in_static_references` violations it surfaced