### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/Connect-Swift-Mocks.podspec
+++ b/Connect-Swift-Mocks.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
   spec.watchos.deployment_target = '6.0'
 
   spec.dependency 'Connect-Swift', "#{spec.version.to_s}"
-  spec.dependency 'SwiftProtobuf', '~> 1.31.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.38.1'
 
   spec.source_files = 'Libraries/ConnectMocks/**/*.swift'
 

--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '13.0'
   spec.watchos.deployment_target = '6.0'
 
-  spec.dependency 'SwiftProtobuf', '~> 1.31.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.38.1'
 
   spec.source_files = 'Libraries/Connect/**/*.swift'
 

--- a/Examples/ElizaCocoaPodsApp/Podfile.lock
+++ b/Examples/ElizaCocoaPodsApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Connect-Swift (1.2.3):
-    - SwiftProtobuf (~> 1.31.0)
-  - SwiftProtobuf (1.31.2)
+    - SwiftProtobuf (~> 1.38.1)
+  - SwiftProtobuf (1.38.1)
 
 DEPENDENCIES:
   - Connect-Swift (from `../..`)
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Connect-Swift: bc264586ce0f2d7e29fef88d6c128c5035bec5f9
-  SwiftProtobuf: ce756ec42f1ba5fb688642eb3e0bb28a02dde8e0
+  Connect-Swift: cf227f8460d3c73adfc2dd8b7f4cc60ea91e9e0d
+  SwiftProtobuf: 409d3aaec90e51b1705b1dd8065b56893450e77c
 
 PODFILE CHECKSUM: b598f373a6ab5add976b09c2ac79029bf2200d48
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/Examples/ElizaSharedSources/GeneratedSources/connectrpc/eliza/v1/eliza.pb.swift
+++ b/Examples/ElizaSharedSources/GeneratedSources/connectrpc/eliza/v1/eliza.pb.swift
@@ -29,13 +29,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// SayRequest is a single-sentence request.
-struct Connectrpc_Eliza_V1_SayRequest: Sendable {
+nonisolated struct Connectrpc_Eliza_V1_SayRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -48,7 +48,7 @@ struct Connectrpc_Eliza_V1_SayRequest: Sendable {
 }
 
 /// SayResponse is a single-sentence response.
-struct Connectrpc_Eliza_V1_SayResponse: Sendable {
+nonisolated struct Connectrpc_Eliza_V1_SayResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -62,7 +62,7 @@ struct Connectrpc_Eliza_V1_SayResponse: Sendable {
 
 /// ConverseRequest is a single sentence request sent as part of a
 /// back-and-forth conversation.
-struct Connectrpc_Eliza_V1_ConverseRequest: Sendable {
+nonisolated struct Connectrpc_Eliza_V1_ConverseRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -76,7 +76,7 @@ struct Connectrpc_Eliza_V1_ConverseRequest: Sendable {
 
 /// ConverseResponse is a single sentence response sent in answer to a
 /// ConverseRequest.
-struct Connectrpc_Eliza_V1_ConverseResponse: Sendable {
+nonisolated struct Connectrpc_Eliza_V1_ConverseResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -89,7 +89,7 @@ struct Connectrpc_Eliza_V1_ConverseResponse: Sendable {
 }
 
 /// IntroduceRequest asks Eliza to introduce itself to the named user.
-struct Connectrpc_Eliza_V1_IntroduceRequest: Sendable {
+nonisolated struct Connectrpc_Eliza_V1_IntroduceRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -102,7 +102,7 @@ struct Connectrpc_Eliza_V1_IntroduceRequest: Sendable {
 }
 
 /// IntroduceResponse is one sentence of Eliza's introductory monologue.
-struct Connectrpc_Eliza_V1_IntroduceResponse: Sendable {
+nonisolated struct Connectrpc_Eliza_V1_IntroduceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -116,9 +116,9 @@ struct Connectrpc_Eliza_V1_IntroduceResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.eliza.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.eliza.v1"
 
-extension Connectrpc_Eliza_V1_SayRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Eliza_V1_SayRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SayRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
@@ -148,7 +148,7 @@ extension Connectrpc_Eliza_V1_SayRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Connectrpc_Eliza_V1_SayResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Eliza_V1_SayResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SayResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
@@ -178,7 +178,7 @@ extension Connectrpc_Eliza_V1_SayResponse: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Connectrpc_Eliza_V1_ConverseRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Eliza_V1_ConverseRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConverseRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
@@ -208,7 +208,7 @@ extension Connectrpc_Eliza_V1_ConverseRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Connectrpc_Eliza_V1_ConverseResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Eliza_V1_ConverseResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConverseResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 
@@ -238,7 +238,7 @@ extension Connectrpc_Eliza_V1_ConverseResponse: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Connectrpc_Eliza_V1_IntroduceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Eliza_V1_IntroduceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IntroduceRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0")
 
@@ -268,7 +268,7 @@ extension Connectrpc_Eliza_V1_IntroduceRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Connectrpc_Eliza_V1_IntroduceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Eliza_V1_IntroduceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IntroduceResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sentence\0")
 

--- a/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "4a9a97111099376854a7f8f0f9f88b9d61f52eff",
-        "version" : "2.92.2"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "c2ba4cfbb83f307c66f5a6df6bb43e3c88dfbf80",
-        "version" : "1.39.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
-        "version" : "2.36.0"
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
-        "version" : "1.37.0"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
       }
     },
     {

--- a/Examples/buf.gen.yaml
+++ b/Examples/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.31.0
+  - plugin: buf.build/apple/swift:v1.38.1
     opt: Visibility=Internal
     out: ./ElizaSharedSources/GeneratedSources
   - name: connect-swift

--- a/Libraries/Connect/Internal/GeneratedSources/proto/grpc/status/v1/status.pb.swift
+++ b/Libraries/Connect/Internal/GeneratedSources/proto/grpc/status/v1/status.pb.swift
@@ -29,7 +29,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -38,7 +38,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 ///
 /// This struct must remain binary-compatible with
 /// https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto.
-struct Grpc_Status_V1_Status: Sendable {
+nonisolated struct Grpc_Status_V1_Status: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -58,9 +58,9 @@ struct Grpc_Status_V1_Status: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.status.v1"
+fileprivate nonisolated let _protobuf_package = "grpc.status.v1"
 
-extension Grpc_Status_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Status_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Status"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}details\0")
 

--- a/Libraries/Connect/buf.gen.yaml
+++ b/Libraries/Connect/buf.gen.yaml
@@ -1,5 +1,5 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.31.0
+  - plugin: buf.build/apple/swift:v1.38.1
     opt: Visibility=Internal
     out: ./Internal/GeneratedSources

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "4a9a97111099376854a7f8f0f9f88b9d61f52eff",
-        "version" : "2.92.2"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "c2ba4cfbb83f307c66f5a6df6bb43e3c88dfbf80",
-        "version" : "1.39.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
-        "version" : "2.36.0"
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "81558271e243f8f47dfe8e9fdd55f3c2b5413f68",
-        "version" : "1.37.0"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -49,19 +49,19 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-nio.git",
-            from: "2.92.2"
+            from: "2.101.3"
         ),
         .package(
             url: "https://github.com/apple/swift-nio-http2.git",
-            from: "1.39.0"
+            from: "1.44.0"
         ),
         .package(
             url: "https://github.com/apple/swift-nio-ssl.git",
-            from: "2.36.0"
+            from: "2.37.2"
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
-            from: "1.31.0"
+            from: "1.38.1"
         ),
     ],
     targets: [

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
@@ -22,7 +22,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -30,7 +34,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -39,7 +43,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// these from stdin and, for each one, invokes an RPC as directed
 /// and writes the results (in the form of a ClientCompatResponse
 /// message) to stdout.
-struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -47,7 +51,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// The name of the test that this request is performing.
   /// When writing test cases, this is a required field.
   var testName: String {
-    get {return _storage._testName}
+    get {_storage._testName}
     set {_uniqueStorage()._testName = newValue}
   }
 
@@ -59,37 +63,37 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   ///
   /// The HTTP version to use for the test (i.e. HTTP/1.1, HTTP/2, HTTP/3).
   var httpVersion: Connectrpc_Conformance_V1_HTTPVersion {
-    get {return _storage._httpVersion}
+    get {_storage._httpVersion}
     set {_uniqueStorage()._httpVersion = newValue}
   }
 
   /// The protocol to use for the test (i.e. Connect, gRPC, gRPC-web).
   var `protocol`: Connectrpc_Conformance_V1_Protocol {
-    get {return _storage._protocol}
+    get {_storage._protocol}
     set {_uniqueStorage()._protocol = newValue}
   }
 
   /// The codec to use for the test (i.e. JSON, proto/binary).
   var codec: Connectrpc_Conformance_V1_Codec {
-    get {return _storage._codec}
+    get {_storage._codec}
     set {_uniqueStorage()._codec = newValue}
   }
 
   /// The compression to use for the test (i.e. brotli, gzip, identity).
   var compression: Connectrpc_Conformance_V1_Compression {
-    get {return _storage._compression}
+    get {_storage._compression}
     set {_uniqueStorage()._compression = newValue}
   }
 
   /// The server host that this request will be sent to.
   var host: String {
-    get {return _storage._host}
+    get {_storage._host}
     set {_uniqueStorage()._host = newValue}
   }
 
   /// The server port that this request will be sent to.
   var port: UInt32 {
-    get {return _storage._port}
+    get {_storage._port}
     set {_uniqueStorage()._port = newValue}
   }
 
@@ -97,7 +101,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// server's PEM-encoded certificate, which the client should
   /// verify and trust.
   var serverTlsCert: Data {
-    get {return _storage._serverTlsCert}
+    get {_storage._serverTlsCert}
     set {_uniqueStorage()._serverTlsCert = newValue}
   }
 
@@ -105,18 +109,18 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// authenticate with the server. This will only be present
   /// when server_tls_cert is non-empty.
   var clientTlsCreds: Connectrpc_Conformance_V1_TLSCreds {
-    get {return _storage._clientTlsCreds ?? Connectrpc_Conformance_V1_TLSCreds()}
+    get {_storage._clientTlsCreds ?? Connectrpc_Conformance_V1_TLSCreds()}
     set {_uniqueStorage()._clientTlsCreds = newValue}
   }
   /// Returns true if `clientTlsCreds` has been explicitly set.
-  var hasClientTlsCreds: Bool {return _storage._clientTlsCreds != nil}
+  var hasClientTlsCreds: Bool {_storage._clientTlsCreds != nil}
   /// Clears the value of `clientTlsCreds`. Subsequent reads from it will return its default value.
   mutating func clearClientTlsCreds() {_uniqueStorage()._clientTlsCreds = nil}
 
   /// If non-zero, indicates the maximum size in bytes for a message.
   /// If the server sends anything larger, the client should reject it.
   var messageReceiveLimit: UInt32 {
-    get {return _storage._messageReceiveLimit}
+    get {_storage._messageReceiveLimit}
     set {_uniqueStorage()._messageReceiveLimit = newValue}
   }
 
@@ -124,11 +128,11 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// If specified, method must also be specified.
   /// If not specified, defaults to "connectrpc.conformance.v1.ConformanceService".
   var service: String {
-    get {return _storage._service ?? String()}
+    get {_storage._service ?? String()}
     set {_uniqueStorage()._service = newValue}
   }
   /// Returns true if `service` has been explicitly set.
-  var hasService: Bool {return _storage._service != nil}
+  var hasService: Bool {_storage._service != nil}
   /// Clears the value of `service`. Subsequent reads from it will return its default value.
   mutating func clearService() {_uniqueStorage()._service = nil}
 
@@ -136,11 +140,11 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// If specified, service must also be specified.
   /// If not specified, the test runner will auto-populate this field based on the stream_type.
   var method: String {
-    get {return _storage._method ?? String()}
+    get {_storage._method ?? String()}
     set {_uniqueStorage()._method = newValue}
   }
   /// Returns true if `method` has been explicitly set.
-  var hasMethod: Bool {return _storage._method != nil}
+  var hasMethod: Bool {_storage._method != nil}
   /// Clears the value of `method`. Subsequent reads from it will return its default value.
   mutating func clearMethod() {_uniqueStorage()._method = nil}
 
@@ -148,7 +152,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// stream, or half-duplex bidi stream).
   /// When writing test cases, this is a required field.
   var streamType: Connectrpc_Conformance_V1_StreamType {
-    get {return _storage._streamType}
+    get {_storage._streamType}
     set {_uniqueStorage()._streamType = newValue}
   }
 
@@ -156,7 +160,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// Unary, this instructs the client to use a GET HTTP method
   /// when making the request.
   var useGetHTTPMethod: Bool {
-    get {return _storage._useGetHTTPMethod}
+    get {_storage._useGetHTTPMethod}
     set {_uniqueStorage()._useGetHTTPMethod = newValue}
   }
 
@@ -165,7 +169,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// part of the relevant protocol (such as "content-type", etc) should
   /// not be stated here.
   var requestHeaders: [Connectrpc_Conformance_V1_Header] {
-    get {return _storage._requestHeaders}
+    get {_storage._requestHeaders}
     set {_uniqueStorage()._requestHeaders = newValue}
   }
 
@@ -177,18 +181,18 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// For client and bidi stream methods, all entries will have the
   /// same type URL.
   var requestMessages: [SwiftProtobuf.Google_Protobuf_Any] {
-    get {return _storage._requestMessages}
+    get {_storage._requestMessages}
     set {_uniqueStorage()._requestMessages = newValue}
   }
 
   /// The timeout, in milliseconds, for the request. This is equivalent to a
   /// deadline for the request. If unset, there will be no timeout.
   var timeoutMs: UInt32 {
-    get {return _storage._timeoutMs ?? 0}
+    get {_storage._timeoutMs ?? 0}
     set {_uniqueStorage()._timeoutMs = newValue}
   }
   /// Returns true if `timeoutMs` has been explicitly set.
-  var hasTimeoutMs: Bool {return _storage._timeoutMs != nil}
+  var hasTimeoutMs: Bool {_storage._timeoutMs != nil}
   /// Clears the value of `timeoutMs`. Subsequent reads from it will return its default value.
   mutating func clearTimeoutMs() {_uniqueStorage()._timeoutMs = nil}
 
@@ -196,18 +200,18 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// For client or bidi stream methods, this delay should be
   /// applied before each request sent.
   var requestDelayMs: UInt32 {
-    get {return _storage._requestDelayMs}
+    get {_storage._requestDelayMs}
     set {_uniqueStorage()._requestDelayMs = newValue}
   }
 
   /// If present, the client should cancel the RPC instead of
   /// allowing to complete normally.
   var cancel: Connectrpc_Conformance_V1_ClientCompatRequest.Cancel {
-    get {return _storage._cancel ?? Connectrpc_Conformance_V1_ClientCompatRequest.Cancel()}
+    get {_storage._cancel ?? Connectrpc_Conformance_V1_ClientCompatRequest.Cancel()}
     set {_uniqueStorage()._cancel = newValue}
   }
   /// Returns true if `cancel` has been explicitly set.
-  var hasCancel: Bool {return _storage._cancel != nil}
+  var hasCancel: Bool {_storage._cancel != nil}
   /// Clears the value of `cancel`. Subsequent reads from it will return its default value.
   mutating func clearCancel() {_uniqueStorage()._cancel = nil}
 
@@ -221,17 +225,17 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// provided and valid so that the reference client knows how it
   /// should try to interpret the server's response.
   var rawRequest: Connectrpc_Conformance_V1_RawHTTPRequest {
-    get {return _storage._rawRequest ?? Connectrpc_Conformance_V1_RawHTTPRequest()}
+    get {_storage._rawRequest ?? Connectrpc_Conformance_V1_RawHTTPRequest()}
     set {_uniqueStorage()._rawRequest = newValue}
   }
   /// Returns true if `rawRequest` has been explicitly set.
-  var hasRawRequest: Bool {return _storage._rawRequest != nil}
+  var hasRawRequest: Bool {_storage._rawRequest != nil}
   /// Clears the value of `rawRequest`. Subsequent reads from it will return its default value.
   mutating func clearRawRequest() {_uniqueStorage()._rawRequest = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Cancel: Sendable {
+  nonisolated struct Cancel: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -301,7 +305,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
     /// after all request messages are sent and the send side is
     /// closed (as if the after_close_send_ms field were present
     /// and zero).
-    enum OneOf_CancelTiming: Equatable, Sendable {
+    nonisolated enum OneOf_CancelTiming: Equatable, Sendable {
       /// When present, the client should cancel *instead of*
       /// closing the send side of the stream, after all requests
       /// have been sent.
@@ -344,7 +348,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
 }
 
 /// The outcome of one ClientCompatRequest.
-struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -390,7 +394,7 @@ struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
   /// (e.g. a unary request that defines zero or multiple request messages).
   ///
   /// However, once the RPC is issued, any resulting error should instead be encoded in response.
-  enum OneOf_Result: Equatable, Sendable {
+  nonisolated enum OneOf_Result: Equatable, Sendable {
     case response(Connectrpc_Conformance_V1_ClientResponseResult)
     case error(Connectrpc_Conformance_V1_ClientErrorResult)
 
@@ -401,7 +405,7 @@ struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
 
 /// The result of a ClientCompatRequest, which may or may not be successful.
 /// The client will build this message and return it back to the test runner.
-struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -419,11 +423,11 @@ struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
   /// of a runtime error and should always be the proto equivalent of a Connect
   /// or gRPC error.
   var error: Connectrpc_Conformance_V1_Error {
-    get {return _error ?? Connectrpc_Conformance_V1_Error()}
+    get {_error ?? Connectrpc_Conformance_V1_Error()}
     set {_error = newValue}
   }
   /// Returns true if `error` has been explicitly set.
-  var hasError: Bool {return self._error != nil}
+  var hasError: Bool {self._error != nil}
   /// Clears the value of `error`. Subsequent reads from it will return its default value.
   mutating func clearError() {self._error = nil}
 
@@ -439,11 +443,11 @@ struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
   /// If you are implementing a client-under-test, you should ignore this field
   /// and leave it unset.
   var httpStatusCode: Int32 {
-    get {return _httpStatusCode ?? 0}
+    get {_httpStatusCode ?? 0}
     set {_httpStatusCode = newValue}
   }
   /// Returns true if `httpStatusCode` has been explicitly set.
-  var hasHTTPStatusCode: Bool {return self._httpStatusCode != nil}
+  var hasHTTPStatusCode: Bool {self._httpStatusCode != nil}
   /// Clears the value of `httpStatusCode`. Subsequent reads from it will return its default value.
   mutating func clearHTTPStatusCode() {self._httpStatusCode = nil}
 
@@ -466,7 +470,7 @@ struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
 /// The client is not able to fulfill the ClientCompatRequest. This may be due
 /// to a runtime error or an unexpected internal error such as the requested protocol
 /// not being supported. This is completely independent of the actual RPC invocation.
-struct Connectrpc_Conformance_V1_ClientErrorResult: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientErrorResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -484,7 +488,7 @@ struct Connectrpc_Conformance_V1_ClientErrorResult: Sendable {
 /// Details about various values as observed on the wire. This message is used
 /// only by the reference client when reporting results and should not be populated
 /// by clients under test.
-struct Connectrpc_Conformance_V1_WireDetails: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_WireDetails: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -495,11 +499,11 @@ struct Connectrpc_Conformance_V1_WireDetails: Sendable {
   /// When processing an error from a Connect server, this should contain
   /// the actual JSON received on the wire.
   var connectErrorRaw: SwiftProtobuf.Google_Protobuf_Struct {
-    get {return _connectErrorRaw ?? SwiftProtobuf.Google_Protobuf_Struct()}
+    get {_connectErrorRaw ?? SwiftProtobuf.Google_Protobuf_Struct()}
     set {_connectErrorRaw = newValue}
   }
   /// Returns true if `connectErrorRaw` has been explicitly set.
-  var hasConnectErrorRaw: Bool {return self._connectErrorRaw != nil}
+  var hasConnectErrorRaw: Bool {self._connectErrorRaw != nil}
   /// Clears the value of `connectErrorRaw`. Subsequent reads from it will return its default value.
   mutating func clearConnectErrorRaw() {self._connectErrorRaw = nil}
 
@@ -516,11 +520,11 @@ struct Connectrpc_Conformance_V1_WireDetails: Sendable {
   /// capture all of the entries and their exact on-the-wire spelling
   /// and formatting.
   var actualGrpcwebTrailers: String {
-    get {return _actualGrpcwebTrailers ?? String()}
+    get {_actualGrpcwebTrailers ?? String()}
     set {_actualGrpcwebTrailers = newValue}
   }
   /// Returns true if `actualGrpcwebTrailers` has been explicitly set.
-  var hasActualGrpcwebTrailers: Bool {return self._actualGrpcwebTrailers != nil}
+  var hasActualGrpcwebTrailers: Bool {self._actualGrpcwebTrailers != nil}
   /// Clears the value of `actualGrpcwebTrailers`. Subsequent reads from it will return its default value.
   mutating func clearActualGrpcwebTrailers() {self._actualGrpcwebTrailers = nil}
 
@@ -534,9 +538,9 @@ struct Connectrpc_Conformance_V1_WireDetails: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientCompatRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}test_name\0\u{3}http_version\0\u{1}protocol\0\u{1}codec\0\u{1}compression\0\u{1}host\0\u{1}port\0\u{3}server_tls_cert\0\u{3}client_tls_creds\0\u{3}message_receive_limit\0\u{1}service\0\u{1}method\0\u{3}stream_type\0\u{3}use_get_http_method\0\u{3}request_headers\0\u{3}request_messages\0\u{3}timeout_ms\0\u{3}request_delay_ms\0\u{1}cancel\0\u{3}raw_request\0")
 
@@ -739,7 +743,7 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ClientCompatRequest.protoMessageName + ".Cancel"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}before_close_send\0\u{3}after_close_send_ms\0\u{3}after_num_responses\0")
 
@@ -813,7 +817,7 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Me
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientCompatResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}test_name\0\u{1}response\0\u{1}error\0")
 
@@ -885,7 +889,7 @@ extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientResponseResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{1}payloads\0\u{1}error\0\u{3}response_trailers\0\u{3}num_unsent_requests\0\u{3}http_status_code\0\u{1}feedback\0")
 
@@ -949,7 +953,7 @@ extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientErrorResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}message\0")
 
@@ -979,7 +983,7 @@ extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Connectrpc_Conformance_V1_WireDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_WireDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WireDetails"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}actual_status_code\0\u{3}connect_error_raw\0\u{3}actual_http_trailers\0\u{3}actual_grpcweb_trailers\0")
 

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
@@ -22,7 +22,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -30,12 +34,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case httpVersion1 // = 1
@@ -77,7 +81,7 @@ enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum, Swift.CaseIterab
 
 }
 
-enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case connect // = 1
@@ -123,7 +127,7 @@ enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum, Swift.CaseIterable 
 
 }
 
-enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case proto // = 1
@@ -169,7 +173,7 @@ enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case identity // = 1
@@ -223,7 +227,7 @@ enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum, Swift.CaseIterab
 
 }
 
-enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case unary // = 1
@@ -273,7 +277,7 @@ enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum, Swift.CaseIterabl
 
 }
 
-enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case canceled // = 1
@@ -369,7 +373,7 @@ enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 /// Config defines the configuration for running conformance tests.
 /// This enumerates all of the "flavors" of the test suite to run.
-struct Connectrpc_Conformance_V1_Config: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_Config: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -379,11 +383,11 @@ struct Connectrpc_Conformance_V1_Config: Sendable {
   /// If absent, an empty message is used. See Features for more
   /// on how empty/absent fields are interpreted.
   var features: Connectrpc_Conformance_V1_Features {
-    get {return _features ?? Connectrpc_Conformance_V1_Features()}
+    get {_features ?? Connectrpc_Conformance_V1_Features()}
     set {_features = newValue}
   }
   /// Returns true if `features` has been explicitly set.
-  var hasFeatures: Bool {return self._features != nil}
+  var hasFeatures: Bool {self._features != nil}
   /// Clears the value of `features`. Subsequent reads from it will return its default value.
   mutating func clearFeatures() {self._features = nil}
 
@@ -406,7 +410,7 @@ struct Connectrpc_Conformance_V1_Config: Sendable {
 /// used to determine the server configurations and test cases that
 /// will be run. They are defined in YAML files and are specified as part of the
 /// --conf flag to the test runner.
-struct Connectrpc_Conformance_V1_Features: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_Features: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -437,22 +441,22 @@ struct Connectrpc_Conformance_V1_Features: Sendable {
   /// Whether H2C (unencrypted, non-TLS HTTP/2 over cleartext) is supported.
   /// If absent, true is assumed.
   var supportsH2C: Bool {
-    get {return _supportsH2C ?? false}
+    get {_supportsH2C ?? false}
     set {_supportsH2C = newValue}
   }
   /// Returns true if `supportsH2C` has been explicitly set.
-  var hasSupportsH2C: Bool {return self._supportsH2C != nil}
+  var hasSupportsH2C: Bool {self._supportsH2C != nil}
   /// Clears the value of `supportsH2C`. Subsequent reads from it will return its default value.
   mutating func clearSupportsH2C() {self._supportsH2C = nil}
 
   /// Whether TLS is supported.
   /// If absent, true is assumed.
   var supportsTls: Bool {
-    get {return _supportsTls ?? false}
+    get {_supportsTls ?? false}
     set {_supportsTls = newValue}
   }
   /// Returns true if `supportsTls` has been explicitly set.
-  var hasSupportsTls: Bool {return self._supportsTls != nil}
+  var hasSupportsTls: Bool {self._supportsTls != nil}
   /// Clears the value of `supportsTls`. Subsequent reads from it will return its default value.
   mutating func clearSupportsTls() {self._supportsTls = nil}
 
@@ -460,55 +464,55 @@ struct Connectrpc_Conformance_V1_Features: Sendable {
   /// If absent, false is assumed. This should not be set if
   /// supports_tls is false.
   var supportsTlsClientCerts: Bool {
-    get {return _supportsTlsClientCerts ?? false}
+    get {_supportsTlsClientCerts ?? false}
     set {_supportsTlsClientCerts = newValue}
   }
   /// Returns true if `supportsTlsClientCerts` has been explicitly set.
-  var hasSupportsTlsClientCerts: Bool {return self._supportsTlsClientCerts != nil}
+  var hasSupportsTlsClientCerts: Bool {self._supportsTlsClientCerts != nil}
   /// Clears the value of `supportsTlsClientCerts`. Subsequent reads from it will return its default value.
   mutating func clearSupportsTlsClientCerts() {self._supportsTlsClientCerts = nil}
 
   /// Whether trailers are supported.
   /// If absent, true is assumed. If false, implies that gRPC protocol is not allowed.
   var supportsTrailers: Bool {
-    get {return _supportsTrailers ?? false}
+    get {_supportsTrailers ?? false}
     set {_supportsTrailers = newValue}
   }
   /// Returns true if `supportsTrailers` has been explicitly set.
-  var hasSupportsTrailers: Bool {return self._supportsTrailers != nil}
+  var hasSupportsTrailers: Bool {self._supportsTrailers != nil}
   /// Clears the value of `supportsTrailers`. Subsequent reads from it will return its default value.
   mutating func clearSupportsTrailers() {self._supportsTrailers = nil}
 
   /// Whether half duplex bidi streams are supported over HTTP/1.1.
   /// If absent, false is assumed.
   var supportsHalfDuplexBidiOverHTTP1: Bool {
-    get {return _supportsHalfDuplexBidiOverHTTP1 ?? false}
+    get {_supportsHalfDuplexBidiOverHTTP1 ?? false}
     set {_supportsHalfDuplexBidiOverHTTP1 = newValue}
   }
   /// Returns true if `supportsHalfDuplexBidiOverHTTP1` has been explicitly set.
-  var hasSupportsHalfDuplexBidiOverHTTP1: Bool {return self._supportsHalfDuplexBidiOverHTTP1 != nil}
+  var hasSupportsHalfDuplexBidiOverHTTP1: Bool {self._supportsHalfDuplexBidiOverHTTP1 != nil}
   /// Clears the value of `supportsHalfDuplexBidiOverHTTP1`. Subsequent reads from it will return its default value.
   mutating func clearSupportsHalfDuplexBidiOverHTTP1() {self._supportsHalfDuplexBidiOverHTTP1 = nil}
 
   /// Whether Connect via GET is supported.
   /// If absent, true is assumed.
   var supportsConnectGet: Bool {
-    get {return _supportsConnectGet ?? false}
+    get {_supportsConnectGet ?? false}
     set {_supportsConnectGet = newValue}
   }
   /// Returns true if `supportsConnectGet` has been explicitly set.
-  var hasSupportsConnectGet: Bool {return self._supportsConnectGet != nil}
+  var hasSupportsConnectGet: Bool {self._supportsConnectGet != nil}
   /// Clears the value of `supportsConnectGet`. Subsequent reads from it will return its default value.
   mutating func clearSupportsConnectGet() {self._supportsConnectGet = nil}
 
   /// Whether a message receive limit is supported.
   /// If absent, true is assumed.
   var supportsMessageReceiveLimit: Bool {
-    get {return _supportsMessageReceiveLimit ?? false}
+    get {_supportsMessageReceiveLimit ?? false}
     set {_supportsMessageReceiveLimit = newValue}
   }
   /// Returns true if `supportsMessageReceiveLimit` has been explicitly set.
-  var hasSupportsMessageReceiveLimit: Bool {return self._supportsMessageReceiveLimit != nil}
+  var hasSupportsMessageReceiveLimit: Bool {self._supportsMessageReceiveLimit != nil}
   /// Clears the value of `supportsMessageReceiveLimit`. Subsequent reads from it will return its default value.
   mutating func clearSupportsMessageReceiveLimit() {self._supportsMessageReceiveLimit = nil}
 
@@ -529,7 +533,7 @@ struct Connectrpc_Conformance_V1_Features: Sendable {
 /// run, the Config and the supported features therein are used to compute all
 /// of the cases relevant to the implementation under test. These configuration
 /// cases are then used to select which test cases are applicable.
-struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -552,22 +556,22 @@ struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
   /// If absent, indicates cases for plaintext (no TLS) but also for
   /// TLS if features indicate that TLS is supported.
   var useTls: Bool {
-    get {return _useTls ?? false}
+    get {_useTls ?? false}
     set {_useTls = newValue}
   }
   /// Returns true if `useTls` has been explicitly set.
-  var hasUseTls: Bool {return self._useTls != nil}
+  var hasUseTls: Bool {self._useTls != nil}
   /// Clears the value of `useTls`. Subsequent reads from it will return its default value.
   mutating func clearUseTls() {self._useTls = nil}
 
   /// If absent, indicates cases without client certs but also cases
   /// that use client certs if features indicate they are supported.
   var useTlsClientCerts: Bool {
-    get {return _useTlsClientCerts ?? false}
+    get {_useTlsClientCerts ?? false}
     set {_useTlsClientCerts = newValue}
   }
   /// Returns true if `useTlsClientCerts` has been explicitly set.
-  var hasUseTlsClientCerts: Bool {return self._useTlsClientCerts != nil}
+  var hasUseTlsClientCerts: Bool {self._useTlsClientCerts != nil}
   /// Clears the value of `useTlsClientCerts`. Subsequent reads from it will return its default value.
   mutating func clearUseTlsClientCerts() {self._useTlsClientCerts = nil}
 
@@ -575,11 +579,11 @@ struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
   /// limits but also cases that do test message receive limits if
   /// features indicate they are supported.
   var useMessageReceiveLimit: Bool {
-    get {return _useMessageReceiveLimit ?? false}
+    get {_useMessageReceiveLimit ?? false}
     set {_useMessageReceiveLimit = newValue}
   }
   /// Returns true if `useMessageReceiveLimit` has been explicitly set.
-  var hasUseMessageReceiveLimit: Bool {return self._useMessageReceiveLimit != nil}
+  var hasUseMessageReceiveLimit: Bool {self._useMessageReceiveLimit != nil}
   /// Clears the value of `useMessageReceiveLimit`. Subsequent reads from it will return its default value.
   mutating func clearUseMessageReceiveLimit() {self._useMessageReceiveLimit = nil}
 
@@ -595,7 +599,7 @@ struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
 /// TLSCreds represents credentials for TLS. It includes both a
 /// certificate and corresponding private key. Both are encoded
 /// in PEM format.
-struct Connectrpc_Conformance_V1_TLSCreds: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_TLSCreds: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -611,33 +615,33 @@ struct Connectrpc_Conformance_V1_TLSCreds: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0HTTP_VERSION_UNSPECIFIED\0\u{1}HTTP_VERSION_1\0\u{1}HTTP_VERSION_2\0\u{1}HTTP_VERSION_3\0")
 }
 
-extension Connectrpc_Conformance_V1_Protocol: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Protocol: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PROTOCOL_UNSPECIFIED\0\u{1}PROTOCOL_CONNECT\0\u{1}PROTOCOL_GRPC\0\u{1}PROTOCOL_GRPC_WEB\0")
 }
 
-extension Connectrpc_Conformance_V1_Codec: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Codec: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CODEC_UNSPECIFIED\0\u{1}CODEC_PROTO\0\u{1}CODEC_JSON\0\u{1}CODEC_TEXT\0")
 }
 
-extension Connectrpc_Conformance_V1_Compression: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Compression: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0COMPRESSION_UNSPECIFIED\0\u{1}COMPRESSION_IDENTITY\0\u{1}COMPRESSION_GZIP\0\u{1}COMPRESSION_BR\0\u{1}COMPRESSION_ZSTD\0\u{1}COMPRESSION_DEFLATE\0\u{1}COMPRESSION_SNAPPY\0")
 }
 
-extension Connectrpc_Conformance_V1_StreamType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_StreamType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STREAM_TYPE_UNSPECIFIED\0\u{1}STREAM_TYPE_UNARY\0\u{1}STREAM_TYPE_CLIENT_STREAM\0\u{1}STREAM_TYPE_SERVER_STREAM\0\u{1}STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM\0\u{1}STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM\0")
 }
 
-extension Connectrpc_Conformance_V1_Code: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Code: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CODE_UNSPECIFIED\0\u{1}CODE_CANCELED\0\u{1}CODE_UNKNOWN\0\u{1}CODE_INVALID_ARGUMENT\0\u{1}CODE_DEADLINE_EXCEEDED\0\u{1}CODE_NOT_FOUND\0\u{1}CODE_ALREADY_EXISTS\0\u{1}CODE_PERMISSION_DENIED\0\u{1}CODE_RESOURCE_EXHAUSTED\0\u{1}CODE_FAILED_PRECONDITION\0\u{1}CODE_ABORTED\0\u{1}CODE_OUT_OF_RANGE\0\u{1}CODE_UNIMPLEMENTED\0\u{1}CODE_INTERNAL\0\u{1}CODE_UNAVAILABLE\0\u{1}CODE_DATA_LOSS\0\u{1}CODE_UNAUTHENTICATED\0")
 }
 
-extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Config"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}features\0\u{3}include_cases\0\u{3}exclude_cases\0")
 
@@ -681,7 +685,7 @@ extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Features"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}versions\0\u{1}protocols\0\u{1}codecs\0\u{1}compressions\0\u{3}stream_types\0\u{3}supports_h2c\0\u{3}supports_tls\0\u{3}supports_tls_client_certs\0\u{3}supports_trailers\0\u{3}supports_half_duplex_bidi_over_http1\0\u{3}supports_connect_get\0\u{3}supports_message_receive_limit\0")
 
@@ -770,7 +774,7 @@ extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConfigCase"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{1}protocol\0\u{1}codec\0\u{1}compression\0\u{3}stream_type\0\u{3}use_tls\0\u{3}use_tls_client_certs\0\u{3}use_message_receive_limit\0")
 
@@ -839,7 +843,7 @@ extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Connectrpc_Conformance_V1_TLSCreds: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TLSCreds: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TLSCreds"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cert\0\u{1}key\0")
 

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
@@ -22,7 +22,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -30,7 +34,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -49,7 +53,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// Each test process is expected to start only one RPC server.
 /// When testing multiple configurations, multiple test processes
 /// will be started, each with different properties.
-struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -105,11 +109,11 @@ struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
   /// If it chooses to use a different certificate and key, it must send
   /// back the corresponding certificate in the ServerCompatResponse.
   var serverCreds: Connectrpc_Conformance_V1_TLSCreds {
-    get {return _serverCreds ?? Connectrpc_Conformance_V1_TLSCreds()}
+    get {_serverCreds ?? Connectrpc_Conformance_V1_TLSCreds()}
     set {_serverCreds = newValue}
   }
   /// Returns true if `serverCreds` has been explicitly set.
-  var hasServerCreds: Bool {return self._serverCreds != nil}
+  var hasServerCreds: Bool {self._serverCreds != nil}
   /// Clears the value of `serverCreds`. Subsequent reads from it will return its default value.
   mutating func clearServerCreds() {self._serverCreds = nil}
 
@@ -121,7 +125,7 @@ struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
 }
 
 /// The outcome of one ServerCompatRequest.
-struct Connectrpc_Conformance_V1_ServerCompatResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ServerCompatResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -146,9 +150,9 @@ struct Connectrpc_Conformance_V1_ServerCompatResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerCompatRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}protocol\0\u{3}http_version\0\u{4}\u{2}use_tls\0\u{3}client_tls_cert\0\u{3}message_receive_limit\0\u{3}server_creds\0")
 
