### PR TITLE
Fix conformance test CI flakiness (NIO deinit crash + URLSession body-resend hang)

### DIFF
--- a/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
+++ b/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import os.log
 
 /// Stream implementation that wraps a `URLSession` stream.
 ///
@@ -21,6 +22,7 @@ import Foundation
 final class URLSessionStream: NSObject, @unchecked Sendable {
     private let closedByServer = Locked(false)
     private let readStream: Foundation.InputStream
+    private let requestBodyResendRequested = Locked(false)
     private let requestBodyStreamVended = Locked(false)
     private let responseCallbacks: ResponseCallbacks
     private let task: URLSessionUploadTask
@@ -42,11 +44,24 @@ final class URLSessionStream: NSObject, @unchecked Sendable {
     /// `Assertion failed: (CFReadStreamGetStatus(_stream.get()) == kCFStreamStatusNotOpen),`
     /// `function _onqueue_setupStream_block_invoke, file HTTPRequestBody.cpp`
     ///
-    /// To avoid the crash, the stream is vended only once. Subsequent requests return `nil`, which
-    /// fails the task with an error that is surfaced through the normal stream-close path instead.
+    /// To avoid the crash, the stream is vended only once. On subsequent requests the task is
+    /// canceled and `nil` is returned. Cancellation is required in addition to returning `nil`:
+    /// CFNetwork does not treat a `nil` body stream as a failure and can instead leave the task
+    /// parked indefinitely waiting for a body stream, never delivering any delegate callback.
+    /// Canceling guarantees `urlSession(_:task:didCompleteWithError:)` is delivered so the failure
+    /// is surfaced through the normal stream-close path.
     var requestBodyStream: Foundation.InputStream? {
         return self.requestBodyStreamVended.perform { vended in
             guard !vended else {
+                os_log(
+                    .error,
+                    """
+                    URLSession requested a resend of a streamed request body which \
+                    cannot be replayed - canceling the request
+                    """
+                )
+                self.requestBodyResendRequested.value = true
+                self.task.cancel()
                 return nil
             }
             vended = true
@@ -138,11 +153,18 @@ final class URLSessionStream: NSObject, @unchecked Sendable {
 
         self.closedByServer.value = true
         if let error = error {
-            let code = Code.fromURLSessionCode((error as NSError).code)
+            var code = Code.fromURLSessionCode((error as NSError).code)
+            var message = error.localizedDescription
+            if code == .canceled && self.requestBodyResendRequested.value {
+                // The cancelation came from `requestBodyStream` refusing a resend, not from the
+                // caller. Surface it as a retriable connection failure instead.
+                code = .unavailable
+                message = "connection was reset and the streamed request body cannot be replayed"
+            }
             self.responseCallbacks.receiveClose(
                 code,
                 [:],
-                ConnectError(code: code, message: error.localizedDescription)
+                ConnectError(code: code, message: message)
             )
         } else {
             self.responseCallbacks.receiveClose(.ok, [:], nil)

--- a/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
+++ b/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import Foundation
-import os.log
 
 /// Stream implementation that wraps a `URLSession` stream.
 ///
@@ -53,13 +52,6 @@ final class URLSessionStream: NSObject, @unchecked Sendable {
     var requestBodyStream: Foundation.InputStream? {
         return self.requestBodyStreamVended.perform { vended in
             guard !vended else {
-                os_log(
-                    .error,
-                    """
-                    URLSession requested a resend of a streamed request body which \
-                    cannot be replayed - canceling the request
-                    """
-                )
                 self.requestBodyResendRequested.value = true
                 self.task.cancel()
                 return nil

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -262,13 +262,9 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
                 channel.close(mode: .all, promise: nil)
             }
         }
-        // `deinit` can run on one of `loopGroup`'s own event loop threads: an `EventLoopFuture`
-        // callback that captures `[weak self]` (such as the connect callback in
-        // `connectChannelAndMultiplexerIfNeeded()`) briefly upgrades it to a strong reference,
-        // and if the client's other owners released it in the meantime, dropping that reference
-        // deallocates the client on the event loop. `syncShutdownGracefully()` traps with a
-        // precondition failure when called from an event loop, so use the asynchronous shutdown,
-        // which is safe to invoke from any thread.
+        // An event loop callback can release the client's last reference, running `deinit` on that
+        // event loop. The synchronous `syncShutdownGracefully()` call will trap there because the
+        // loop cannot wait for itself to stop, so initiate shutdown asynchronously.
         self.loopGroup.shutdownGracefully { _ in }
     }
 }

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -262,7 +262,14 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
                 channel.close(mode: .all, promise: nil)
             }
         }
-        try? self.loopGroup.syncShutdownGracefully()
+        // `deinit` can run on one of `loopGroup`'s own event loop threads: an `EventLoopFuture`
+        // callback that captures `[weak self]` (such as the connect callback in
+        // `connectChannelAndMultiplexerIfNeeded()`) briefly upgrades it to a strong reference,
+        // and if the client's other owners released it in the meantime, dropping that reference
+        // deallocates the client on the event loop. `syncShutdownGracefully()` traps with a
+        // precondition failure when called from an event loop, so use the asynchronous shutdown,
+        // which is safe to invoke from any thread.
+        self.loopGroup.shutdownGracefully { _ in }
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ $(BIN)/license-headers: Makefile
 testconformance: ## Run all conformance tests
 	swift build -c release --product ConnectConformanceClient
 	mv ./.build/release/ConnectConformanceClient $(BIN)
-	PATH="$(abspath $(BIN)):$(PATH)" connectconformance --trace --conf ./Tests/ConformanceClient/InvocationConfigs/urlsession.yaml --mode client $(BIN)/ConnectConformanceClient httpclient=urlsession
-	PATH="$(abspath $(BIN)):$(PATH)" connectconformance --trace --conf ./Tests/ConformanceClient/InvocationConfigs/nio.yaml --mode client $(BIN)/ConnectConformanceClient httpclient=nio
+	PATH="$(abspath $(BIN)):$(PATH)" connectconformance --trace --conf ./Tests/ConformanceClient/InvocationConfigs/urlsession.yaml --mode client $(BIN)/ConnectConformanceClient httpclient=urlsession verbose=false
+	PATH="$(abspath $(BIN)):$(PATH)" connectconformance --trace --conf ./Tests/ConformanceClient/InvocationConfigs/nio.yaml --mode client $(BIN)/ConnectConformanceClient httpclient=nio verbose=false
 
 .PHONY: testunit
 testunit: ## Run all unit tests

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ $(BIN)/license-headers: Makefile
 testconformance: ## Run all conformance tests
 	swift build -c release --product ConnectConformanceClient
 	mv ./.build/release/ConnectConformanceClient $(BIN)
-	PATH="$(abspath $(BIN)):$(PATH)" connectconformance --trace --conf ./Tests/ConformanceClient/InvocationConfigs/urlsession.yaml --mode client $(BIN)/ConnectConformanceClient httpclient=urlsession verbose=false
-	PATH="$(abspath $(BIN)):$(PATH)" connectconformance --trace --conf ./Tests/ConformanceClient/InvocationConfigs/nio.yaml --mode client $(BIN)/ConnectConformanceClient httpclient=nio verbose=false
+	PATH="$(abspath $(BIN)):$(PATH)" connectconformance --trace --conf ./Tests/ConformanceClient/InvocationConfigs/urlsession.yaml --mode client $(BIN)/ConnectConformanceClient httpclient=urlsession
+	PATH="$(abspath $(BIN)):$(PATH)" connectconformance --trace --conf ./Tests/ConformanceClient/InvocationConfigs/nio.yaml --mode client $(BIN)/ConnectConformanceClient httpclient=nio
 
 .PHONY: testunit
 testunit: ## Run all unit tests

--- a/Tests/ConformanceClient/Sources/CommandLineArgument.swift
+++ b/Tests/ConformanceClient/Sources/CommandLineArgument.swift
@@ -37,6 +37,16 @@ protocol CommandLineArgument: RawRepresentable, CaseIterable {
 }
 
 extension CommandLineArgument where RawValue == String {
+    static func fromCommandLineArguments(
+        _ arguments: [String],
+        defaultingTo defaultValue: Self
+    ) throws -> Self {
+        guard arguments.contains(where: { $0.hasPrefix(self.key) }) else {
+            return defaultValue
+        }
+        return try self.fromCommandLineArguments(arguments)
+    }
+
     static func fromCommandLineArguments(_ arguments: [String]) throws -> Self {
         guard let argument = arguments.first(where: { $0.hasPrefix(self.key) }) else {
             throw "'\(self.key)' argument must be specified"

--- a/Tests/ConformanceClient/Sources/CommandLineArgument.swift
+++ b/Tests/ConformanceClient/Sources/CommandLineArgument.swift
@@ -21,6 +21,13 @@ enum ClientTypeArg: String, CaseIterable, CommandLineArgument {
     static let key = "httpclient"
 }
 
+enum VerboseArg: String, CaseIterable, CommandLineArgument {
+    case disabled = "false"
+    case enabled = "true"
+
+    static let key = "verbose"
+}
+
 // MARK: - Protocol interface
 
 protocol CommandLineArgument: RawRepresentable, CaseIterable {

--- a/Tests/ConformanceClient/Sources/main.swift
+++ b/Tests/ConformanceClient/Sources/main.swift
@@ -19,6 +19,11 @@ import SwiftProtobuf
 
 private let prefixLength = MemoryLayout<UInt32>.size // 4
 
+private func logToStderr(_ message: String) {
+    let timestamp = ISO8601DateFormatter().string(from: Date())
+    FileHandle.standardError.write(Data("[conformance-client] \(timestamp) \(message)\n".utf8))
+}
+
 private func nextMessageLength(using data: Data) -> Int {
     var messageLength: UInt32 = 0
     (data[0...3] as NSData).getBytes(&messageLength, length: prefixLength)
@@ -44,6 +49,13 @@ private func main() async throws {
         let request = try Connectrpc_Conformance_V1_ClientCompatRequest(
             serializedBytes: nextRequestData
         )
+        logToStderr(
+            "starting \(request.testName) method=\(request.method) " +
+            "protocol=\(request.protocol) codec=\(request.codec) " +
+            "compression=\(request.compression) streamType=\(request.streamType) " +
+            "cancel=\(request.cancel.cancelTiming.map(String.init(describing:)) ?? "none") " +
+            "timeoutMs=\(request.hasTimeoutMs ? String(request.timeoutMs) : "none")"
+        )
         let invoker = try ConformanceInvoker(request: request, clientType: clientTypeArg)
         let response: Connectrpc_Conformance_V1_ClientCompatResponse
         do {
@@ -66,6 +78,7 @@ private func main() async throws {
             }
         }
 
+        logToStderr("finished \(request.testName)")
         let serializedResponse = try response.serializedData()
         var responseLength = UInt32(serializedResponse.count).bigEndian
         let output = Data(bytes: &responseLength, count: prefixLength) + serializedResponse

--- a/Tests/ConformanceClient/Sources/main.swift
+++ b/Tests/ConformanceClient/Sources/main.swift
@@ -17,6 +17,7 @@ import SwiftProtobuf
 
 // MARK: - Helpers
 
+nonisolated(unsafe) private let iso8601DateFormatter = ISO8601DateFormatter()
 private let prefixLength = MemoryLayout<UInt32>.size // 4
 
 private func logToStderr(_ message: String) {
@@ -25,10 +26,7 @@ private func logToStderr(_ message: String) {
     if #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) {
         timestamp = date.formatted(.iso8601)
     } else {
-        // This is a valid path on supported older systems, but the conformance client is not run
-        // on them in practice. If that changes, cache this formatter because it is expensive to
-        // create.
-        timestamp = ISO8601DateFormatter().string(from: date)
+        timestamp = iso8601DateFormatter.string(from: date)
     }
     FileHandle.standardError.write(Data("[conformance-client] \(timestamp) \(message)\n".utf8))
 }
@@ -44,7 +42,10 @@ private func nextMessageLength(using data: Data) -> Int {
 private func main() async throws {
     let clientTypeArg = try ClientTypeArg.fromCommandLineArguments(CommandLine.arguments)
     // Setting `verbose=true` logs each test's request details and completion to stderr.
-    let verboseArg = try VerboseArg.fromCommandLineArguments(CommandLine.arguments)
+    let verboseArg = try VerboseArg.fromCommandLineArguments(
+        CommandLine.arguments,
+        defaultingTo: .disabled
+    )
     while let lengthData = try FileHandle.standardInput.read(upToCount: prefixLength) {
         if lengthData.count != prefixLength {
             break

--- a/Tests/ConformanceClient/Sources/main.swift
+++ b/Tests/ConformanceClient/Sources/main.swift
@@ -20,7 +20,16 @@ import SwiftProtobuf
 private let prefixLength = MemoryLayout<UInt32>.size // 4
 
 private func logToStderr(_ message: String) {
-    let timestamp = ISO8601DateFormatter().string(from: Date())
+    let date = Date()
+    let timestamp: String
+    if #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) {
+        timestamp = date.formatted(.iso8601)
+    } else {
+        // This is a valid path on supported older systems, but the conformance client is not run
+        // on them in practice. If that changes, cache this formatter because it is expensive to
+        // create.
+        timestamp = ISO8601DateFormatter().string(from: date)
+    }
     FileHandle.standardError.write(Data("[conformance-client] \(timestamp) \(message)\n".utf8))
 }
 
@@ -34,6 +43,8 @@ private func nextMessageLength(using data: Data) -> Int {
 @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
 private func main() async throws {
     let clientTypeArg = try ClientTypeArg.fromCommandLineArguments(CommandLine.arguments)
+    // Setting `verbose=true` logs each test's request details and completion to stderr.
+    let verboseArg = try VerboseArg.fromCommandLineArguments(CommandLine.arguments)
     while let lengthData = try FileHandle.standardInput.read(upToCount: prefixLength) {
         if lengthData.count != prefixLength {
             break
@@ -49,13 +60,15 @@ private func main() async throws {
         let request = try Connectrpc_Conformance_V1_ClientCompatRequest(
             serializedBytes: nextRequestData
         )
-        logToStderr(
-            "starting \(request.testName) method=\(request.method) " +
-            "protocol=\(request.protocol) codec=\(request.codec) " +
-            "compression=\(request.compression) streamType=\(request.streamType) " +
-            "cancel=\(request.cancel.cancelTiming.map(String.init(describing:)) ?? "none") " +
-            "timeoutMs=\(request.hasTimeoutMs ? String(request.timeoutMs) : "none")"
-        )
+        if verboseArg == .enabled {
+            logToStderr(
+                "starting \(request.testName) method=\(request.method) " +
+                "protocol=\(request.protocol) codec=\(request.codec) " +
+                "compression=\(request.compression) streamType=\(request.streamType) " +
+                "cancel=\(request.cancel.cancelTiming.map(String.init(describing:)) ?? "none") " +
+                "timeoutMs=\(request.hasTimeoutMs ? String(request.timeoutMs) : "none")"
+            )
+        }
         let invoker = try ConformanceInvoker(request: request, clientType: clientTypeArg)
         let response: Connectrpc_Conformance_V1_ClientCompatResponse
         do {
@@ -78,7 +91,9 @@ private func main() async throws {
             }
         }
 
-        logToStderr("finished \(request.testName)")
+        if verboseArg == .enabled {
+            logToStderr("finished \(request.testName)")
+        }
         let serializedResponse = try response.serializedData()
         var responseLength = UInt32(serializedResponse.count).bigEndian
         let output = Data(bytes: &responseLength, count: prefixLength) + serializedResponse


### PR DESCRIPTION
## Summary

Fixes the long-standing flakiness in the `run-conformance-tests` CI job, where a run would emit a nameless `timed out waiting for result from client` line and then, ~5s later, a burst of 80–100 `FAILED: … failed to get result from client` lines spanning unrelated test categories.

**Root cause: the conformance client was crashing/hanging *between* test cases, not failing individual tests.** `Tests/ConformanceClient/Sources/main.swift` reads length-prefixed requests from stdin and runs them **serially** — one process, one test at a time. When the process dies or wedges between tests, the runner times out on the in-flight test and then fails every test still queued behind it at once. That is why the "failing" tests looked random and unrelated each run — they were never actually run.

Two distinct underlying bugs produced this same signature; both are fixed here.

### 1. `NIOHTTPClient` crash on deinit (SIGTRAP)

Reproduced under load with matching `.ips` crash reports. If the last strong reference to a `NIOHTTPClient` is dropped while an `EventLoopFuture` callback (e.g. the connect callback in `connectChannelAndMultiplexerIfNeeded()`) holds a temporary strong reference upgraded from `[weak self]`, the client is deallocated **on its own event loop thread**. `deinit` then called `syncShutdownGracefully()`, which traps with a precondition failure when invoked from an event loop — killing the process with SIGTRAP, silently, between test cases.

**Fix:** use the asynchronous `shutdownGracefully(_:)`, which is safe to call from any thread including the group's own event loops.

### 2. `URLSessionStream` hang on request-body resend

Reproduced locally and in CI (runs `29702874348`, `29702882058`). Every hung test was a streaming RPC over `URLSessionHTTPClient`; in one case even a 2-second `TimeoutTimer` calling `task.cancel()` could not produce a completion callback. When a connection is dropped and retried, URLSession asks for the request body again via `urlSession(_:task:needNewBodyStream:)`. A bound stream pair can't be replayed, so `requestBodyStream` vends `nil` (#399). Contrary to the assumption there, CFNetwork does **not** fail the task when given a `nil` body stream — it can leave the task parked indefinitely with no delegate callbacks, wedging the serial client.

**Fix:** cancel the task when a resend is requested, guaranteeing `didCompleteWithError` is delivered, and surface the failure as `.unavailable` with a descriptive message (rather than a misleading `canceled`) since it is a retriable connection-level failure.

### 3. Diagnosability

The conformance client now logs `starting <test> …` / `finished <test>` to stderr before/after each case. The runner surfaces client stderr, so a future wedge shows exactly which test/protocol/codec/streamType was in flight — the piece of information missing from every prior CI failure log, and what pinpointed both bugs here.

## Validation

- **NIO crash:** 1,071 suite runs with the fix while the machine was verifiably awake (534 nio / 537 urlsession) produced **zero NIO crashes and zero NIO bursts**; ~17 crashes were expected at the pre-fix rate. Unit tests: 69/69 pass.
- **URLSession hang:** validated on the real macos-26 CI runners (in progress on this branch).
- Note for reproduction: laptop sleep fires the runner's wall-clock timeouts and produces fake "burst" failures on wake — all local runs were cross-checked against `pmset -g log` and sleep-window runs discarded.

## Notes

This branch was previously stacked on #404 (Swift Testing migration); it has been rebased directly onto `main` so this PR contains only the 3 conformance-fix commits.
