### PR TITLE
Migrate NIOHTTPClient off deprecated HTTP2StreamMultiplexer

### DIFF
--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -15,11 +15,11 @@
 import Connect
 import Foundation
 import NIOConcurrencyHelpers
-@preconcurrency import NIOCore
+import NIOCore
 import NIOHTTP1
 import NIOHTTP2
 import NIOPosix
-@preconcurrency import NIOSSL
+import NIOSSL
 import os.log
 
 /// HTTP client powered by Swift NIO which supports trailers (unlike URLSession).
@@ -32,13 +32,13 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     private let timeout: TimeInterval?
     private let useSSL: Bool
 
-    private var pendingRequests = [(NIOHTTP2.HTTP2StreamMultiplexer?) -> Void]()
+    private var pendingRequests = [(NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer?) -> Void]()
     private var state = State.disconnected
 
     private enum State {
         case disconnected
         case connecting
-        case connected(channel: NIOCore.Channel, multiplexer: NIOHTTP2.HTTP2StreamMultiplexer)
+        case connected(channel: NIOCore.Channel, multiplexer: NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer)
     }
 
     /// Designated initializer for the client.
@@ -74,28 +74,21 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
             .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
-                do {
-                    let channelPipeline: EventLoopFuture<Void>
+                channel.eventLoop.makeCompletedFuture {
                     if let tlsConfiguration = tlsConfiguration {
                         let sslContext = try NIOSSL.NIOSSLContext(configuration: tlsConfiguration)
                         let sslHandler = try NIOSSL.NIOSSLClientHandler(
                             context: sslContext, serverHostname: host
                         )
-                        channelPipeline = channel.pipeline
-                            .addHandler(sslHandler)
-                    } else {
-                        channelPipeline = channel.pipeline
-                            .addHandlers([])
+                        try channel.pipeline.syncOperations.addHandler(sslHandler)
                     }
-
-                    return channelPipeline.flatMap {
-                        return channel.configureHTTP2Pipeline(mode: .client) { channel in
-                            return channel.eventLoop.makeSucceededVoidFuture()
-                        }
+                    _ = try channel.pipeline.syncOperations.configureHTTP2Pipeline(
+                        mode: .client,
+                        connectionConfiguration: .init(),
+                        streamConfiguration: .init()
+                    ) { channel in
+                        channel.eventLoop.makeSucceededVoidFuture()
                     }
-                    .map { (_: NIOHTTP2.HTTP2StreamMultiplexer) in }
-                } catch {
-                    return channel.close(mode: .all)
                 }
             }
     }
@@ -173,7 +166,9 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
 
     // MARK: - Private
 