@@ -207,7 +211,7 @@ extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Connectrpc_Conformance_V1_ServerCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ServerCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerCompatResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}host\0\u{1}port\0\u{3}pem_cert\0")
 

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
@@ -22,7 +22,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -30,14 +34,14 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// A definition of a response to be sent from a single-response endpoint.
 /// Can be used to define a response for unary or client-streaming calls.
-struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -79,17 +83,17 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
   ///
   /// For test definitions, this field should be used instead of the above fields.
   var rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse {
-    get {return _rawResponse ?? Connectrpc_Conformance_V1_RawHTTPResponse()}
+    get {_rawResponse ?? Connectrpc_Conformance_V1_RawHTTPResponse()}
     set {_rawResponse = newValue}
   }
   /// Returns true if `rawResponse` has been explicitly set.
-  var hasRawResponse: Bool {return self._rawResponse != nil}
+  var hasRawResponse: Bool {self._rawResponse != nil}
   /// Clears the value of `rawResponse`. Subsequent reads from it will return its default value.
   mutating func clearRawResponse() {self._rawResponse = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Response: Equatable, Sendable {
+  nonisolated enum OneOf_Response: Equatable, Sendable {
     /// Response data to send
     case responseData(Data)
     /// Error to raise instead of response message
@@ -106,7 +110,7 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
 
 /// A definition of responses to be sent from a streaming endpoint.
 /// Can be used to define responses for server-streaming or bidi-streaming calls.
-struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -126,11 +130,11 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   /// build a RequestInfo message with available information and append that to
   /// the error details.
   var error: Connectrpc_Conformance_V1_Error {
-    get {return _error ?? Connectrpc_Conformance_V1_Error()}
+    get {_error ?? Connectrpc_Conformance_V1_Error()}
     set {_error = newValue}
   }
   /// Returns true if `error` has been explicitly set.
-  var hasError: Bool {return self._error != nil}
+  var hasError: Bool {self._error != nil}
   /// Clears the value of `error`. Subsequent reads from it will return its default value.
   mutating func clearError() {self._error = nil}
 
@@ -143,11 +147,11 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   ///
   /// For test definitions, this field should be used instead of the above fields.
   var rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse {
-    get {return _rawResponse ?? Connectrpc_Conformance_V1_RawHTTPResponse()}
+    get {_rawResponse ?? Connectrpc_Conformance_V1_RawHTTPResponse()}
     set {_rawResponse = newValue}
   }
   /// Returns true if `rawResponse` has been explicitly set.
-  var hasRawResponse: Bool {return self._rawResponse != nil}
+  var hasRawResponse: Bool {self._rawResponse != nil}
   /// Clears the value of `rawResponse`. Subsequent reads from it will return its default value.
   mutating func clearRawResponse() {self._rawResponse = nil}
 
@@ -159,18 +163,18 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   fileprivate var _rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnaryRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnaryRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The response definition which should be returned in the conformance payload
   var responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -184,18 +188,18 @@ struct Connectrpc_Conformance_V1_UnaryRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with.
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -206,18 +210,18 @@ struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The response definition which should be returned in the conformance payload
   var responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -231,18 +235,18 @@ struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with.
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -253,18 +257,18 @@ struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ServerStreamRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ServerStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The response definition which should be returned in the conformance payload.
   var responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_StreamResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_StreamResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -278,18 +282,18 @@ struct Connectrpc_Conformance_V1_ServerStreamRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -300,7 +304,7 @@ struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -309,11 +313,11 @@ struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
   /// complete. Required in the first message in the stream, but
   /// should be ignored in subsequent messages.
   var responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -328,18 +332,18 @@ struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -350,7 +354,7 @@ struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -358,11 +362,11 @@ struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
   /// Tells the server how to reply; required in the first message
   /// in the stream. Should be ignored in subsequent messages.
   var responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_StreamResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_StreamResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -392,18 +396,18 @@ struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_BidiStreamResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_BidiStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -414,7 +418,7 @@ struct Connectrpc_Conformance_V1_BidiStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnimplementedRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnimplementedRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -424,7 +428,7 @@ struct Connectrpc_Conformance_V1_UnimplementedRequest: Sendable {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -434,7 +438,7 @@ struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -445,17 +449,17 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
 
   /// Echoes back information about the request stream observed so far.
   var requestInfo: Connectrpc_Conformance_V1_ConformancePayload.RequestInfo {
-    get {return _requestInfo ?? Connectrpc_Conformance_V1_ConformancePayload.RequestInfo()}
+    get {_requestInfo ?? Connectrpc_Conformance_V1_ConformancePayload.RequestInfo()}
     set {_requestInfo = newValue}
   }
   /// Returns true if `requestInfo` has been explicitly set.
-  var hasRequestInfo: Bool {return self._requestInfo != nil}
+  var hasRequestInfo: Bool {self._requestInfo != nil}
   /// Clears the value of `requestInfo`. Subsequent reads from it will return its default value.
   mutating func clearRequestInfo() {self._requestInfo = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct RequestInfo: Sendable {
+  nonisolated struct RequestInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -467,11 +471,11 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
     /// type of uint32, but we want to be lenient here to allow whatever value the RPC
     /// server observes, even if it's outside the range of uint32.
     var timeoutMs: Int64 {
-      get {return _timeoutMs ?? 0}
+      get {_timeoutMs ?? 0}
       set {_timeoutMs = newValue}
     }
     /// Returns true if `timeoutMs` has been explicitly set.
-    var hasTimeoutMs: Bool {return self._timeoutMs != nil}
+    var hasTimeoutMs: Bool {self._timeoutMs != nil}
     /// Clears the value of `timeoutMs`. Subsequent reads from it will return its default value.
     mutating func clearTimeoutMs() {self._timeoutMs = nil}
 
@@ -490,11 +494,11 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
     /// server framework, at a minimum, at least expose to application code whether the
     /// request used GET vs. POST.
     var connectGetInfo: Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo {
-      get {return _connectGetInfo ?? Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo()}
+      get {_connectGetInfo ?? Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo()}
       set {_connectGetInfo = newValue}
     }
     /// Returns true if `connectGetInfo` has been explicitly set.
-    var hasConnectGetInfo: Bool {return self._connectGetInfo != nil}
+    var hasConnectGetInfo: Bool {self._connectGetInfo != nil}
     /// Clears the value of `connectGetInfo`. Subsequent reads from it will return its default value.
     mutating func clearConnectGetInfo() {self._connectGetInfo = nil}
 
@@ -506,7 +510,7 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
     fileprivate var _connectGetInfo: Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo? = nil
   }
 
-  struct ConnectGetInfo: Sendable {
+  nonisolated struct ConnectGetInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -525,7 +529,7 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
 }
 
 /// An error definition used for specifying a desired error response
-struct Connectrpc_Conformance_V1_Error: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_Error: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -539,11 +543,11 @@ struct Connectrpc_Conformance_V1_Error: Sendable {
   /// error conditions where the exact message to be used is not specified, only the
   /// code.
   var message: String {
-    get {return _message ?? String()}
+    get {_message ?? String()}
     set {_message = newValue}
   }
   /// Returns true if `message` has been explicitly set.
-  var hasMessage: Bool {return self._message != nil}
+  var hasMessage: Bool {self._message != nil}
   /// Clears the value of `message`. Subsequent reads from it will return its default value.
   mutating func clearMessage() {self._message = nil}
 
@@ -559,7 +563,7 @@ struct Connectrpc_Conformance_V1_Error: Sendable {
 }
 
 /// A tuple of name and values (ASCII) for a header or trailer entry.
-struct Connectrpc_Conformance_V1_Header: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_Header: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -580,7 +584,7 @@ struct Connectrpc_Conformance_V1_Header: Sendable {
 /// RawHTTPRequest models a raw HTTP request. This can be used to craft
 /// custom requests with odd properties (including certain kinds of
 /// malformed requests) to test edge cases in servers.
-struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -625,7 +629,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Body: Equatable, Sendable {
+  nonisolated enum OneOf_Body: Equatable, Sendable {
     /// The body is a single message.
     case unary(Connectrpc_Conformance_V1_MessageContents)
     /// The body is a stream, encoded using a five-byte
@@ -634,7 +638,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 
   }
 
-  struct EncodedQueryParam: Sendable {
+  nonisolated struct EncodedQueryParam: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -644,11 +648,11 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 
     /// Query param value.
     var value: Connectrpc_Conformance_V1_MessageContents {
-      get {return _value ?? Connectrpc_Conformance_V1_MessageContents()}
+      get {_value ?? Connectrpc_Conformance_V1_MessageContents()}
       set {_value = newValue}
     }
     /// Returns true if `value` has been explicitly set.
-    var hasValue: Bool {return self._value != nil}
+    var hasValue: Bool {self._value != nil}
     /// Clears the value of `value`. Subsequent reads from it will return its default value.
     mutating func clearValue() {self._value = nil}
 
@@ -667,7 +671,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 }
 
 /// MessageContents represents a message in a request body.
-struct Connectrpc_Conformance_V1_MessageContents: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_MessageContents: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -711,7 +715,7 @@ struct Connectrpc_Conformance_V1_MessageContents: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The message data can be defined in one of three ways.
-  enum OneOf_Data: Equatable, Sendable {
+  nonisolated enum OneOf_Data: Equatable, Sendable {
     /// Arbitrary bytes.
     case binary(Data)
     /// Arbitrary text.
@@ -727,7 +731,7 @@ struct Connectrpc_Conformance_V1_MessageContents: Sendable {
 }
 
 /// StreamContents represents a sequence of messages in a request body.
-struct Connectrpc_Conformance_V1_StreamContents: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_StreamContents: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -737,7 +741,7 @@ struct Connectrpc_Conformance_V1_StreamContents: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct StreamItem: Sendable {
+  nonisolated struct StreamItem: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -747,20 +751,20 @@ struct Connectrpc_Conformance_V1_StreamContents: Sendable {
 
     /// if absent use actual length of payload
     var length: UInt32 {
-      get {return _length ?? 0}
+      get {_length ?? 0}
       set {_length = newValue}
     }
     /// Returns true if `length` has been explicitly set.
-    var hasLength: Bool {return self._length != nil}
+    var hasLength: Bool {self._length != nil}
     /// Clears the value of `length`. Subsequent reads from it will return its default value.
     mutating func clearLength() {self._length = nil}
 
     var payload: Connectrpc_Conformance_V1_MessageContents {
-      get {return _payload ?? Connectrpc_Conformance_V1_MessageContents()}
+      get {_payload ?? Connectrpc_Conformance_V1_MessageContents()}
       set {_payload = newValue}
     }
     /// Returns true if `payload` has been explicitly set.
-    var hasPayload: Bool {return self._payload != nil}
+    var hasPayload: Bool {self._payload != nil}
     /// Clears the value of `payload`. Subsequent reads from it will return its default value.
     mutating func clearPayload() {self._payload = nil}
 
@@ -778,7 +782,7 @@ struct Connectrpc_Conformance_V1_StreamContents: Sendable {
 /// RawHTTPResponse models a raw HTTP response. This can be used to craft
 /// custom responses with odd properties (including certain kinds of
 /// malformed responses) to test edge cases in clients.
-struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -815,7 +819,7 @@ struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Body: Equatable, Sendable {
+  nonisolated enum OneOf_Body: Equatable, Sendable {
     /// The body is a single message.
     case unary(Connectrpc_Conformance_V1_MessageContents)
     /// The body is a stream, encoded using a five-byte
@@ -829,9 +833,9 @@ struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryResponseDefinition"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{3}response_data\0\u{1}error\0\u{3}response_trailers\0\u{3}raw_response\0\u{3}response_delay_ms\0")
 
@@ -913,7 +917,7 @@ extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Messa
   }
 }
 
-extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamResponseDefinition"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{3}response_data\0\u{3}response_delay_ms\0\u{1}error\0\u{3}response_trailers\0\u{3}raw_response\0")
 
@@ -972,7 +976,7 @@ extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Mess
   }
 }
 
-extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
@@ -1011,7 +1015,7 @@ extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1045,7 +1049,7 @@ extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IdempotentUnaryRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
@@ -1084,7 +1088,7 @@ extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Messag
   }
 }
 
-extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IdempotentUnaryResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1118,7 +1122,7 @@ extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Messa
   }
 }
 
-extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerStreamRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
@@ -1157,7 +1161,7 @@ extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerStreamResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1191,7 +1195,7 @@ extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientStreamRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
@@ -1230,7 +1234,7 @@ extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientStreamResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1264,7 +1268,7 @@ extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BidiStreamRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}full_duplex\0\u{3}request_data\0")
 
@@ -1308,7 +1312,7 @@ extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Connectrpc_Conformance_V1_BidiStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_BidiStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BidiStreamResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1342,7 +1346,7 @@ extension Connectrpc_Conformance_V1_BidiStreamResponse: SwiftProtobuf.Message, S
   }
 }
 
-extension Connectrpc_Conformance_V1_UnimplementedRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnimplementedRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnimplementedRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1361,7 +1365,7 @@ extension Connectrpc_Conformance_V1_UnimplementedRequest: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnimplementedResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1380,7 +1384,7 @@ extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message
   }
 }
 
-extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConformancePayload"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0\u{3}request_info\0")
 
@@ -1419,7 +1423,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, S
   }
 }
 
-extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ConformancePayload.protoMessageName + ".RequestInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_headers\0\u{3}timeout_ms\0\u{1}requests\0\u{3}connect_get_info\0")
 
@@ -1468,7 +1472,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobu
   }
 }
 
-extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ConformancePayload.protoMessageName + ".ConnectGetInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_params\0")
 
@@ -1498,7 +1502,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProt
   }
 }
 
-extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Error"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}details\0")
 
@@ -1542,7 +1546,7 @@ extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Header"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0")
 
@@ -1577,7 +1581,7 @@ extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawHTTPRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}verb\0\u{1}uri\0\u{1}headers\0\u{3}raw_query_params\0\u{3}encoded_query_params\0\u{1}unary\0\u{1}stream\0")
 
@@ -1669,7 +1673,7 @@ extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_RawHTTPRequest.protoMessageName + ".EncodedQueryParam"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0\u{3}base64_encode\0")
 
@@ -1713,7 +1717,7 @@ extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProto
   }
 }
 
-extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MessageContents"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}binary\0\u{1}text\0\u{3}binary_message\0\u{1}compression\0")
 
@@ -1792,7 +1796,7 @@ extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamContents"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}items\0")
 
@@ -1822,7 +1826,7 @@ extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_StreamContents.protoMessageName + ".StreamItem"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}flags\0\u{1}length\0\u{1}payload\0")
 
@@ -1866,7 +1870,7 @@ extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Mes
   }
 }
 
-extension Connectrpc_Conformance_V1_RawHTTPResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_RawHTTPResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawHTTPResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}status_code\0\u{1}headers\0\u{1}unary\0\u{1}stream\0\u{1}trailers\0")
 

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
@@ -29,7 +29,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -39,7 +39,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// suite, which can contain numerous cases. Each test suite has various properties
 /// that indicate the kinds of features that are tested. Test suites may be skipped
 /// based on whether the client or server under test implements these features.
-struct Connectrpc_Conformance_V1_TestSuite: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_TestSuite: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -96,7 +96,7 @@ struct Connectrpc_Conformance_V1_TestSuite: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum TestMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Used when the test suite does not apply to a particular mode. Such tests
@@ -146,7 +146,7 @@ struct Connectrpc_Conformance_V1_TestSuite: Sendable {
 
   }
 
-  enum ConnectVersionMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum ConnectVersionMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Used when the suite is agnostic to the server's validation
@@ -196,7 +196,7 @@ struct Connectrpc_Conformance_V1_TestSuite: Sendable {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_TestCase: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_TestCase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -210,11 +210,11 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
   /// the test harness based on the test environment (e.g. actual server and
   ///  port to use) and characteristics of a single permutation.
   var request: Connectrpc_Conformance_V1_ClientCompatRequest {
-    get {return _request ?? Connectrpc_Conformance_V1_ClientCompatRequest()}
+    get {_request ?? Connectrpc_Conformance_V1_ClientCompatRequest()}
     set {_request = newValue}
   }
   /// Returns true if `request` has been explicitly set.
-  var hasRequest: Bool {return self._request != nil}
+  var hasRequest: Bool {self._request != nil}
   /// Clears the value of `request`. Subsequent reads from it will return its default value.
   mutating func clearRequest() {self._request = nil}
 
@@ -251,11 +251,11 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
   /// Specifying an expected response explicitly in test definitions will override
   /// the auto-generation of the test runner.
   var expectedResponse: Connectrpc_Conformance_V1_ClientResponseResult {
-    get {return _expectedResponse ?? Connectrpc_Conformance_V1_ClientResponseResult()}
+    get {_expectedResponse ?? Connectrpc_Conformance_V1_ClientResponseResult()}
     set {_expectedResponse = newValue}
   }
   /// Returns true if `expectedResponse` has been explicitly set.
-  var hasExpectedResponse: Bool {return self._expectedResponse != nil}
+  var hasExpectedResponse: Bool {self._expectedResponse != nil}
   /// Clears the value of `expectedResponse`. Subsequent reads from it will return its default value.
   mutating func clearExpectedResponse() {self._expectedResponse = nil}
 
@@ -268,7 +268,7 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct ExpandedSize: Sendable {
+  nonisolated struct ExpandedSize: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -278,11 +278,11 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
     /// Any value greater than zero indicates that the request size will be that
     /// many bytes over the limit.
     var sizeRelativeToLimit: Int32 {
-      get {return _sizeRelativeToLimit ?? 0}
+      get {_sizeRelativeToLimit ?? 0}
       set {_sizeRelativeToLimit = newValue}
     }
     /// Returns true if `sizeRelativeToLimit` has been explicitly set.
-    var hasSizeRelativeToLimit: Bool {return self._sizeRelativeToLimit != nil}
+    var hasSizeRelativeToLimit: Bool {self._sizeRelativeToLimit != nil}
     /// Clears the value of `sizeRelativeToLimit`. Subsequent reads from it will return its default value.
     mutating func clearSizeRelativeToLimit() {self._sizeRelativeToLimit = nil}
 
@@ -301,9 +301,9 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestSuite"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}mode\0\u{3}test_cases\0\u{3}relevant_protocols\0\u{3}relevant_http_versions\0\u{3}relevant_codecs\0\u{3}relevant_compressions\0\u{3}connect_version_mode\0\u{3}relies_on_tls\0\u{3}relies_on_tls_client_certs\0\u{3}relies_on_connect_get\0\u{3}relies_on_message_receive_limit\0")
 
@@ -388,15 +388,15 @@ extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Connectrpc_Conformance_V1_TestSuite.TestMode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestSuite.TestMode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0TEST_MODE_UNSPECIFIED\0\u{1}TEST_MODE_CLIENT\0\u{1}TEST_MODE_SERVER\0")
 }
 
-extension Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CONNECT_VERSION_MODE_UNSPECIFIED\0\u{1}CONNECT_VERSION_MODE_REQUIRE\0\u{1}CONNECT_VERSION_MODE_IGNORE\0")
 }
 
-extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestCase"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}request\0\u{3}expand_requests\0\u{3}expected_response\0\u{3}other_allowed_error_codes\0")
 
@@ -445,7 +445,7 @@ extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Connectrpc_Conformance_V1_TestCase.ExpandedSize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestCase.ExpandedSize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_TestCase.protoMessageName + ".ExpandedSize"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}size_relative_to_limit\0")
 

--- a/Tests/ConformanceClient/buf.gen.yaml
+++ b/Tests/ConformanceClient/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.31.0
+  - plugin: buf.build/apple/swift:v1.38.1
     opt: Visibility=Internal
     out: ./GeneratedSources
   - name: connect-swift

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/client_compat.pb.swift
@@ -22,7 +22,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -30,7 +34,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -39,7 +43,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// these from stdin and, for each one, invokes an RPC as directed
 /// and writes the results (in the form of a ClientCompatResponse
 /// message) to stdout.
-struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -47,7 +51,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// The name of the test that this request is performing.
   /// When writing test cases, this is a required field.
   var testName: String {
-    get {return _storage._testName}
+    get {_storage._testName}
     set {_uniqueStorage()._testName = newValue}
   }
 
@@ -59,37 +63,37 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   ///
   /// The HTTP version to use for the test (i.e. HTTP/1.1, HTTP/2, HTTP/3).
   var httpVersion: Connectrpc_Conformance_V1_HTTPVersion {
-    get {return _storage._httpVersion}
+    get {_storage._httpVersion}
     set {_uniqueStorage()._httpVersion = newValue}
   }
 
   /// The protocol to use for the test (i.e. Connect, gRPC, gRPC-web).
   var `protocol`: Connectrpc_Conformance_V1_Protocol {
-    get {return _storage._protocol}
+    get {_storage._protocol}
     set {_uniqueStorage()._protocol = newValue}
   }
 
   /// The codec to use for the test (i.e. JSON, proto/binary).
   var codec: Connectrpc_Conformance_V1_Codec {
-    get {return _storage._codec}
+    get {_storage._codec}
     set {_uniqueStorage()._codec = newValue}
   }
 
   /// The compression to use for the test (i.e. brotli, gzip, identity).
   var compression: Connectrpc_Conformance_V1_Compression {
-    get {return _storage._compression}
+    get {_storage._compression}
     set {_uniqueStorage()._compression = newValue}
   }
 
   /// The server host that this request will be sent to.
   var host: String {
-    get {return _storage._host}
+    get {_storage._host}
     set {_uniqueStorage()._host = newValue}
   }
 
   /// The server port that this request will be sent to.
   var port: UInt32 {
-    get {return _storage._port}
+    get {_storage._port}
     set {_uniqueStorage()._port = newValue}
   }
 
@@ -97,7 +101,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// server's PEM-encoded certificate, which the client should
   /// verify and trust.
   var serverTlsCert: Data {
-    get {return _storage._serverTlsCert}
+    get {_storage._serverTlsCert}
     set {_uniqueStorage()._serverTlsCert = newValue}
   }
 
@@ -105,18 +109,18 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// authenticate with the server. This will only be present
   /// when server_tls_cert is non-empty.
   var clientTlsCreds: Connectrpc_Conformance_V1_TLSCreds {
-    get {return _storage._clientTlsCreds ?? Connectrpc_Conformance_V1_TLSCreds()}
+    get {_storage._clientTlsCreds ?? Connectrpc_Conformance_V1_TLSCreds()}
     set {_uniqueStorage()._clientTlsCreds = newValue}
   }
   /// Returns true if `clientTlsCreds` has been explicitly set.
-  var hasClientTlsCreds: Bool {return _storage._clientTlsCreds != nil}
+  var hasClientTlsCreds: Bool {_storage._clientTlsCreds != nil}
   /// Clears the value of `clientTlsCreds`. Subsequent reads from it will return its default value.
   mutating func clearClientTlsCreds() {_uniqueStorage()._clientTlsCreds = nil}
 
   /// If non-zero, indicates the maximum size in bytes for a message.
   /// If the server sends anything larger, the client should reject it.
   var messageReceiveLimit: UInt32 {
-    get {return _storage._messageReceiveLimit}
+    get {_storage._messageReceiveLimit}
     set {_uniqueStorage()._messageReceiveLimit = newValue}
   }
 
@@ -124,11 +128,11 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// If specified, method must also be specified.
   /// If not specified, defaults to "connectrpc.conformance.v1.ConformanceService".
   var service: String {
-    get {return _storage._service ?? String()}
+    get {_storage._service ?? String()}
     set {_uniqueStorage()._service = newValue}
   }
   /// Returns true if `service` has been explicitly set.
-  var hasService: Bool {return _storage._service != nil}
+  var hasService: Bool {_storage._service != nil}
   /// Clears the value of `service`. Subsequent reads from it will return its default value.
   mutating func clearService() {_uniqueStorage()._service = nil}
 
@@ -136,11 +140,11 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// If specified, service must also be specified.
   /// If not specified, the test runner will auto-populate this field based on the stream_type.
   var method: String {
-    get {return _storage._method ?? String()}
+    get {_storage._method ?? String()}
     set {_uniqueStorage()._method = newValue}
   }
   /// Returns true if `method` has been explicitly set.
-  var hasMethod: Bool {return _storage._method != nil}
+  var hasMethod: Bool {_storage._method != nil}
   /// Clears the value of `method`. Subsequent reads from it will return its default value.
   mutating func clearMethod() {_uniqueStorage()._method = nil}
 
@@ -148,7 +152,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// stream, or half-duplex bidi stream).
   /// When writing test cases, this is a required field.
   var streamType: Connectrpc_Conformance_V1_StreamType {
-    get {return _storage._streamType}
+    get {_storage._streamType}
     set {_uniqueStorage()._streamType = newValue}
   }
 
@@ -156,7 +160,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// Unary, this instructs the client to use a GET HTTP method
   /// when making the request.
   var useGetHTTPMethod: Bool {
-    get {return _storage._useGetHTTPMethod}
+    get {_storage._useGetHTTPMethod}
     set {_uniqueStorage()._useGetHTTPMethod = newValue}
   }
 
@@ -165,7 +169,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// part of the relevant protocol (such as "content-type", etc) should
   /// not be stated here.
   var requestHeaders: [Connectrpc_Conformance_V1_Header] {
-    get {return _storage._requestHeaders}
+    get {_storage._requestHeaders}
     set {_uniqueStorage()._requestHeaders = newValue}
   }
 
@@ -177,18 +181,18 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// For client and bidi stream methods, all entries will have the
   /// same type URL.
   var requestMessages: [SwiftProtobuf.Google_Protobuf_Any] {
-    get {return _storage._requestMessages}
+    get {_storage._requestMessages}
     set {_uniqueStorage()._requestMessages = newValue}
   }
 
   /// The timeout, in milliseconds, for the request. This is equivalent to a
   /// deadline for the request. If unset, there will be no timeout.
   var timeoutMs: UInt32 {
-    get {return _storage._timeoutMs ?? 0}
+    get {_storage._timeoutMs ?? 0}
     set {_uniqueStorage()._timeoutMs = newValue}
   }
   /// Returns true if `timeoutMs` has been explicitly set.
-  var hasTimeoutMs: Bool {return _storage._timeoutMs != nil}
+  var hasTimeoutMs: Bool {_storage._timeoutMs != nil}
   /// Clears the value of `timeoutMs`. Subsequent reads from it will return its default value.
   mutating func clearTimeoutMs() {_uniqueStorage()._timeoutMs = nil}
 
@@ -196,18 +200,18 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// For client or bidi stream methods, this delay should be
   /// applied before each request sent.
   var requestDelayMs: UInt32 {
-    get {return _storage._requestDelayMs}
+    get {_storage._requestDelayMs}
     set {_uniqueStorage()._requestDelayMs = newValue}
   }
 
   /// If present, the client should cancel the RPC instead of
   /// allowing to complete normally.
   var cancel: Connectrpc_Conformance_V1_ClientCompatRequest.Cancel {
-    get {return _storage._cancel ?? Connectrpc_Conformance_V1_ClientCompatRequest.Cancel()}
+    get {_storage._cancel ?? Connectrpc_Conformance_V1_ClientCompatRequest.Cancel()}
     set {_uniqueStorage()._cancel = newValue}
   }
   /// Returns true if `cancel` has been explicitly set.
-  var hasCancel: Bool {return _storage._cancel != nil}
+  var hasCancel: Bool {_storage._cancel != nil}
   /// Clears the value of `cancel`. Subsequent reads from it will return its default value.
   mutating func clearCancel() {_uniqueStorage()._cancel = nil}
 
@@ -221,17 +225,17 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
   /// provided and valid so that the reference client knows how it
   /// should try to interpret the server's response.
   var rawRequest: Connectrpc_Conformance_V1_RawHTTPRequest {
-    get {return _storage._rawRequest ?? Connectrpc_Conformance_V1_RawHTTPRequest()}
+    get {_storage._rawRequest ?? Connectrpc_Conformance_V1_RawHTTPRequest()}
     set {_uniqueStorage()._rawRequest = newValue}
   }
   /// Returns true if `rawRequest` has been explicitly set.