-    private func sendOrQueueRequest(send: @escaping (NIOHTTP2.HTTP2StreamMultiplexer?) -> Void) {
+    private func sendOrQueueRequest(
+        send: @escaping (NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer?) -> Void
+    ) {
         self.lock.withLock {
             switch self.state {
             case .connected(_, let multiplexer):
@@ -198,7 +193,8 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
                     switch result {
                     case .success(let channel):
                         let multiplexer = try channel.pipeline.syncOperations
-                            .handler(type: HTTP2StreamMultiplexer.self)
+                            .handler(type: NIOHTTP2.NIOHTTP2Handler.self)
+                            .syncMultiplexer()
                         channel.closeFuture.whenComplete { [weak self] _ in
                             self?.lock.withLock { self?.state = .disconnected }
                         }
@@ -219,7 +215,9 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
             }
     }
 
-    private func flushOrFailPendingRequests(using multiplexer: NIOHTTP2.HTTP2StreamMultiplexer?) {
+    private func flushOrFailPendingRequests(
+        using multiplexer: NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer?
+    ) {
         for request in self.pendingRequests {
             request(multiplexer)
         }
@@ -229,13 +227,16 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     private func startMultiplexChannel(
         for url: URL,
         on eventLoop: NIOCore.EventLoop,
-        using multiplexer: NIOHTTP2.HTTP2StreamMultiplexer,
-        with connectHandler: any NIOCore.ChannelInboundHandler
+        using multiplexer: NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer,
+        with connectHandler: any NIOCore.ChannelInboundHandler & Sendable
     ) {
-        let handlers = self.createChannelHandlers(with: connectHandler)
         let promise = eventLoop.makePromise(of: NIOCore.Channel.self)
         multiplexer.createStreamChannel(promise: promise) { channel in
-            return channel.pipeline.addHandlers(handlers)
+            channel.eventLoop.makeCompletedFuture {
+                try channel.pipeline.syncOperations.addHandlers(
+                    self.createChannelHandlers(with: connectHandler)
+                )
+            }
         }
     }
 
@@ -271,6 +272,6 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
 
 private extension ConnectError {
     static func disconnected() -> Self {
-        return .init(code: .unavailable, message: "client is not connected")
+        .init(code: .unavailable, message: "client is not connected")
     }
 }

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -38,7 +38,9 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     private enum State {
         case disconnected
         case connecting
-        case connected(channel: NIOCore.Channel, multiplexer: NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer)
+        case connected(
+            channel: NIOCore.Channel, multiplexer: NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer
+        )
     }
 
     /// Designated initializer for the client.


### PR DESCRIPTION
Fixes #408.

## Summary

Building `ConnectNIO` against recent `swift-nio-http2` releases produces a series of Sendable and deprecation warnings originating in `NIOHTTPClient`. The root cause is that the client was still built on `NIOHTTP2.HTTP2StreamMultiplexer`, which NIO has deprecated in favor of the inline multiplexer, `NIOHTTP2Handler.StreamMultiplexer`. This PR migrates `NIOHTTPClient` to the supported API, which eliminates all of the warnings without changing the client's public API or behavior.

## Changes

**Adopt `NIOHTTP2Handler.StreamMultiplexer`.** All references to the deprecated `HTTP2StreamMultiplexer` (the `pendingRequests` queue, the `State.connected` case, and the `sendOrQueueRequest`/`flushOrFailPendingRequests`/`startMultiplexChannel` signatures) now use `NIOHTTP2Handler.StreamMultiplexer`. After the connection is established, the multiplexer is retrieved via `pipeline.syncOperations.handler(type: NIOHTTP2Handler.self).syncMultiplexer()`, which is the supported pattern for the inline multiplexer.

**Configure the pipeline synchronously in the channel initializer.** The `channelInitializer` previously chained `EventLoopFuture`s (`pipeline.addHandler(...)` / `channel.configureHTTP2Pipeline(...)`), which both used the deprecated multiplexer under the hood and required passing non-`Sendable` values into `@Sendable` closures. It now wraps the setup in `eventLoop.makeCompletedFuture { ... }` and uses `pipeline.syncOperations` to add the SSL handler and configure the HTTP/2 pipeline. Since the initializer runs on the channel's event loop, the synchronous API is safe here, avoids the future-chaining entirely, and lets thrown errors (e.g. from `NIOSSLContext` creation) propagate through the completed future instead of the previous manual `do`/`catch` + `channel.close()` fallback.

**Create stream channels the same way.** `startMultiplexChannel` now builds its per-stream handlers inside `eventLoop.makeCompletedFuture { ... }` using `syncOperations.addHandlers(...)`, matching the connection-level setup. The `connectHandler` parameter is now `any ChannelInboundHandler & Sendable`, which the inline multiplexer's `@Sendable` stream initializer requires; both concrete handler types passed here (`ConnectUnaryChannelHandler` and `ConnectStreamChannelHandler`) already satisfy it.

**Remove `@preconcurrency` imports.** With the deprecated API gone, the `@preconcurrency` annotations on `import NIOCore` and `import NIOSSL` are no longer needed and have been removed, so any future concurrency issues in this file will surface as warnings rather than being suppressed.

## Why this approach

The deprecation message on `HTTP2StreamMultiplexer` directs users to `NIOHTTP2Handler.StreamMultiplexer`, and the inline multiplexer is where NIO's Sendable-correct APIs live. Migrating to it fixes the warnings at the source rather than suppressing them, keeps `ConnectNIO` on NIO's supported path, and requires no changes for consumers of `NIOHTTPClient`.

## Validation

- `swift build` completes with no warnings in `ConnectNIO`.
- Unit tests pass (`make testunit`).
- Conformance tests pass for both the URLSession and NIO clients (`make testconformance`).
- The example apps (Swift PM and CocoaPods) build successfully.