-  var hasRawRequest: Bool {return _storage._rawRequest != nil}
+  var hasRawRequest: Bool {_storage._rawRequest != nil}
   /// Clears the value of `rawRequest`. Subsequent reads from it will return its default value.
   mutating func clearRawRequest() {_uniqueStorage()._rawRequest = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Cancel: Sendable {
+  nonisolated struct Cancel: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -301,7 +305,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
     /// after all request messages are sent and the send side is
     /// closed (as if the after_close_send_ms field were present
     /// and zero).
-    enum OneOf_CancelTiming: Equatable, Sendable {
+    nonisolated enum OneOf_CancelTiming: Equatable, Sendable {
       /// When present, the client should cancel *instead of*
       /// closing the send side of the stream, after all requests
       /// have been sent.
@@ -344,7 +348,7 @@ struct Connectrpc_Conformance_V1_ClientCompatRequest: @unchecked Sendable {
 }
 
 /// The outcome of one ClientCompatRequest.
-struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -390,7 +394,7 @@ struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
   /// (e.g. a unary request that defines zero or multiple request messages).
   ///
   /// However, once the RPC is issued, any resulting error should instead be encoded in response.
-  enum OneOf_Result: Equatable, Sendable {
+  nonisolated enum OneOf_Result: Equatable, Sendable {
     case response(Connectrpc_Conformance_V1_ClientResponseResult)
     case error(Connectrpc_Conformance_V1_ClientErrorResult)
 
@@ -401,7 +405,7 @@ struct Connectrpc_Conformance_V1_ClientCompatResponse: Sendable {
 
 /// The result of a ClientCompatRequest, which may or may not be successful.
 /// The client will build this message and return it back to the test runner.
-struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -419,11 +423,11 @@ struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
   /// of a runtime error and should always be the proto equivalent of a Connect
   /// or gRPC error.
   var error: Connectrpc_Conformance_V1_Error {
-    get {return _error ?? Connectrpc_Conformance_V1_Error()}
+    get {_error ?? Connectrpc_Conformance_V1_Error()}
     set {_error = newValue}
   }
   /// Returns true if `error` has been explicitly set.
-  var hasError: Bool {return self._error != nil}
+  var hasError: Bool {self._error != nil}
   /// Clears the value of `error`. Subsequent reads from it will return its default value.
   mutating func clearError() {self._error = nil}
 
@@ -439,11 +443,11 @@ struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
   /// If you are implementing a client-under-test, you should ignore this field
   /// and leave it unset.
   var httpStatusCode: Int32 {
-    get {return _httpStatusCode ?? 0}
+    get {_httpStatusCode ?? 0}
     set {_httpStatusCode = newValue}
   }
   /// Returns true if `httpStatusCode` has been explicitly set.
-  var hasHTTPStatusCode: Bool {return self._httpStatusCode != nil}
+  var hasHTTPStatusCode: Bool {self._httpStatusCode != nil}
   /// Clears the value of `httpStatusCode`. Subsequent reads from it will return its default value.
   mutating func clearHTTPStatusCode() {self._httpStatusCode = nil}
 
@@ -466,7 +470,7 @@ struct Connectrpc_Conformance_V1_ClientResponseResult: Sendable {
 /// The client is not able to fulfill the ClientCompatRequest. This may be due
 /// to a runtime error or an unexpected internal error such as the requested protocol
 /// not being supported. This is completely independent of the actual RPC invocation.
-struct Connectrpc_Conformance_V1_ClientErrorResult: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientErrorResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -484,7 +488,7 @@ struct Connectrpc_Conformance_V1_ClientErrorResult: Sendable {
 /// Details about various values as observed on the wire. This message is used
 /// only by the reference client when reporting results and should not be populated
 /// by clients under test.
-struct Connectrpc_Conformance_V1_WireDetails: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_WireDetails: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -495,11 +499,11 @@ struct Connectrpc_Conformance_V1_WireDetails: Sendable {
   /// When processing an error from a Connect server, this should contain
   /// the actual JSON received on the wire.
   var connectErrorRaw: SwiftProtobuf.Google_Protobuf_Struct {
-    get {return _connectErrorRaw ?? SwiftProtobuf.Google_Protobuf_Struct()}
+    get {_connectErrorRaw ?? SwiftProtobuf.Google_Protobuf_Struct()}
     set {_connectErrorRaw = newValue}
   }
   /// Returns true if `connectErrorRaw` has been explicitly set.
-  var hasConnectErrorRaw: Bool {return self._connectErrorRaw != nil}
+  var hasConnectErrorRaw: Bool {self._connectErrorRaw != nil}
   /// Clears the value of `connectErrorRaw`. Subsequent reads from it will return its default value.
   mutating func clearConnectErrorRaw() {self._connectErrorRaw = nil}
 
@@ -516,11 +520,11 @@ struct Connectrpc_Conformance_V1_WireDetails: Sendable {
   /// capture all of the entries and their exact on-the-wire spelling
   /// and formatting.
   var actualGrpcwebTrailers: String {
-    get {return _actualGrpcwebTrailers ?? String()}
+    get {_actualGrpcwebTrailers ?? String()}
     set {_actualGrpcwebTrailers = newValue}
   }
   /// Returns true if `actualGrpcwebTrailers` has been explicitly set.
-  var hasActualGrpcwebTrailers: Bool {return self._actualGrpcwebTrailers != nil}
+  var hasActualGrpcwebTrailers: Bool {self._actualGrpcwebTrailers != nil}
   /// Clears the value of `actualGrpcwebTrailers`. Subsequent reads from it will return its default value.
   mutating func clearActualGrpcwebTrailers() {self._actualGrpcwebTrailers = nil}
 
@@ -534,9 +538,9 @@ struct Connectrpc_Conformance_V1_WireDetails: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientCompatRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}test_name\0\u{3}http_version\0\u{1}protocol\0\u{1}codec\0\u{1}compression\0\u{1}host\0\u{1}port\0\u{3}server_tls_cert\0\u{3}client_tls_creds\0\u{3}message_receive_limit\0\u{1}service\0\u{1}method\0\u{3}stream_type\0\u{3}use_get_http_method\0\u{3}request_headers\0\u{3}request_messages\0\u{3}timeout_ms\0\u{3}request_delay_ms\0\u{1}cancel\0\u{3}raw_request\0")
 
@@ -739,7 +743,7 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ClientCompatRequest.protoMessageName + ".Cancel"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}before_close_send\0\u{3}after_close_send_ms\0\u{3}after_num_responses\0")
 
@@ -813,7 +817,7 @@ extension Connectrpc_Conformance_V1_ClientCompatRequest.Cancel: SwiftProtobuf.Me
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientCompatResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}test_name\0\u{1}response\0\u{1}error\0")
 
@@ -885,7 +889,7 @@ extension Connectrpc_Conformance_V1_ClientCompatResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientResponseResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{1}payloads\0\u{1}error\0\u{3}response_trailers\0\u{3}num_unsent_requests\0\u{3}http_status_code\0\u{1}feedback\0")
 
@@ -949,7 +953,7 @@ extension Connectrpc_Conformance_V1_ClientResponseResult: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientErrorResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}message\0")
 
@@ -979,7 +983,7 @@ extension Connectrpc_Conformance_V1_ClientErrorResult: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Connectrpc_Conformance_V1_WireDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_WireDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WireDetails"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}actual_status_code\0\u{3}connect_error_raw\0\u{3}actual_http_trailers\0\u{3}actual_grpcweb_trailers\0")
 

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/config.pb.swift
@@ -22,7 +22,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -30,12 +34,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case httpVersion1 // = 1
@@ -77,7 +81,7 @@ enum Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf.Enum, Swift.CaseIterab
 
 }
 
-enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case connect // = 1
@@ -123,7 +127,7 @@ enum Connectrpc_Conformance_V1_Protocol: SwiftProtobuf.Enum, Swift.CaseIterable 
 
 }
 
-enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case proto // = 1
@@ -169,7 +173,7 @@ enum Connectrpc_Conformance_V1_Codec: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case identity // = 1
@@ -223,7 +227,7 @@ enum Connectrpc_Conformance_V1_Compression: SwiftProtobuf.Enum, Swift.CaseIterab
 
 }
 
-enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case unary // = 1
@@ -273,7 +277,7 @@ enum Connectrpc_Conformance_V1_StreamType: SwiftProtobuf.Enum, Swift.CaseIterabl
 
 }
 
-enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case canceled // = 1
@@ -369,7 +373,7 @@ enum Connectrpc_Conformance_V1_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 /// Config defines the configuration for running conformance tests.
 /// This enumerates all of the "flavors" of the test suite to run.
-struct Connectrpc_Conformance_V1_Config: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_Config: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -379,11 +383,11 @@ struct Connectrpc_Conformance_V1_Config: Sendable {
   /// If absent, an empty message is used. See Features for more
   /// on how empty/absent fields are interpreted.
   var features: Connectrpc_Conformance_V1_Features {
-    get {return _features ?? Connectrpc_Conformance_V1_Features()}
+    get {_features ?? Connectrpc_Conformance_V1_Features()}
     set {_features = newValue}
   }
   /// Returns true if `features` has been explicitly set.
-  var hasFeatures: Bool {return self._features != nil}
+  var hasFeatures: Bool {self._features != nil}
   /// Clears the value of `features`. Subsequent reads from it will return its default value.
   mutating func clearFeatures() {self._features = nil}
 
@@ -406,7 +410,7 @@ struct Connectrpc_Conformance_V1_Config: Sendable {
 /// used to determine the server configurations and test cases that
 /// will be run. They are defined in YAML files and are specified as part of the
 /// --conf flag to the test runner.
-struct Connectrpc_Conformance_V1_Features: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_Features: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -437,22 +441,22 @@ struct Connectrpc_Conformance_V1_Features: Sendable {
   /// Whether H2C (unencrypted, non-TLS HTTP/2 over cleartext) is supported.
   /// If absent, true is assumed.
   var supportsH2C: Bool {
-    get {return _supportsH2C ?? false}
+    get {_supportsH2C ?? false}
     set {_supportsH2C = newValue}
   }
   /// Returns true if `supportsH2C` has been explicitly set.
-  var hasSupportsH2C: Bool {return self._supportsH2C != nil}
+  var hasSupportsH2C: Bool {self._supportsH2C != nil}
   /// Clears the value of `supportsH2C`. Subsequent reads from it will return its default value.
   mutating func clearSupportsH2C() {self._supportsH2C = nil}
 
   /// Whether TLS is supported.
   /// If absent, true is assumed.
   var supportsTls: Bool {
-    get {return _supportsTls ?? false}
+    get {_supportsTls ?? false}
     set {_supportsTls = newValue}
   }
   /// Returns true if `supportsTls` has been explicitly set.
-  var hasSupportsTls: Bool {return self._supportsTls != nil}
+  var hasSupportsTls: Bool {self._supportsTls != nil}
   /// Clears the value of `supportsTls`. Subsequent reads from it will return its default value.
   mutating func clearSupportsTls() {self._supportsTls = nil}
 
@@ -460,55 +464,55 @@ struct Connectrpc_Conformance_V1_Features: Sendable {
   /// If absent, false is assumed. This should not be set if
   /// supports_tls is false.
   var supportsTlsClientCerts: Bool {
-    get {return _supportsTlsClientCerts ?? false}
+    get {_supportsTlsClientCerts ?? false}
     set {_supportsTlsClientCerts = newValue}
   }
   /// Returns true if `supportsTlsClientCerts` has been explicitly set.
-  var hasSupportsTlsClientCerts: Bool {return self._supportsTlsClientCerts != nil}
+  var hasSupportsTlsClientCerts: Bool {self._supportsTlsClientCerts != nil}
   /// Clears the value of `supportsTlsClientCerts`. Subsequent reads from it will return its default value.
   mutating func clearSupportsTlsClientCerts() {self._supportsTlsClientCerts = nil}
 
   /// Whether trailers are supported.
   /// If absent, true is assumed. If false, implies that gRPC protocol is not allowed.
   var supportsTrailers: Bool {
-    get {return _supportsTrailers ?? false}
+    get {_supportsTrailers ?? false}
     set {_supportsTrailers = newValue}
   }
   /// Returns true if `supportsTrailers` has been explicitly set.
-  var hasSupportsTrailers: Bool {return self._supportsTrailers != nil}
+  var hasSupportsTrailers: Bool {self._supportsTrailers != nil}
   /// Clears the value of `supportsTrailers`. Subsequent reads from it will return its default value.
   mutating func clearSupportsTrailers() {self._supportsTrailers = nil}
 
   /// Whether half duplex bidi streams are supported over HTTP/1.1.
   /// If absent, false is assumed.
   var supportsHalfDuplexBidiOverHTTP1: Bool {
-    get {return _supportsHalfDuplexBidiOverHTTP1 ?? false}
+    get {_supportsHalfDuplexBidiOverHTTP1 ?? false}
     set {_supportsHalfDuplexBidiOverHTTP1 = newValue}
   }
   /// Returns true if `supportsHalfDuplexBidiOverHTTP1` has been explicitly set.
-  var hasSupportsHalfDuplexBidiOverHTTP1: Bool {return self._supportsHalfDuplexBidiOverHTTP1 != nil}
+  var hasSupportsHalfDuplexBidiOverHTTP1: Bool {self._supportsHalfDuplexBidiOverHTTP1 != nil}
   /// Clears the value of `supportsHalfDuplexBidiOverHTTP1`. Subsequent reads from it will return its default value.
   mutating func clearSupportsHalfDuplexBidiOverHTTP1() {self._supportsHalfDuplexBidiOverHTTP1 = nil}
 
   /// Whether Connect via GET is supported.
   /// If absent, true is assumed.
   var supportsConnectGet: Bool {
-    get {return _supportsConnectGet ?? false}
+    get {_supportsConnectGet ?? false}
     set {_supportsConnectGet = newValue}
   }
   /// Returns true if `supportsConnectGet` has been explicitly set.
-  var hasSupportsConnectGet: Bool {return self._supportsConnectGet != nil}
+  var hasSupportsConnectGet: Bool {self._supportsConnectGet != nil}
   /// Clears the value of `supportsConnectGet`. Subsequent reads from it will return its default value.
   mutating func clearSupportsConnectGet() {self._supportsConnectGet = nil}
 
   /// Whether a message receive limit is supported.
   /// If absent, true is assumed.
   var supportsMessageReceiveLimit: Bool {
-    get {return _supportsMessageReceiveLimit ?? false}
+    get {_supportsMessageReceiveLimit ?? false}
     set {_supportsMessageReceiveLimit = newValue}
   }
   /// Returns true if `supportsMessageReceiveLimit` has been explicitly set.
-  var hasSupportsMessageReceiveLimit: Bool {return self._supportsMessageReceiveLimit != nil}
+  var hasSupportsMessageReceiveLimit: Bool {self._supportsMessageReceiveLimit != nil}
   /// Clears the value of `supportsMessageReceiveLimit`. Subsequent reads from it will return its default value.
   mutating func clearSupportsMessageReceiveLimit() {self._supportsMessageReceiveLimit = nil}
 
@@ -529,7 +533,7 @@ struct Connectrpc_Conformance_V1_Features: Sendable {
 /// run, the Config and the supported features therein are used to compute all
 /// of the cases relevant to the implementation under test. These configuration
 /// cases are then used to select which test cases are applicable.
-struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -552,22 +556,22 @@ struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
   /// If absent, indicates cases for plaintext (no TLS) but also for
   /// TLS if features indicate that TLS is supported.
   var useTls: Bool {
-    get {return _useTls ?? false}
+    get {_useTls ?? false}
     set {_useTls = newValue}
   }
   /// Returns true if `useTls` has been explicitly set.
-  var hasUseTls: Bool {return self._useTls != nil}
+  var hasUseTls: Bool {self._useTls != nil}
   /// Clears the value of `useTls`. Subsequent reads from it will return its default value.
   mutating func clearUseTls() {self._useTls = nil}
 
   /// If absent, indicates cases without client certs but also cases
   /// that use client certs if features indicate they are supported.
   var useTlsClientCerts: Bool {
-    get {return _useTlsClientCerts ?? false}
+    get {_useTlsClientCerts ?? false}
     set {_useTlsClientCerts = newValue}
   }
   /// Returns true if `useTlsClientCerts` has been explicitly set.
-  var hasUseTlsClientCerts: Bool {return self._useTlsClientCerts != nil}
+  var hasUseTlsClientCerts: Bool {self._useTlsClientCerts != nil}
   /// Clears the value of `useTlsClientCerts`. Subsequent reads from it will return its default value.
   mutating func clearUseTlsClientCerts() {self._useTlsClientCerts = nil}
 
@@ -575,11 +579,11 @@ struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
   /// limits but also cases that do test message receive limits if
   /// features indicate they are supported.
   var useMessageReceiveLimit: Bool {
-    get {return _useMessageReceiveLimit ?? false}
+    get {_useMessageReceiveLimit ?? false}
     set {_useMessageReceiveLimit = newValue}
   }
   /// Returns true if `useMessageReceiveLimit` has been explicitly set.
-  var hasUseMessageReceiveLimit: Bool {return self._useMessageReceiveLimit != nil}
+  var hasUseMessageReceiveLimit: Bool {self._useMessageReceiveLimit != nil}
   /// Clears the value of `useMessageReceiveLimit`. Subsequent reads from it will return its default value.
   mutating func clearUseMessageReceiveLimit() {self._useMessageReceiveLimit = nil}
 
@@ -595,7 +599,7 @@ struct Connectrpc_Conformance_V1_ConfigCase: Sendable {
 /// TLSCreds represents credentials for TLS. It includes both a
 /// certificate and corresponding private key. Both are encoded
 /// in PEM format.
-struct Connectrpc_Conformance_V1_TLSCreds: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_TLSCreds: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -611,33 +615,33 @@ struct Connectrpc_Conformance_V1_TLSCreds: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_HTTPVersion: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0HTTP_VERSION_UNSPECIFIED\0\u{1}HTTP_VERSION_1\0\u{1}HTTP_VERSION_2\0\u{1}HTTP_VERSION_3\0")
 }
 
-extension Connectrpc_Conformance_V1_Protocol: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Protocol: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PROTOCOL_UNSPECIFIED\0\u{1}PROTOCOL_CONNECT\0\u{1}PROTOCOL_GRPC\0\u{1}PROTOCOL_GRPC_WEB\0")
 }
 
-extension Connectrpc_Conformance_V1_Codec: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Codec: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CODEC_UNSPECIFIED\0\u{1}CODEC_PROTO\0\u{1}CODEC_JSON\0\u{1}CODEC_TEXT\0")
 }
 
-extension Connectrpc_Conformance_V1_Compression: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Compression: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0COMPRESSION_UNSPECIFIED\0\u{1}COMPRESSION_IDENTITY\0\u{1}COMPRESSION_GZIP\0\u{1}COMPRESSION_BR\0\u{1}COMPRESSION_ZSTD\0\u{1}COMPRESSION_DEFLATE\0\u{1}COMPRESSION_SNAPPY\0")
 }
 
-extension Connectrpc_Conformance_V1_StreamType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_StreamType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STREAM_TYPE_UNSPECIFIED\0\u{1}STREAM_TYPE_UNARY\0\u{1}STREAM_TYPE_CLIENT_STREAM\0\u{1}STREAM_TYPE_SERVER_STREAM\0\u{1}STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM\0\u{1}STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM\0")
 }
 
-extension Connectrpc_Conformance_V1_Code: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Code: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CODE_UNSPECIFIED\0\u{1}CODE_CANCELED\0\u{1}CODE_UNKNOWN\0\u{1}CODE_INVALID_ARGUMENT\0\u{1}CODE_DEADLINE_EXCEEDED\0\u{1}CODE_NOT_FOUND\0\u{1}CODE_ALREADY_EXISTS\0\u{1}CODE_PERMISSION_DENIED\0\u{1}CODE_RESOURCE_EXHAUSTED\0\u{1}CODE_FAILED_PRECONDITION\0\u{1}CODE_ABORTED\0\u{1}CODE_OUT_OF_RANGE\0\u{1}CODE_UNIMPLEMENTED\0\u{1}CODE_INTERNAL\0\u{1}CODE_UNAVAILABLE\0\u{1}CODE_DATA_LOSS\0\u{1}CODE_UNAUTHENTICATED\0")
 }
 
-extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Config"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}features\0\u{3}include_cases\0\u{3}exclude_cases\0")
 
@@ -681,7 +685,7 @@ extension Connectrpc_Conformance_V1_Config: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Features"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}versions\0\u{1}protocols\0\u{1}codecs\0\u{1}compressions\0\u{3}stream_types\0\u{3}supports_h2c\0\u{3}supports_tls\0\u{3}supports_tls_client_certs\0\u{3}supports_trailers\0\u{3}supports_half_duplex_bidi_over_http1\0\u{3}supports_connect_get\0\u{3}supports_message_receive_limit\0")
 
@@ -770,7 +774,7 @@ extension Connectrpc_Conformance_V1_Features: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConfigCase"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{1}protocol\0\u{1}codec\0\u{1}compression\0\u{3}stream_type\0\u{3}use_tls\0\u{3}use_tls_client_certs\0\u{3}use_message_receive_limit\0")
 
@@ -839,7 +843,7 @@ extension Connectrpc_Conformance_V1_ConfigCase: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Connectrpc_Conformance_V1_TLSCreds: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TLSCreds: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TLSCreds"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cert\0\u{1}key\0")
 

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/server_compat.pb.swift
@@ -22,7 +22,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -30,7 +34,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -49,7 +53,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// Each test process is expected to start only one RPC server.
 /// When testing multiple configurations, multiple test processes
 /// will be started, each with different properties.
-struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -105,11 +109,11 @@ struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
   /// If it chooses to use a different certificate and key, it must send
   /// back the corresponding certificate in the ServerCompatResponse.
   var serverCreds: Connectrpc_Conformance_V1_TLSCreds {
-    get {return _serverCreds ?? Connectrpc_Conformance_V1_TLSCreds()}
+    get {_serverCreds ?? Connectrpc_Conformance_V1_TLSCreds()}
     set {_serverCreds = newValue}
   }
   /// Returns true if `serverCreds` has been explicitly set.
-  var hasServerCreds: Bool {return self._serverCreds != nil}
+  var hasServerCreds: Bool {self._serverCreds != nil}
   /// Clears the value of `serverCreds`. Subsequent reads from it will return its default value.
   mutating func clearServerCreds() {self._serverCreds = nil}
 
@@ -121,7 +125,7 @@ struct Connectrpc_Conformance_V1_ServerCompatRequest: Sendable {
 }
 
 /// The outcome of one ServerCompatRequest.
-struct Connectrpc_Conformance_V1_ServerCompatResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ServerCompatResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -146,9 +150,9 @@ struct Connectrpc_Conformance_V1_ServerCompatResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerCompatRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}protocol\0\u{3}http_version\0\u{4}\u{2}use_tls\0\u{3}client_tls_cert\0\u{3}message_receive_limit\0\u{3}server_creds\0")
 
@@ -207,7 +211,7 @@ extension Connectrpc_Conformance_V1_ServerCompatRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Connectrpc_Conformance_V1_ServerCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ServerCompatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerCompatResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}host\0\u{1}port\0\u{3}pem_cert\0")
 

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.pb.swift
@@ -22,7 +22,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -30,14 +34,14 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// A definition of a response to be sent from a single-response endpoint.
 /// Can be used to define a response for unary or client-streaming calls.
-struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -79,17 +83,17 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
   ///
   /// For test definitions, this field should be used instead of the above fields.
   var rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse {
-    get {return _rawResponse ?? Connectrpc_Conformance_V1_RawHTTPResponse()}
+    get {_rawResponse ?? Connectrpc_Conformance_V1_RawHTTPResponse()}
     set {_rawResponse = newValue}
   }
   /// Returns true if `rawResponse` has been explicitly set.
-  var hasRawResponse: Bool {return self._rawResponse != nil}
+  var hasRawResponse: Bool {self._rawResponse != nil}
   /// Clears the value of `rawResponse`. Subsequent reads from it will return its default value.
   mutating func clearRawResponse() {self._rawResponse = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Response: Equatable, Sendable {
+  nonisolated enum OneOf_Response: Equatable, Sendable {
     /// Response data to send
     case responseData(Data)
     /// Error to raise instead of response message
@@ -106,7 +110,7 @@ struct Connectrpc_Conformance_V1_UnaryResponseDefinition: Sendable {
 
 /// A definition of responses to be sent from a streaming endpoint.
 /// Can be used to define responses for server-streaming or bidi-streaming calls.
-struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -126,11 +130,11 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   /// build a RequestInfo message with available information and append that to
   /// the error details.
   var error: Connectrpc_Conformance_V1_Error {
-    get {return _error ?? Connectrpc_Conformance_V1_Error()}
+    get {_error ?? Connectrpc_Conformance_V1_Error()}
     set {_error = newValue}
   }
   /// Returns true if `error` has been explicitly set.
-  var hasError: Bool {return self._error != nil}
+  var hasError: Bool {self._error != nil}
   /// Clears the value of `error`. Subsequent reads from it will return its default value.
   mutating func clearError() {self._error = nil}
 
@@ -143,11 +147,11 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   ///
   /// For test definitions, this field should be used instead of the above fields.
   var rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse {
-    get {return _rawResponse ?? Connectrpc_Conformance_V1_RawHTTPResponse()}
+    get {_rawResponse ?? Connectrpc_Conformance_V1_RawHTTPResponse()}
     set {_rawResponse = newValue}
   }
   /// Returns true if `rawResponse` has been explicitly set.
-  var hasRawResponse: Bool {return self._rawResponse != nil}
+  var hasRawResponse: Bool {self._rawResponse != nil}
   /// Clears the value of `rawResponse`. Subsequent reads from it will return its default value.
   mutating func clearRawResponse() {self._rawResponse = nil}
 
@@ -159,18 +163,18 @@ struct Connectrpc_Conformance_V1_StreamResponseDefinition: Sendable {
   fileprivate var _rawResponse: Connectrpc_Conformance_V1_RawHTTPResponse? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnaryRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnaryRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The response definition which should be returned in the conformance payload
   var responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -184,18 +188,18 @@ struct Connectrpc_Conformance_V1_UnaryRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with.
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -206,18 +210,18 @@ struct Connectrpc_Conformance_V1_UnaryResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The response definition which should be returned in the conformance payload
   var responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -231,18 +235,18 @@ struct Connectrpc_Conformance_V1_IdempotentUnaryRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with.
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -253,18 +257,18 @@ struct Connectrpc_Conformance_V1_IdempotentUnaryResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ServerStreamRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ServerStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The response definition which should be returned in the conformance payload.
   var responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_StreamResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_StreamResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -278,18 +282,18 @@ struct Connectrpc_Conformance_V1_ServerStreamRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -300,7 +304,7 @@ struct Connectrpc_Conformance_V1_ServerStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -309,11 +313,11 @@ struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
   /// complete. Required in the first message in the stream, but
   /// should be ignored in subsequent messages.
   var responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_UnaryResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -328,18 +332,18 @@ struct Connectrpc_Conformance_V1_ClientStreamRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_UnaryResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -350,7 +354,7 @@ struct Connectrpc_Conformance_V1_ClientStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -358,11 +362,11 @@ struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
   /// Tells the server how to reply; required in the first message
   /// in the stream. Should be ignored in subsequent messages.
   var responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition {
-    get {return _responseDefinition ?? Connectrpc_Conformance_V1_StreamResponseDefinition()}
+    get {_responseDefinition ?? Connectrpc_Conformance_V1_StreamResponseDefinition()}
     set {_responseDefinition = newValue}
   }
   /// Returns true if `responseDefinition` has been explicitly set.
-  var hasResponseDefinition: Bool {return self._responseDefinition != nil}
+  var hasResponseDefinition: Bool {self._responseDefinition != nil}
   /// Clears the value of `responseDefinition`. Subsequent reads from it will return its default value.
   mutating func clearResponseDefinition() {self._responseDefinition = nil}
 
@@ -392,18 +396,18 @@ struct Connectrpc_Conformance_V1_BidiStreamRequest: Sendable {
   fileprivate var _responseDefinition: Connectrpc_Conformance_V1_StreamResponseDefinition? = nil
 }
 
-struct Connectrpc_Conformance_V1_BidiStreamResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_BidiStreamResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The conformance payload to respond with
   var payload: Connectrpc_Conformance_V1_ConformancePayload {
-    get {return _payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
+    get {_payload ?? Connectrpc_Conformance_V1_ConformancePayload()}
     set {_payload = newValue}
   }
   /// Returns true if `payload` has been explicitly set.
-  var hasPayload: Bool {return self._payload != nil}
+  var hasPayload: Bool {self._payload != nil}
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   mutating func clearPayload() {self._payload = nil}
 
@@ -414,7 +418,7 @@ struct Connectrpc_Conformance_V1_BidiStreamResponse: Sendable {
   fileprivate var _payload: Connectrpc_Conformance_V1_ConformancePayload? = nil
 }
 
-struct Connectrpc_Conformance_V1_UnimplementedRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnimplementedRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -424,7 +428,7 @@ struct Connectrpc_Conformance_V1_UnimplementedRequest: Sendable {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -434,7 +438,7 @@ struct Connectrpc_Conformance_V1_UnimplementedResponse: Sendable {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -445,17 +449,17 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
 
   /// Echoes back information about the request stream observed so far.
   var requestInfo: Connectrpc_Conformance_V1_ConformancePayload.RequestInfo {
-    get {return _requestInfo ?? Connectrpc_Conformance_V1_ConformancePayload.RequestInfo()}
+    get {_requestInfo ?? Connectrpc_Conformance_V1_ConformancePayload.RequestInfo()}
     set {_requestInfo = newValue}
   }
   /// Returns true if `requestInfo` has been explicitly set.
-  var hasRequestInfo: Bool {return self._requestInfo != nil}
+  var hasRequestInfo: Bool {self._requestInfo != nil}
   /// Clears the value of `requestInfo`. Subsequent reads from it will return its default value.
   mutating func clearRequestInfo() {self._requestInfo = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct RequestInfo: Sendable {
+  nonisolated struct RequestInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -467,11 +471,11 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
     /// type of uint32, but we want to be lenient here to allow whatever value the RPC
     /// server observes, even if it's outside the range of uint32.
     var timeoutMs: Int64 {
-      get {return _timeoutMs ?? 0}
+      get {_timeoutMs ?? 0}
       set {_timeoutMs = newValue}
     }
     /// Returns true if `timeoutMs` has been explicitly set.
-    var hasTimeoutMs: Bool {return self._timeoutMs != nil}
+    var hasTimeoutMs: Bool {self._timeoutMs != nil}
     /// Clears the value of `timeoutMs`. Subsequent reads from it will return its default value.
     mutating func clearTimeoutMs() {self._timeoutMs = nil}
 
@@ -490,11 +494,11 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
     /// server framework, at a minimum, at least expose to application code whether the
     /// request used GET vs. POST.
     var connectGetInfo: Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo {
-      get {return _connectGetInfo ?? Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo()}
+      get {_connectGetInfo ?? Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo()}
       set {_connectGetInfo = newValue}
     }
     /// Returns true if `connectGetInfo` has been explicitly set.
-    var hasConnectGetInfo: Bool {return self._connectGetInfo != nil}
+    var hasConnectGetInfo: Bool {self._connectGetInfo != nil}
     /// Clears the value of `connectGetInfo`. Subsequent reads from it will return its default value.
     mutating func clearConnectGetInfo() {self._connectGetInfo = nil}
 
@@ -506,7 +510,7 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
     fileprivate var _connectGetInfo: Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo? = nil
   }
 
-  struct ConnectGetInfo: Sendable {
+  nonisolated struct ConnectGetInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -525,7 +529,7 @@ struct Connectrpc_Conformance_V1_ConformancePayload: Sendable {
 }
 
 /// An error definition used for specifying a desired error response
-struct Connectrpc_Conformance_V1_Error: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_Error: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -539,11 +543,11 @@ struct Connectrpc_Conformance_V1_Error: Sendable {
   /// error conditions where the exact message to be used is not specified, only the
   /// code.
   var message: String {
-    get {return _message ?? String()}
+    get {_message ?? String()}
     set {_message = newValue}
   }
   /// Returns true if `message` has been explicitly set.
-  var hasMessage: Bool {return self._message != nil}
+  var hasMessage: Bool {self._message != nil}
   /// Clears the value of `message`. Subsequent reads from it will return its default value.
   mutating func clearMessage() {self._message = nil}
 
@@ -559,7 +563,7 @@ struct Connectrpc_Conformance_V1_Error: Sendable {
 }
 
 /// A tuple of name and values (ASCII) for a header or trailer entry.
-struct Connectrpc_Conformance_V1_Header: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_Header: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -580,7 +584,7 @@ struct Connectrpc_Conformance_V1_Header: Sendable {
 /// RawHTTPRequest models a raw HTTP request. This can be used to craft
 /// custom requests with odd properties (including certain kinds of
 /// malformed requests) to test edge cases in servers.
-struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -625,7 +629,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Body: Equatable, Sendable {
+  nonisolated enum OneOf_Body: Equatable, Sendable {
     /// The body is a single message.
     case unary(Connectrpc_Conformance_V1_MessageContents)
     /// The body is a stream, encoded using a five-byte
@@ -634,7 +638,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 
   }
 
-  struct EncodedQueryParam: Sendable {
+  nonisolated struct EncodedQueryParam: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -644,11 +648,11 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 
     /// Query param value.
     var value: Connectrpc_Conformance_V1_MessageContents {
-      get {return _value ?? Connectrpc_Conformance_V1_MessageContents()}
+      get {_value ?? Connectrpc_Conformance_V1_MessageContents()}
       set {_value = newValue}
     }
     /// Returns true if `value` has been explicitly set.
-    var hasValue: Bool {return self._value != nil}
+    var hasValue: Bool {self._value != nil}
     /// Clears the value of `value`. Subsequent reads from it will return its default value.
     mutating func clearValue() {self._value = nil}
 
@@ -667,7 +671,7 @@ struct Connectrpc_Conformance_V1_RawHTTPRequest: Sendable {
 }
 
 /// MessageContents represents a message in a request body.
-struct Connectrpc_Conformance_V1_MessageContents: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_MessageContents: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -711,7 +715,7 @@ struct Connectrpc_Conformance_V1_MessageContents: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The message data can be defined in one of three ways.
-  enum OneOf_Data: Equatable, Sendable {
+  nonisolated enum OneOf_Data: Equatable, Sendable {
     /// Arbitrary bytes.
     case binary(Data)
     /// Arbitrary text.
@@ -727,7 +731,7 @@ struct Connectrpc_Conformance_V1_MessageContents: Sendable {
 }
 
 /// StreamContents represents a sequence of messages in a request body.
-struct Connectrpc_Conformance_V1_StreamContents: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_StreamContents: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -737,7 +741,7 @@ struct Connectrpc_Conformance_V1_StreamContents: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct StreamItem: Sendable {
+  nonisolated struct StreamItem: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -747,20 +751,20 @@ struct Connectrpc_Conformance_V1_StreamContents: Sendable {
 
     /// if absent use actual length of payload
     var length: UInt32 {
-      get {return _length ?? 0}
+      get {_length ?? 0}
       set {_length = newValue}
     }
     /// Returns true if `length` has been explicitly set.
-    var hasLength: Bool {return self._length != nil}
+    var hasLength: Bool {self._length != nil}
     /// Clears the value of `length`. Subsequent reads from it will return its default value.
     mutating func clearLength() {self._length = nil}
 
     var payload: Connectrpc_Conformance_V1_MessageContents {
-      get {return _payload ?? Connectrpc_Conformance_V1_MessageContents()}
+      get {_payload ?? Connectrpc_Conformance_V1_MessageContents()}
       set {_payload = newValue}
     }
     /// Returns true if `payload` has been explicitly set.
-    var hasPayload: Bool {return self._payload != nil}
+    var hasPayload: Bool {self._payload != nil}
     /// Clears the value of `payload`. Subsequent reads from it will return its default value.
     mutating func clearPayload() {self._payload = nil}
 
@@ -778,7 +782,7 @@ struct Connectrpc_Conformance_V1_StreamContents: Sendable {
 /// RawHTTPResponse models a raw HTTP response. This can be used to craft
 /// custom responses with odd properties (including certain kinds of
 /// malformed responses) to test edge cases in clients.
-struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -815,7 +819,7 @@ struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Body: Equatable, Sendable {
+  nonisolated enum OneOf_Body: Equatable, Sendable {
     /// The body is a single message.
     case unary(Connectrpc_Conformance_V1_MessageContents)
     /// The body is a stream, encoded using a five-byte
@@ -829,9 +833,9 @@ struct Connectrpc_Conformance_V1_RawHTTPResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryResponseDefinition"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{3}response_data\0\u{1}error\0\u{3}response_trailers\0\u{3}raw_response\0\u{3}response_delay_ms\0")
 
@@ -913,7 +917,7 @@ extension Connectrpc_Conformance_V1_UnaryResponseDefinition: SwiftProtobuf.Messa
   }
 }
 
-extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamResponseDefinition"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_headers\0\u{3}response_data\0\u{3}response_delay_ms\0\u{1}error\0\u{3}response_trailers\0\u{3}raw_response\0")
 
@@ -972,7 +976,7 @@ extension Connectrpc_Conformance_V1_StreamResponseDefinition: SwiftProtobuf.Mess
   }
 }
 
-extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
@@ -1011,7 +1015,7 @@ extension Connectrpc_Conformance_V1_UnaryRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnaryResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1045,7 +1049,7 @@ extension Connectrpc_Conformance_V1_UnaryResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IdempotentUnaryRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
@@ -1084,7 +1088,7 @@ extension Connectrpc_Conformance_V1_IdempotentUnaryRequest: SwiftProtobuf.Messag
   }
 }
 
-extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IdempotentUnaryResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1118,7 +1122,7 @@ extension Connectrpc_Conformance_V1_IdempotentUnaryResponse: SwiftProtobuf.Messa
   }
 }
 
-extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerStreamRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
@@ -1157,7 +1161,7 @@ extension Connectrpc_Conformance_V1_ServerStreamRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServerStreamResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1191,7 +1195,7 @@ extension Connectrpc_Conformance_V1_ServerStreamResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientStreamRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}request_data\0")
 
@@ -1230,7 +1234,7 @@ extension Connectrpc_Conformance_V1_ClientStreamRequest: SwiftProtobuf.Message, 
   }
 }
 
-extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClientStreamResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1264,7 +1268,7 @@ extension Connectrpc_Conformance_V1_ClientStreamResponse: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BidiStreamRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_definition\0\u{3}full_duplex\0\u{3}request_data\0")
 
@@ -1308,7 +1312,7 @@ extension Connectrpc_Conformance_V1_BidiStreamRequest: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Connectrpc_Conformance_V1_BidiStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_BidiStreamResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BidiStreamResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
 
@@ -1342,7 +1346,7 @@ extension Connectrpc_Conformance_V1_BidiStreamResponse: SwiftProtobuf.Message, S
   }
 }
 
-extension Connectrpc_Conformance_V1_UnimplementedRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnimplementedRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnimplementedRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1361,7 +1365,7 @@ extension Connectrpc_Conformance_V1_UnimplementedRequest: SwiftProtobuf.Message,
   }
 }
 
-extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnimplementedResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1380,7 +1384,7 @@ extension Connectrpc_Conformance_V1_UnimplementedResponse: SwiftProtobuf.Message
   }
 }
 
-extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConformancePayload"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0\u{3}request_info\0")
 
@@ -1419,7 +1423,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload: SwiftProtobuf.Message, S
   }
 }
 
-extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ConformancePayload.protoMessageName + ".RequestInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_headers\0\u{3}timeout_ms\0\u{1}requests\0\u{3}connect_get_info\0")
 
@@ -1468,7 +1472,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload.RequestInfo: SwiftProtobu
   }
 }
 
-extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_ConformancePayload.protoMessageName + ".ConnectGetInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_params\0")
 
@@ -1498,7 +1502,7 @@ extension Connectrpc_Conformance_V1_ConformancePayload.ConnectGetInfo: SwiftProt
   }
 }
 
-extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Error"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}details\0")
 
@@ -1542,7 +1546,7 @@ extension Connectrpc_Conformance_V1_Error: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Header"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0")
 
@@ -1577,7 +1581,7 @@ extension Connectrpc_Conformance_V1_Header: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawHTTPRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}verb\0\u{1}uri\0\u{1}headers\0\u{3}raw_query_params\0\u{3}encoded_query_params\0\u{1}unary\0\u{1}stream\0")
 
@@ -1669,7 +1673,7 @@ extension Connectrpc_Conformance_V1_RawHTTPRequest: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_RawHTTPRequest.protoMessageName + ".EncodedQueryParam"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0\u{3}base64_encode\0")
 
@@ -1713,7 +1717,7 @@ extension Connectrpc_Conformance_V1_RawHTTPRequest.EncodedQueryParam: SwiftProto
   }
 }
 
-extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MessageContents"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}binary\0\u{1}text\0\u{3}binary_message\0\u{1}compression\0")
 
@@ -1792,7 +1796,7 @@ extension Connectrpc_Conformance_V1_MessageContents: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamContents"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}items\0")
 
@@ -1822,7 +1826,7 @@ extension Connectrpc_Conformance_V1_StreamContents: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_StreamContents.protoMessageName + ".StreamItem"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}flags\0\u{1}length\0\u{1}payload\0")
 
@@ -1866,7 +1870,7 @@ extension Connectrpc_Conformance_V1_StreamContents.StreamItem: SwiftProtobuf.Mes
   }
 }
 
-extension Connectrpc_Conformance_V1_RawHTTPResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_RawHTTPResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawHTTPResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}status_code\0\u{1}headers\0\u{1}unary\0\u{1}stream\0\u{1}trailers\0")
 

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/suite.pb.swift
@@ -29,7 +29,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -39,7 +39,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// suite, which can contain numerous cases. Each test suite has various properties
 /// that indicate the kinds of features that are tested. Test suites may be skipped
 /// based on whether the client or server under test implements these features.
-struct Connectrpc_Conformance_V1_TestSuite: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_TestSuite: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -96,7 +96,7 @@ struct Connectrpc_Conformance_V1_TestSuite: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum TestMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Used when the test suite does not apply to a particular mode. Such tests
@@ -146,7 +146,7 @@ struct Connectrpc_Conformance_V1_TestSuite: Sendable {
 
   }
 
-  enum ConnectVersionMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum ConnectVersionMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Used when the suite is agnostic to the server's validation
@@ -196,7 +196,7 @@ struct Connectrpc_Conformance_V1_TestSuite: Sendable {
   init() {}
 }
 
-struct Connectrpc_Conformance_V1_TestCase: Sendable {
+nonisolated struct Connectrpc_Conformance_V1_TestCase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -210,11 +210,11 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
   /// the test harness based on the test environment (e.g. actual server and
   ///  port to use) and characteristics of a single permutation.
   var request: Connectrpc_Conformance_V1_ClientCompatRequest {
-    get {return _request ?? Connectrpc_Conformance_V1_ClientCompatRequest()}
+    get {_request ?? Connectrpc_Conformance_V1_ClientCompatRequest()}
     set {_request = newValue}
   }
   /// Returns true if `request` has been explicitly set.
-  var hasRequest: Bool {return self._request != nil}
+  var hasRequest: Bool {self._request != nil}
   /// Clears the value of `request`. Subsequent reads from it will return its default value.
   mutating func clearRequest() {self._request = nil}
 
@@ -251,11 +251,11 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
   /// Specifying an expected response explicitly in test definitions will override
   /// the auto-generation of the test runner.
   var expectedResponse: Connectrpc_Conformance_V1_ClientResponseResult {
-    get {return _expectedResponse ?? Connectrpc_Conformance_V1_ClientResponseResult()}
+    get {_expectedResponse ?? Connectrpc_Conformance_V1_ClientResponseResult()}
     set {_expectedResponse = newValue}
   }
   /// Returns true if `expectedResponse` has been explicitly set.
-  var hasExpectedResponse: Bool {return self._expectedResponse != nil}
+  var hasExpectedResponse: Bool {self._expectedResponse != nil}
   /// Clears the value of `expectedResponse`. Subsequent reads from it will return its default value.
   mutating func clearExpectedResponse() {self._expectedResponse = nil}
 
@@ -268,7 +268,7 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct ExpandedSize: Sendable {
+  nonisolated struct ExpandedSize: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -278,11 +278,11 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
     /// Any value greater than zero indicates that the request size will be that
     /// many bytes over the limit.
     var sizeRelativeToLimit: Int32 {
-      get {return _sizeRelativeToLimit ?? 0}
+      get {_sizeRelativeToLimit ?? 0}
       set {_sizeRelativeToLimit = newValue}
     }
     /// Returns true if `sizeRelativeToLimit` has been explicitly set.
-    var hasSizeRelativeToLimit: Bool {return self._sizeRelativeToLimit != nil}
+    var hasSizeRelativeToLimit: Bool {self._sizeRelativeToLimit != nil}
     /// Clears the value of `sizeRelativeToLimit`. Subsequent reads from it will return its default value.
     mutating func clearSizeRelativeToLimit() {self._sizeRelativeToLimit = nil}
 
@@ -301,9 +301,9 @@ struct Connectrpc_Conformance_V1_TestCase: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "connectrpc.conformance.v1"
+fileprivate nonisolated let _protobuf_package = "connectrpc.conformance.v1"
 
-extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestSuite"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}mode\0\u{3}test_cases\0\u{3}relevant_protocols\0\u{3}relevant_http_versions\0\u{3}relevant_codecs\0\u{3}relevant_compressions\0\u{3}connect_version_mode\0\u{3}relies_on_tls\0\u{3}relies_on_tls_client_certs\0\u{3}relies_on_connect_get\0\u{3}relies_on_message_receive_limit\0")
 
@@ -388,15 +388,15 @@ extension Connectrpc_Conformance_V1_TestSuite: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Connectrpc_Conformance_V1_TestSuite.TestMode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestSuite.TestMode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0TEST_MODE_UNSPECIFIED\0\u{1}TEST_MODE_CLIENT\0\u{1}TEST_MODE_SERVER\0")
 }
 
-extension Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestSuite.ConnectVersionMode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CONNECT_VERSION_MODE_UNSPECIFIED\0\u{1}CONNECT_VERSION_MODE_REQUIRE\0\u{1}CONNECT_VERSION_MODE_IGNORE\0")
 }
 
-extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestCase"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}request\0\u{3}expand_requests\0\u{3}expected_response\0\u{3}other_allowed_error_codes\0")
 
@@ -445,7 +445,7 @@ extension Connectrpc_Conformance_V1_TestCase: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Connectrpc_Conformance_V1_TestCase.ExpandedSize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Connectrpc_Conformance_V1_TestCase.ExpandedSize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Connectrpc_Conformance_V1_TestCase.protoMessageName + ".ExpandedSize"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}size_relative_to_limit\0")
 

--- a/Tests/UnitTests/ConnectLibraryTests/buf.gen.yaml
+++ b/Tests/UnitTests/ConnectLibraryTests/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift:v1.31.0
+  - plugin: buf.build/apple/swift:v1.38.1
     opt: Visibility=Internal
     out: ./GeneratedSources
   - name: connect-swift


### PR DESCRIPTION
## Summary

Updates all Swift NIO / Protobuf dependencies to their latest versions:

| Dependency | Old | New |
|---|---|---|
| swift-nio | 2.92.2 | 2.101.3 |
| swift-nio-http2 | 1.39.0 | 1.44.0 |
| swift-nio-ssl | 2.36.0 | 2.37.2 |
| swift-protobuf | 1.31.0 | 1.38.1 |

Follows the "Updating Dependencies" process in `.github/CONTRIBUTING.md`:

- `Package.swift` version bumps
- Both `Package.resolved` files re-resolved (main package + `ElizaSwiftPackageApp`)
- `Connect-Swift.podspec` / `Connect-Swift-Mocks.podspec` → `SwiftProtobuf ~> 1.38.1`
- All four `buf.gen.yaml` files → `buf.build/apple/swift:v1.38.1`
- `pod update` in `ElizaCocoaPodsApp` (Podfile.lock → SwiftProtobuf 1.38.1)
- `make buildplugins && make generate` to regenerate code with the new plugin

The regenerated `*.pb.swift` diff is purely the newer `buf.build/apple/swift` plugin emitting `nonisolated` on generated types (a SwiftProtobuf Swift 6 codegen improvement).

## ⚠️ Prerequisite: land the conformance-flakiness fix first

The swift-nio bump **amplifies a pre-existing `NIOHTTPClient` deinit-on-event-loop bug**. Older NIO tolerated `deinit` shutting down the client's own event loop while callbacks were still queued; newer NIO floods stderr (~24×/run) with:

> `Cannot schedule tasks on an EventLoop that has already shut down. This will be upgraded to a forced crash in future SwiftNIO versions.`

The conformance client processes requests serially, so a process death fails everything queued — producing flaky `run-conformance-tests` bursts (see test plan). The fix already exists on **`eddie/conformance-test-flakiness`** (switches `deinit` to async `shutdownGracefully { _ in }`). That branch should merge **before or together with** this one; newer NIO's explicit "forced crash in future" warning makes it effectively a prerequisite.

## Other known follow-up

The bump also surfaces **4 `Sendable` warnings** in `NIOHTTPClient.swift` (build still succeeds). Clearing them requires migrating off the now-deprecated `HTTP2StreamMultiplexer` to the inline `NIOHTTP2Handler.StreamMultiplexer` — a behavior-sensitive HTTP/2 change that warrants its own conformance-tested PR. Tracked in #408.

## Test plan (run locally on this branch)

- [x] `swift build` succeeds
- [x] `make testunit` — **72 tests, 0 failures**
- [x] `make testconformance` (urlsession) — **966/966 passed**
- [x] `make testconformance` (nio) — passes **1681/1681** on a clean run, **but flaky**: an earlier run gave 629 passed / 101 failed / 951 unrun due to the deinit issue above. Blocked on the `eddie/conformance-test-flakiness` fix for stable CI.
- [x] Example apps build — `ElizaSwiftPackageApp` (SPM) and `ElizaCocoaPodsApp` (CocoaPods) both **BUILD SUCCEEDED**
