### PR TITLE
Swift 6 strict concurrency: enforce, document, and close the remaining gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,18 @@ jobs:
       - uses: actions/checkout@v7
       - name: Build Connect watchOS library
         run: set -o pipefail && xcodebuild -scheme Connect-Package -destination 'platform=watchOS Simulator,name=Apple Watch Ultra 3 (49mm),OS=latest' | xcbeautify
+  build-strict-concurrency:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+      # The package builds in Swift 6 language mode (see `swiftLanguageModes` in
+      # Package.swift), so strict concurrency violations are already errors. This job
+      # guards the remaining gap: warnings. Without it, a strict-concurrency warning
+      # (for example one downgraded by `@preconcurrency`) can land unnoticed.
+      # `--build-tests` extends the guarantee to the test targets, which the
+      # `xcodebuild -scheme Connect-Package` jobs above do not cover.
+      - name: Build all targets and tests with warnings as errors
+        run: swift build --build-tests -Xswiftc -warnings-as-errors
   build-plugin-and-generate:
     runs-on: macos-26
     steps:

--- a/Connect-Swift-Mocks.podspec
+++ b/Connect-Swift-Mocks.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |spec|
 
   spec.source_files = 'Libraries/ConnectMocks/**/*.swift'
 
-  spec.swift_versions = ['5.0']
+  spec.swift_versions = ['5.0', '6.0']
 end

--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |spec|
 
   spec.source_files = 'Libraries/Connect/**/*.swift'
 
-  spec.swift_versions = ['5.0']
+  spec.swift_versions = ['5.0', '6.0']
 end

--- a/Examples/ElizaCocoaPodsApp/Podfile.lock
+++ b/Examples/ElizaCocoaPodsApp/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Connect-Swift: cf227f8460d3c73adfc2dd8b7f4cc60ea91e9e0d
+  Connect-Swift: c0ac8943a512f31723359cb463f9c4294e52ba54
   SwiftProtobuf: 409d3aaec90e51b1705b1dd8065b56893450e77c
 
 PODFILE CHECKSUM: b598f373a6ab5add976b09c2ac79029bf2200d48

--- a/Libraries/Connect/Internal/Streaming/BidirectionalAsyncStream.swift
+++ b/Libraries/Connect/Internal/Streaming/BidirectionalAsyncStream.swift
@@ -33,7 +33,16 @@ class BidirectionalAsyncStream<
     private var receiveResult: ((StreamResult<Output>) -> Void)!
     /// Callbacks used to send outbound data and close the stream.
     /// Optional because these callbacks are not available until the stream is initialized.
-    private var requestCallbacks: RequestCallbacks<Input>?
+    ///
+    /// Guarded by a lock rather than left as a plain `var`: this is written once by
+    /// `configureForSending(with:)` but read from arbitrary threads, including the
+    /// `@Sendable` `continuation.onTermination` closure below, which fires on whichever
+    /// thread cancels or tears down the consuming task. The class is `@unchecked Sendable`,
+    /// so the compiler cannot flag an unsynchronized access here.
+    ///
+    /// Only the reference read is performed under the lock. Never invoke a callback while
+    /// holding it - they re-enter interceptor and network code.
+    private let requestCallbacks = Locked<RequestCallbacks<Input>?>(nil)
 
     private struct NotConfiguredForSendingError: Swift.Error {}
 
@@ -55,7 +64,7 @@ class BidirectionalAsyncStream<
                 }
             }
             continuation.onTermination = { @Sendable _ in
-                self.requestCallbacks?.sendClose()
+                self.requestCallbacks.value?.sendClose()
             }
         }
     }
@@ -69,7 +78,7 @@ class BidirectionalAsyncStream<
     /// - returns: This instance of the stream (useful for chaining).
     @discardableResult
     func configureForSending(with requestCallbacks: RequestCallbacks<Input>) -> Self {
-        self.requestCallbacks = requestCallbacks
+        self.requestCallbacks.value = requestCallbacks
         return self
     }
 
@@ -86,7 +95,7 @@ class BidirectionalAsyncStream<
 extension BidirectionalAsyncStream: BidirectionalAsyncStreamInterface {
     @discardableResult
     func send(_ input: Input) throws -> Self {
-        guard let sendData = self.requestCallbacks?.sendData else {
+        guard let sendData = self.requestCallbacks.value?.sendData else {
             throw NotConfiguredForSendingError()
         }
 
@@ -99,10 +108,10 @@ extension BidirectionalAsyncStream: BidirectionalAsyncStreamInterface {
     }
 
     func close() {
-        self.requestCallbacks?.sendClose()
+        self.requestCallbacks.value?.sendClose()
     }
 
     func cancel() {
-        self.requestCallbacks?.cancel()
+        self.requestCallbacks.value?.cancel()
     }
 }

--- a/Libraries/Connect/Internal/Streaming/ClientOnlyStream.swift
+++ b/Libraries/Connect/Internal/Streaming/ClientOnlyStream.swift
@@ -23,7 +23,15 @@ final class ClientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>: @
     private let receivedResults = Locked([StreamResult<Output>]())
     /// Callbacks used to send outbound data and close the stream.
     /// Optional because these callbacks are not available until the stream is initialized.
-    private var requestCallbacks: RequestCallbacks<Input>?
+    ///
+    /// Guarded by a lock rather than left as a plain `var`: this is written once by
+    /// `configureForSending(with:)` but read from arbitrary threads by `send()`,
+    /// `closeAndReceive()` and `cancel()`. The class is `@unchecked Sendable`, so the
+    /// compiler cannot flag an unsynchronized access here.
+    ///
+    /// Only the reference read is performed under the lock. Never invoke a callback while
+    /// holding it - they re-enter interceptor and network code.
+    private let requestCallbacks = Locked<RequestCallbacks<Input>?>(nil)
 
     private struct NotConfiguredForSendingError: Swift.Error {}
 
@@ -40,7 +48,7 @@ final class ClientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>: @
     /// - returns: This instance of the stream (useful for chaining).
     @discardableResult
     func configureForSending(with requestCallbacks: RequestCallbacks<Input>) -> Self {
-        self.requestCallbacks = requestCallbacks
+        self.requestCallbacks.value = requestCallbacks
         return self
     }
 
@@ -67,7 +75,7 @@ final class ClientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>: @
 extension ClientOnlyStream: ClientOnlyStreamInterface {
     @discardableResult
     func send(_ input: Input) throws -> Self {
-        guard let sendData = self.requestCallbacks?.sendData else {
+        guard let sendData = self.requestCallbacks.value?.sendData else {
             throw NotConfiguredForSendingError()
         }
 
@@ -76,10 +84,10 @@ extension ClientOnlyStream: ClientOnlyStreamInterface {
     }
 
     func closeAndReceive() {
-        self.requestCallbacks?.sendClose()
+        self.requestCallbacks.value?.sendClose()
     }
 
     func cancel() {
-        self.requestCallbacks?.cancel()
+        self.requestCallbacks.value?.cancel()
     }
 }

--- a/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
+++ b/Libraries/Connect/Internal/Streaming/URLSessionStream.swift
@@ -18,6 +18,20 @@ import Foundation
 ///
 /// Note: This class is `@unchecked Sendable` because the `Foundation.{Input|Output}Stream`
 /// types do not conform to `Sendable`.
+///
+/// Known gap, deliberately not addressed here: `writeStream` is written by `sendData(_:)` and
+/// closed by `close()` with no lock. Both are reachable concurrently through
+/// `RequestCallbacks.sendData` / `.sendClose`, which `ProtocolClient`'s
+/// `PendingRequestCallbacks` does not serialize, so concurrent `sendData(_:)` calls can
+/// interleave writes into the bound `OutputStream`. Unlike the other `@unchecked Sendable`
+/// sites in this package - which are safe by an unenforced convention - this is a genuine
+/// latent race.
+///
+/// It is left alone on purpose: the fix (a lock around the `writeStream.write` loop and
+/// `close()`) changes throughput behavior under load, and this file already carries two
+/// hard-won CFNetwork workarounds (see `requestBodyStream` below, plus #399 and #412). It
+/// belongs in its own change gated on both conformance runs and a client-streaming soak,
+/// rather than being folded into a non-behavioral concurrency-annotation pass.
 final class URLSessionStream: NSObject, @unchecked Sendable {
     private let closedByServer = Locked(false)
     private let readStream: Foundation.InputStream

--- a/Libraries/Connect/Internal/Utilities/Lock.swift
+++ b/Libraries/Connect/Internal/Utilities/Lock.swift
@@ -25,6 +25,10 @@ final class Lock: @unchecked Sendable {
         self.underlyingLock.initialize(to: os_unfair_lock())
     }
 
+    // Deinit isolation audit: safe on any thread. Swift 6 does not check the isolation of
+    // `deinit`, so this is verified by inspection rather than by the compiler. There is no
+    // isolation requirement here, and the lock cannot be held at this point because `deinit`
+    // only runs once the last reference is gone.
     deinit {
         self.underlyingLock.deinitialize(count: 1)
         self.underlyingLock.deallocate()

--- a/Libraries/Connect/Internal/Utilities/Locked.swift
+++ b/Libraries/Connect/Internal/Utilities/Locked.swift
@@ -16,6 +16,14 @@ import Foundation
 
 /// Class containing an internal lock which can be used to ensure thread-safe access to an
 /// underlying value. Conforms to `Sendable`, making it accessible from `@Sendable` closures.
+///
+/// `Wrapped` is intentionally unconstrained. Constraining it to `Sendable` would break the
+/// main reason this type exists - guarding values that are not themselves `Sendable` - which
+/// is the standard trade-off for a mutex box, and is why this type is `@unchecked Sendable`.
+///
+/// `ConnectNIO` has its own minimal copy of this type (see `GRPCInterceptor.swift`) because
+/// this one is `internal` to the `Connect` module and cannot be shared across the module
+/// boundary; that file documents why the alternatives were rejected.
 final class Locked<Wrapped>: @unchecked Sendable {
     private let lock = Lock()
     private var wrappedValue: Wrapped

--- a/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
+++ b/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
@@ -16,7 +16,17 @@ import Foundation
 
 final class TimeoutTimer: @unchecked Sendable {
     private let hasTimedOut = Locked(false)
-    private var onTimeout: (() -> Void)?
+    /// Callback to invoke when the deadline is reached.
+    ///
+    /// Guarded by a lock rather than confined to `queue`: the class is
+    /// `@unchecked Sendable`, so nothing structurally prevented a future edit from reading
+    /// this from off-queue, and the compiler could not flag it.
+    ///
+    /// The callback must be read out of the lock and invoked *outside* it. It re-enters this
+    /// object - `ProtocolClient` passes a closure that cancels the in-flight request, and
+    /// cancelation can lead back to `cancel()` or to `deinit`. Holding a lock across it
+    /// reintroduces the deadlock fixed in #389.
+    private let onTimeout = Locked<(@Sendable () -> Void)?>(nil)
     private let queue = DispatchQueue(label: "connectrpc.Timeout")
     private let timeout: TimeInterval
     private var workItem: DispatchWorkItem! // Force-unwrapped to allow capturing self in init
@@ -33,7 +43,9 @@ final class TimeoutTimer: @unchecked Sendable {
         self.timeout = timeout
         self.workItem = DispatchWorkItem { [weak self] in
             self?.hasTimedOut.value = true
-            self?.onTimeout?()
+            // Read the callback out of the lock before invoking it - see `onTimeout` above.
+            let onTimeout = self?.onTimeout.value
+            onTimeout?()
         }
     }
 
@@ -41,9 +53,13 @@ final class TimeoutTimer: @unchecked Sendable {
         self.cancel()
     }
 
-    func start(onTimeout: @escaping () -> Void) {
+    /// Start the timer. Must be called at most once per instance: the callback is assigned
+    /// before the work item is scheduled, so the work item cannot observe a `nil` callback.
+    ///
+    /// - parameter onTimeout: Closure to invoke if the deadline is reached before `cancel()`.
+    func start(onTimeout: @escaping @Sendable () -> Void) {
         let milliseconds = Int(self.timeout * 1_000)
-        self.queue.sync { self.onTimeout = onTimeout }
+        self.onTimeout.value = onTimeout
         self.queue.asyncAfter(
             deadline: .now() + .milliseconds(milliseconds), execute: self.workItem
         )

--- a/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
+++ b/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
@@ -49,6 +49,14 @@ final class TimeoutTimer: @unchecked Sendable {
         }
     }
 
+    // Deinit isolation audit: safe on any thread, including from inside `onTimeout` itself.
+    // Swift 6 does not check the isolation of `deinit`, so this is verified by inspection.
+    //
+    // This is not hypothetical: before #389 `cancel()` wrapped `workItem.cancel()` in
+    // `queue.sync`, and when the timer's own work item released the last reference, `deinit`
+    // re-entered the serial queue and deadlocked. `DispatchWorkItem.cancel()` is thread-safe
+    // and non-blocking, which is the only reason this is safe - do not reintroduce a
+    // `queue.sync` or any lock acquisition here.
     deinit {
         self.cancel()
     }

--- a/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
@@ -440,31 +440,35 @@ extension ProtocolClient: ProtocolClientInterface {
     }
 }
 
-private final class PendingRequestCallbacks: @unchecked Sendable {
-    private let lock = Lock()
-    private var callbacks: RequestCallbacks<Data>?
-    private var queue = [(RequestCallbacks<Data>) -> Void]()
+private final class PendingRequestCallbacks: Sendable {
+    private struct State {
+        var callbacks: RequestCallbacks<Data>?
+        var queue = [@Sendable (RequestCallbacks<Data>) -> Void]()
+    }
+
+    private let state = Locked(State())
 
     func setCallbacks(_ callbacks: RequestCallbacks<Data>) {
-        var pendingActions: [(RequestCallbacks<Data>) -> Void] = []
-        self.lock.perform {
-            self.callbacks = callbacks
-            pendingActions = self.queue
-            self.queue = []
+        // Actions run outside the lock to avoid lock-ordering hazards with
+        // locks acquired by the actions themselves.
+        let pendingActions = self.state.perform { state in
+            state.callbacks = callbacks
+            let queued = state.queue
+            state.queue = []
+            return queued
         }
         for action in pendingActions {
             action(callbacks)
         }
     }
 
-    func enqueue(_ action: @escaping (RequestCallbacks<Data>) -> Void) {
-        var callbacksToCall: RequestCallbacks<Data>?
-        self.lock.perform {
-            if let callbacks = self.callbacks {
-                callbacksToCall = callbacks
-            } else {
-                self.queue.append(action)
+    func enqueue(_ action: @escaping @Sendable (RequestCallbacks<Data>) -> Void) {
+        let callbacksToCall = self.state.perform { state -> RequestCallbacks<Data>? in
+            if let callbacks = state.callbacks {
+                return callbacks
             }
+            state.queue.append(action)
+            return nil
         }
         if let callbacks = callbacksToCall {
             action(callbacks)

--- a/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/URLSessionHTTPClient.swift
@@ -48,6 +48,11 @@ open class URLSessionHTTPClient: NSObject, HTTPClientInterface, @unchecked Senda
         delegate.client = self
     }
 
+    // Deinit isolation audit: safe on any thread, including the delegate `OperationQueue`.
+    // Swift 6 does not check the isolation of `deinit`, so this is verified by inspection.
+    // `finishTasksAndInvalidate()` is asynchronous and callable from any thread, and
+    // `URLSessionDelegateWrapper` holds only a `weak` reference back to this client, so the
+    // session's strong hold on its delegate does not keep this object alive or block dealloc.
     deinit {
         self.session.finishTasksAndInvalidate()
     }
@@ -199,6 +204,17 @@ open class URLSessionHTTPClient: NSObject, HTTPClientInterface, @unchecked Senda
 /// To work around this, `URLSessionDelegateWrapper` maintains a `weak` reference to the
 /// `URLSessionHTTPClient` and passes delegate calls through to it, avoiding the retain cycle.
 private final class URLSessionDelegateWrapper: NSObject, @unchecked Sendable {
+    /// Deliberately left unsynchronized, and the reason `@unchecked Sendable` is needed here.
+    ///
+    /// This is written exactly once, in `URLSessionHTTPClient.init` immediately after
+    /// `super.init()`, and that write happens-before any delegate callback can arrive:
+    /// `URLSession` cannot dispatch a callback for a task that does not exist yet, and no task
+    /// can be created until `init` returns. Reads then all occur on the delegate
+    /// `OperationQueue`, which is configured with `maxConcurrentOperationCount = 1`.
+    ///
+    /// It cannot be a `let`: the retain-cycle avoidance described above requires assigning
+    /// `self` after `super.init()`. Wrapping it would need a `weak` box type that does not
+    /// exist here, which is not worth it for one write-once slot.
     weak var client: URLSessionHTTPClient?
 }
 

--- a/Libraries/Connect/Public/Interfaces/Streaming/Callbacks/BidirectionalStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/Callbacks/BidirectionalStreamInterface.swift
@@ -15,7 +15,11 @@
 import SwiftProtobuf
 
 /// Represents a bidirectional stream that can send request messages and initiate closes.
-public protocol BidirectionalStreamInterface<Input> {
+///
+/// Requires `Sendable` for the same reason as `BidirectionalAsyncStreamInterface`: streams are
+/// vended by `ProtocolClientInterface` (itself `Sendable`) and are used across threads, since
+/// results arrive on whichever thread the underlying HTTP client delivers them on.
+public protocol BidirectionalStreamInterface<Input>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage
 

--- a/Libraries/Connect/Public/Interfaces/Streaming/Callbacks/ClientOnlyStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/Callbacks/ClientOnlyStreamInterface.swift
@@ -16,7 +16,11 @@ import SwiftProtobuf
 
 /// Represents a client-only stream (a stream where the client streams data to the server and
 /// eventually receives a response) that can send request messages and initiate closes.
-public protocol ClientOnlyStreamInterface<Input> {
+///
+/// Requires `Sendable` for the same reason as `ClientOnlyAsyncStreamInterface`: streams are
+/// vended by `ProtocolClientInterface` (itself `Sendable`) and are used across threads, since
+/// results arrive on whichever thread the underlying HTTP client delivers them on.
+public protocol ClientOnlyStreamInterface<Input>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage
 

--- a/Libraries/Connect/Public/Interfaces/Streaming/Callbacks/ServerOnlyStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/Callbacks/ServerOnlyStreamInterface.swift
@@ -16,7 +16,11 @@ import SwiftProtobuf
 
 /// Represents a server-only stream (a stream where the server streams data to the client after
 /// receiving an initial request) that can send request messages.
-public protocol ServerOnlyStreamInterface<Input> {
+///
+/// Requires `Sendable` for the same reason as `ServerOnlyAsyncStreamInterface`: streams are
+/// vended by `ProtocolClientInterface` (itself `Sendable`) and are used across threads, since
+/// results arrive on whichever thread the underlying HTTP client delivers them on.
+public protocol ServerOnlyStreamInterface<Input>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage
 

--- a/Libraries/ConnectMocks/MockBidirectionalAsyncStream.swift
+++ b/Libraries/ConnectMocks/MockBidirectionalAsyncStream.swift
@@ -24,6 +24,11 @@ import SwiftProtobuf
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)` or by
 /// subclassing and overriding `results()`.
+///
+/// Note: This class does not handle thread-safe locking, but provides `@unchecked Sendable`
+/// conformance to simplify testing and mocking. It is intended for single-test use: configure
+/// it, exercise it, then assert on it. Do not share an instance across concurrent tests or
+/// mutate its properties from multiple threads.
 @available(iOS 13, *)
 open class MockBidirectionalAsyncStream<
     Input: ProtobufMessage,

--- a/Libraries/ConnectMocks/MockBidirectionalStream.swift
+++ b/Libraries/ConnectMocks/MockBidirectionalStream.swift
@@ -23,6 +23,11 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+///
+/// Note: This class does not handle thread-safe locking, but provides `@unchecked Sendable`
+/// conformance to simplify testing and mocking. It is intended for single-test use: configure
+/// it, exercise it, then assert on it. Do not share an instance across concurrent tests or
+/// mutate its properties from multiple threads.
 @available(iOS 13, *)
 open class MockBidirectionalStream<
     Input: ProtobufMessage,

--- a/Libraries/ConnectMocks/MockClientOnlyAsyncStream.swift
+++ b/Libraries/ConnectMocks/MockClientOnlyAsyncStream.swift
@@ -23,6 +23,11 @@ import SwiftProtobuf
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)` or by
 /// subclassing and overriding `results()`.
+///
+/// Note: This class does not handle thread-safe locking, but provides `@unchecked Sendable`
+/// conformance to simplify testing and mocking. It is intended for single-test use: configure
+/// it, exercise it, then assert on it. Do not share an instance across concurrent tests or
+/// mutate its properties from multiple threads.
 @available(iOS 13, *)
 open class MockClientOnlyAsyncStream<
     Input: ProtobufMessage,

--- a/Libraries/ConnectMocks/MockClientOnlyStream.swift
+++ b/Libraries/ConnectMocks/MockClientOnlyStream.swift
@@ -22,6 +22,11 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+///
+/// Note: This class does not handle thread-safe locking, but provides `@unchecked Sendable`
+/// conformance to simplify testing and mocking. It is intended for single-test use: configure
+/// it, exercise it, then assert on it. Do not share an instance across concurrent tests or
+/// mutate its properties from multiple threads.
 @available(iOS 13, *)
 open class MockClientOnlyStream<
     Input: ProtobufMessage,

--- a/Libraries/ConnectMocks/MockServerOnlyAsyncStream.swift
+++ b/Libraries/ConnectMocks/MockServerOnlyAsyncStream.swift
@@ -24,6 +24,11 @@ import SwiftProtobuf
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)` or by
 /// subclassing and overriding `results()`.
+///
+/// Note: This class does not handle thread-safe locking, but provides `@unchecked Sendable`
+/// conformance to simplify testing and mocking. It is intended for single-test use: configure
+/// it, exercise it, then assert on it. Do not share an instance across concurrent tests or
+/// mutate its properties from multiple threads.
 @available(iOS 13, *)
 open class MockServerOnlyAsyncStream<
     Input: ProtobufMessage,

--- a/Libraries/ConnectMocks/MockServerOnlyStream.swift
+++ b/Libraries/ConnectMocks/MockServerOnlyStream.swift
@@ -23,6 +23,11 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+///
+/// Note: This class does not handle thread-safe locking, but provides `@unchecked Sendable`
+/// conformance to simplify testing and mocking. It is intended for single-test use: configure
+/// it, exercise it, then assert on it. Do not share an instance across concurrent tests or
+/// mutate its properties from multiple threads.
 @available(iOS 13, *)
 open class MockServerOnlyStream<
     Input: ProtobufMessage,

--- a/Libraries/ConnectNIO/Internal/ConnectStreamChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectStreamChannelHandler.swift
@@ -19,6 +19,19 @@ import NIOFoundationCompat
 import NIOHTTP1
 
 /// NIO-based channel handler for streams made through the Connect library.
+///
+/// The mutable state below is deliberately unsynchronized, and this is why the type is
+/// `@unchecked Sendable` rather than checked. Safety rests on two invariants the compiler
+/// cannot see:
+///
+/// 1. NIO invokes `ChannelInboundHandler` callbacks (`channelActive`, `channelRead`,
+///    `handlerAdded`, `handlerRemoved`, `channelInactive`, `errorCaught`,
+///    `userInboundEventTriggered`) only on this channel's `EventLoop`.
+/// 2. Every externally reachable entry point - `sendData(_:)`, `close()`, `cancel()` - funnels
+///    through `runOnEventLoop(action:)`, which hops to that same `EventLoop`.
+///
+/// Any new method that touches this state must go through `runOnEventLoop(action:)`. Adding
+/// one that does not is a data race, and nothing in the type system will stop it.
 final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @unchecked Sendable {
     private let eventLoop: NIOCore.EventLoop
     private let request: Connect.HTTPRequest<Data?>

--- a/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
@@ -22,8 +22,8 @@ import NIOHTTP1
 final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecked Sendable {
     private let eventLoop: NIOCore.EventLoop
     private let request: Connect.HTTPRequest<Data?>
-    private let onMetrics: (Connect.HTTPMetrics) -> Void
-    private let onResponse: (Connect.HTTPResponse) -> Void
+    private let onMetrics: @Sendable (Connect.HTTPMetrics) -> Void
+    private let onResponse: @Sendable (Connect.HTTPResponse) -> Void
 
     private var context: NIOCore.ChannelHandlerContext?
     private var isClosed = false
@@ -35,8 +35,8 @@ final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecke
     init(
         request: Connect.HTTPRequest<Data?>,
         eventLoop: NIOCore.EventLoop,
-        onMetrics: @escaping (Connect.HTTPMetrics) -> Void,
-        onResponse: @escaping (Connect.HTTPResponse) -> Void
+        onMetrics: @escaping @Sendable (Connect.HTTPMetrics) -> Void,
+        onResponse: @escaping @Sendable (Connect.HTTPResponse) -> Void
     ) {
         self.request = request
         self.eventLoop = eventLoop

--- a/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
@@ -19,6 +19,19 @@ import NIOFoundationCompat
 import NIOHTTP1
 
 /// NIO-based channel handler for unary requests made through the Connect library.
+///
+/// The mutable state below is deliberately unsynchronized, and this is why the type is
+/// `@unchecked Sendable` rather than checked. Safety rests on two invariants the compiler
+/// cannot see:
+///
+/// 1. NIO invokes `ChannelInboundHandler` callbacks (`channelActive`, `channelRead`,
+///    `handlerAdded`, `handlerRemoved`, `channelInactive`, `errorCaught`,
+///    `userInboundEventTriggered`) only on this channel's `EventLoop`.
+/// 2. The one externally reachable entry point, `cancel()`, funnels through
+///    `runOnEventLoop(action:)`, which hops to that same `EventLoop`.
+///
+/// Any new method that touches this state must go through `runOnEventLoop(action:)`. Adding
+/// one that does not is a data race, and nothing in the type system will stop it.
 final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecked Sendable {
     private let eventLoop: NIOCore.EventLoop
     private let request: Connect.HTTPRequest<Data?>

--- a/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
+++ b/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
@@ -280,6 +280,15 @@ private extension Envelope {
     }
 }
 
+/// Minimal lock-guarded box, intentionally duplicated from `Connect`'s internal `Locked<T>`
+/// rather than shared.
+///
+/// `Connect.Locked` is `internal` to the `Connect` module, so this module cannot see it. The
+/// obvious fix - promoting it to `package` access - does not work: `Connect-Swift.podspec`
+/// ships `Libraries/Connect/**/*.swift` and CocoaPods compiles without `-package-name`, which
+/// the `package` access level requires. Promoting it to `public` under the `PackageInternal`
+/// convention would work but permanently grows `Connect`'s public API surface to deduplicate
+/// a dozen lines. Both were considered and rejected; keep them separate.
 private final class Locked<T>: @unchecked Sendable {
     private let lock = NIOLock()
     private var wrappedValue: T

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -77,6 +77,18 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     /// when creating new connections thereafter.
     /// This function may be used as an external customization point.
     ///
+    /// Important: the returned bootstrap **must** use this client's own event loop group.
+    /// `unary(...)` and `stream(...)` bind each channel handler to `self.loopGroup.next()` and
+    /// funnel every external entry point through that loop, while NIO delivers the handler's
+    /// inbound callbacks on whichever loop its channel belongs to. If those are two different
+    /// loops, both invariants documented on `ConnectUnaryChannelHandler` and
+    /// `ConnectStreamChannelHandler` break at once and the handler's unsynchronized state is
+    /// read and written concurrently. That is a silent data race, not a trap - the handlers are
+    /// `@unchecked Sendable`, so neither the compiler nor NIO will flag it. Overrides should
+    /// therefore customize the bootstrap returned by `super.createBootstrap()`
+    /// (e.g. `super.createBootstrap().channelOption(...)`) rather than constructing a
+    /// `ClientBootstrap` on a group of their own.
+    ///
     /// - returns: The bootstrap that should be used for creating new connections.
     open func createBootstrap() -> NIOPosix.ClientBootstrap {
         let host = self.host
@@ -204,6 +216,18 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
                 do {
                     switch result {
                     case .success(let channel):
+                        // Debug-only guard for the constraint documented on `createBootstrap()`.
+                        // `loopGroup` has a single loop, so `next()` identifies it. Deliberately
+                        // placed outside `lock.withLock`: the strong `self` this creates may be
+                        // the last reference, and running `deinit` - which takes the lock - while
+                        // the lock is held would deadlock.
+                        assert(
+                            self.map { channel.eventLoop === $0.loopGroup.next() } ?? true,
+                            """
+                            createBootstrap() must use the client's own event loop group; \
+                            customize super.createBootstrap() instead of building a new one.
+                            """
+                        )
                         let multiplexer = try channel.pipeline.syncOperations
                             .handler(type: NIOHTTP2.NIOHTTP2Handler.self)
                             .syncMultiplexer()

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -32,8 +32,14 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     private let timeout: TimeInterval?
     private let useSSL: Bool
 
-    private var pendingRequests = [(NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer?) -> Void]()
+    private var pendingRequests = [PendingRequest]()
     private var state = State.disconnected
+
+    /// Closure invoked with the HTTP/2 multiplexer once a connection is established, or with
+    /// `nil` if connecting failed. Queued while the client is connecting and drained from an
+    /// event-loop callback, hence `@Sendable`.
+    private typealias PendingRequest =
+        @Sendable (NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer?) -> Void
 
     private enum State {
         case disconnected
@@ -168,9 +174,7 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
 
     // MARK: - Private
 
-    private func sendOrQueueRequest(
-        send: @escaping (NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer?) -> Void
-    ) {
+    private func sendOrQueueRequest(send: @escaping PendingRequest) {
         self.lock.withLock {
             switch self.state {
             case .connected(_, let multiplexer):
@@ -243,7 +247,7 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     }
 
     private func createChannelHandlers(
-        with connectHandler: any NIOCore.ChannelInboundHandler
+        with connectHandler: any NIOCore.ChannelInboundHandler & Sendable
     ) -> [NIOCore.ChannelHandler] {
         var handlers: [NIOCore.ChannelHandler] = [
             self.useSSL

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -24,6 +24,12 @@ import os.log
 
 /// HTTP client powered by Swift NIO which supports trailers (unlike URLSession).
 open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
+    /// Lazy initialization is *not* atomic. This is safe only because its sole reader,
+    /// `connectChannelAndMultiplexerIfNeeded()`, is called exclusively from inside
+    /// `sendOrQueueRequest`'s `lock.withLock` block, so the one-time initialization is
+    /// serialized by that lock. Reading `self.bootstrap` from anywhere outside the lock would
+    /// be a race on the lazy initialization itself, and the compiler cannot flag it because
+    /// this class is `@unchecked Sendable`.
     private lazy var bootstrap = self.createBootstrap()
     private let host: String
     private let lock = NIOConcurrencyHelpers.NIOLock()
@@ -263,6 +269,20 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         return handlers
     }
 
+    // Deinit isolation audit: safe, and the most delicate `deinit` in the package. Swift 6
+    // does not check the isolation of `deinit`, so both hazards below are verified by
+    // inspection only - a zero-warning strict-concurrency build says nothing about them.
+    //
+    // Hazard 1 - shutting down the group from one of its own loops. Addressed in #407 and
+    // described in the comment on `shutdownGracefully` below.
+    //
+    // Hazard 2 - lock re-entrancy. `NIOLock` is not reentrant and this `deinit` acquires it.
+    // That is safe only because every closure that could release the last reference holds a
+    // strong reference across the whole `withLock` expression via its *outer* optional chain:
+    // `self?.lock.withLock { self?... }` keeps `self` alive for the duration of the call, so
+    // an inner `self?` temporary can never be the last release. Rewriting any of those
+    // closures to `guard let self` and calling `self.lock.withLock` would silently break this
+    // and deadlock here. Do not refactor them without re-deriving this property.
     deinit {
         self.lock.withLock {
             if case .connected(let channel, _) = self.state {
@@ -272,6 +292,16 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         // An event loop callback can release the client's last reference, running `deinit` on that
         // event loop. The synchronous `syncShutdownGracefully()` call will trap there because the
         // loop cannot wait for itself to stop, so initiate shutdown asynchronously.
+        //
+        // Known consequence: a `Cancelable` returned by `unary(...)` captures its handler
+        // strongly, and the handler holds its `EventLoop` strongly, but the group is owned by
+        // this client. A `Cancelable` invoked after the client is gone therefore reaches
+        // `runOnEventLoop` -> `EventLoop.submit` on a loop this call has already shut down.
+        // SwiftNIO currently logs "Cannot schedule tasks on an EventLoop that has already
+        // shut down" and ignores it - the conformance suite emits ~25 such lines per NIO run,
+        // both before and after this migration - but SwiftNIO states it will become a forced
+        // crash in a future version. Fixing it means tying handler/`Cancelable` lifetime to
+        // the client rather than to the closure; tracked as follow-up, not addressed here.
         self.loopGroup.shutdownGracefully { _ in }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:6.0
 
 // Copyright 2022-2025 The Connect Authors
 //
@@ -166,5 +166,5 @@ let package = Package(
             path: "Plugins/ConnectSwiftPlugin"
         ),
     ],
-    swiftLanguageVersions: [.version("6"), .v5]
+    swiftLanguageModes: [.v6, .v5]
 )

--- a/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
+++ b/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
@@ -64,6 +64,9 @@ final class ConnectMockGenerator: Generator {
         self.printLine("///")
         self.printLine("/// Note: This class does not handle thread-safe locking, but provides")
         self.printLine("/// `@unchecked Sendable` conformance to simplify testing and mocking.")
+        self.printLine("/// It is intended for single-test use: configure it, exercise it, then")
+        self.printLine("/// assert on it. Do not share an instance across concurrent tests or")
+        self.printLine("/// mutate its properties from multiple threads.")
         self.printLine("@available(iOS 13, *)")
         self.printLine(
             """

--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ To use `protoc` instead of `buf`, add a `--connect-swift_out` flag to
 +    my.proto
 ```
 
+## Requirements
+
+Swift Package Manager consumption requires **Xcode 16 / Swift 6** (or newer)
+because the package manifest uses `swift-tools-version:6.0`.
+CocoaPods consumers can still build the library in Swift 5 or Swift 6 mode
+as declared in the podspecs.
+
 ## Quick Start
 
 Head over to our [quick start tutorial][getting-started] to get started.

--- a/Tests/ConformanceClient/Sources/ConformanceInvoker.swift
+++ b/Tests/ConformanceClient/Sources/ConformanceInvoker.swift
@@ -155,7 +155,12 @@ final class ConformanceInvoker: Sendable {
         let unaryRequest = try Connectrpc_Conformance_V1_UnaryRequest(
             unpackingAny: self.context.requestMessages[0]
         )
-        let task = Task { [unowned self] in
+        // Unstructured `Task` on purpose: the conformance `cancelTiming` matrix needs a handle
+        // to cancel this call independently of the enclosing task, which structured
+        // concurrency does not allow. `self` is captured strongly - the task is a local and is
+        // never stored on `self`, so there is no retain cycle, and a strong capture cannot
+        // become a use-after-free if an early return is ever added before `await task.value`.
+        let task = Task {
             return await self.client.unary(
                 request: unaryRequest,
                 headers: .fromConformanceHeaders(self.context.requestHeaders)
@@ -189,7 +194,8 @@ final class ConformanceInvoker: Sendable {
         let unaryRequest = try Connectrpc_Conformance_V1_IdempotentUnaryRequest(
             unpackingAny: self.context.requestMessages[0]
         )
-        let task = Task { [unowned self] in
+        // Unstructured `Task` on purpose, with a strong `self` capture - see `invokeUnary()`.
+        let task = Task {
             return await self.client.idempotentUnary(
                 request: unaryRequest,
                 headers: .fromConformanceHeaders(self.context.requestHeaders)

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTests.swift
@@ -54,12 +54,51 @@ struct TimeoutTests {
         #expect((error as? ConnectError)?.message == "request exceeded allowed timeout")
     }
 
+    /// A terminal callback can cancel the timer before `ProtocolClient` reaches its
+    /// `start()` call, so cancelation must be sticky rather than a no-op.
+    @available(iOS 13, *)
+    @Test
+    func cancelBeforeStartDisarmsTimer() async throws {
+        let timer = try #require(TimeoutTimer(config: self.makeConfig()))
+        let didTimeOut = Locked(false)
+
+        timer.cancel()
+        timer.start(onTimeout: { didTimeOut.value = true })
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(didTimeOut.value == false)
+        #expect(timer.timedOut == false)
+    }
+
+    /// A cancelation racing `start()` must not be lost.
+    @available(iOS 13, *)
+    @Test
+    func cancelConcurrentWithStartDisarmsTimer() async throws {
+        let timers = try (0..<100).map { _ in
+            try #require(TimeoutTimer(config: self.makeConfig()))
+        }
+        let timedOutCount = Locked(0)
+        await withTaskGroup(of: Void.self) { group in
+            for timer in timers {
+                group.addTask {
+                    timer.start(onTimeout: { timedOutCount.perform { $0 += 1 } })
+                }
+                group.addTask { timer.cancel() }
+            }
+        }
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(timedOutCount.value == 0)
+    }
+
+    private func makeConfig() -> ProtocolClientConfig {
+        return ProtocolClientConfig(host: "http://localhost", timeout: 0.01)
+    }
+
     private func makeClient() -> Connectrpc_Conformance_V1_ConformanceServiceClient {
-        let config = ProtocolClientConfig(
-            host: "http://localhost",
-            timeout: 0.01
+        let protocolClient = ProtocolClient(
+            httpClient: TimeoutHTTPClient(), config: self.makeConfig()
         )
-        let protocolClient = ProtocolClient(httpClient: TimeoutHTTPClient(), config: config)
         return Connectrpc_Conformance_V1_ConformanceServiceClient(client: protocolClient)
     }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTests.swift
@@ -64,7 +64,10 @@ struct TimeoutTests {
     }
 }
 
-private final class TimeoutHTTPClient: HTTPClientInterface, @unchecked Sendable {
+/// Stateless by design - it holds no stored properties, so `Sendable` is checked by the
+/// compiler rather than asserted with `@unchecked`. Per-request state lives in `Locked`
+/// values captured by the returned closures.
+private final class TimeoutHTTPClient: HTTPClientInterface, Sendable {
     @discardableResult
     func unary(
         request: HTTPRequest<Data?>,

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.mock.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.mock.swift
@@ -20,6 +20,9 @@ import SwiftProtobuf
 ///
 /// Note: This class does not handle thread-safe locking, but provides
 /// `@unchecked Sendable` conformance to simplify testing and mocking.
+/// It is intended for single-test use: configure it, exercise it, then
+/// assert on it. Do not share an instance across concurrent tests or
+/// mutate its properties from multiple threads.
 @available(iOS 13, *)
 internal class Connectrpc_Conformance_V1_ConformanceServiceClientMock: Connectrpc_Conformance_V1_ConformanceServiceClientInterface, @unchecked Sendable {
     private var cancellables = [Combine.AnyCancellable]()


### PR DESCRIPTION
## Problem

The package has been buildable in Swift 6 language mode for a while — `Package.swift` already listed Swift 6 first in `swiftLanguageVersions`, so the library, mocks, and NIO targets all compiled under full strict concurrency with zero warnings. What was missing was everything around that fact:

- **Nothing enforced it.** No CI job built with strict-concurrency warnings as errors, so a `@preconcurrency`-downgraded warning could land unnoticed and the zero-warning state could rot silently.
- **The manifest was stale.** `swift-tools-version:5.6` with the deprecated `swiftLanguageVersions` spelling, while the package's actual floor had moved.
- **Twenty `@unchecked Sendable` sites carried no justification.** Some are structurally required (`open` classes consumers subclass, the `Lock`/`Locked` primitives themselves, event-loop-confined NIO handlers). Others were just unsynchronized `var`s that predated `Locked`. Nothing in the source distinguished the two, so a reader could not tell a deliberate escape hatch from an oversight — and neither could the next person to edit them.
- **One real API asymmetry.** The three callback-based stream protocols did not require `Sendable`; their three async/await counterparts did.

So this is not a "make it compile" migration. It is a hedging-correctness and lock-it-in pass.

## Changes

Fourteen commits, each independently reviewable. Grouped by theme below.

### Manifest and enforcement

- **`Package.swift`** — `swift-tools-version:6.0`, and `swiftLanguageVersions: [.version("6"), .v5]` → `swiftLanguageModes: [.v6, .v5]`. Behavior-neutral; the package already resolved to Swift 6 mode.
- **`.github/workflows/ci.yml`** — new `build-strict-concurrency` job running `swift build --build-tests -Xswiftc -warnings-as-errors`. Swift 6 language mode already makes strict-concurrency *violations* errors; this job closes the remaining gap, which is warnings. `--build-tests` extends the guarantee to the test targets, which the `xcodebuild -scheme Connect-Package` jobs do not cover.

### Real synchronization fixes

These changed behavior, not just annotations.

- **`BidirectionalAsyncStream.swift`, `ClientOnlyStream.swift`** — `requestCallbacks` was a plain `var` written by `configureForSending(with:)` and read from arbitrary threads, including `AsyncStream`'s `@Sendable onTermination` closure, which fires on whichever thread tears down the consuming task. Both now hold it in `Locked`. Only the reference read happens under the lock — the callbacks re-enter interceptor and transport code, so invoking them while holding it would be a lock-ordering hazard.
- **`TimeoutTimer.swift`** — `onTimeout` was written under `queue.sync` and read unsynchronized from the timer's own work item. It is now `Locked`, and the callback is read out of the lock *before* being invoked. That ordering is load-bearing: the closure `ProtocolClient` passes cancels the in-flight request, and cancelation can lead back into `cancel()` or `deinit`. Holding a lock across it reintroduces the deadlock fixed in #389.
- **`ProtocolClient.swift`** — `PendingRequestCallbacks` folded from `Lock` + two mutable vars into a single `Locked<State>` and made checked `Sendable`. Queued closures gain `@Sendable`, which they always needed in practice: stored on one thread, invoked on whichever completes the request. Actions are still collected inside the lock and invoked outside it.
- **`ConnectUnaryChannelHandler.swift`** — the stored `onMetrics` / `onResponse` callbacks were not `@Sendable` despite being invoked from the event loop after crossing a thread boundary. Now annotated, along with `NIOHTTPClient`'s queued `PendingRequest` closures and `createChannelHandlers`' handler parameter.

### Written-down invariants

The compiler cannot check these, so they are stated in-source, at the site where a future edit would break them.

- **`ConnectStreamChannelHandler.swift`, `ConnectUnaryChannelHandler.swift`** — why the mutable state is deliberately unsynchronized: NIO invokes `ChannelInboundHandler` callbacks only on the channel's `EventLoop`, and every external entry point funnels through `runOnEventLoop(action:)`. Any new method that touches this state and skips that hop is a data race, and nothing in the type system will stop it.
- **`NIOHTTPClient.swift`** — three separate hazards. (1) The lazy `bootstrap` is not atomically initialized and is safe only because its sole reader runs inside `lock.withLock`. (2) `deinit` acquires a non-reentrant `NIOLock`, which is safe only because every closure that could release the last reference holds it across the whole `withLock` expression via its *outer* optional chain — rewriting any of those to `guard let self` would deadlock. (3) `createBootstrap()` is an `open` customization point, and an override returning a bootstrap on a foreign event loop group breaks both handler confinement invariants at once; a debug `assert` now catches it.
- **`Lock.swift`, `Locked.swift`, `URLSessionStream.swift`, `URLSessionHTTPClient.swift`** — deinit isolation audits (Swift 6 does not check `deinit` isolation, so these are verified by inspection), plus why each type's unchecked conformance is structural rather than lazy.
- **`GRPCInterceptor.swift`** — why `ConnectNIO` duplicates a minimal `Locked` instead of sharing `Connect`'s. Promoting it to `package` access does not work: `Connect-Swift.podspec` ships these sources and CocoaPods compiles without `-package-name`. Promoting to `public` would permanently grow the public API surface to deduplicate a dozen lines. Both were considered and rejected.

### Mocks and test targets

- **Six `ConnectMocks` base classes + the generator template** — documented as single-test-use and not thread-safe. The gap was the reverse of what it looked like: the generator already emitted a thread-safety note, but the hand-written base classes that consumers actually subclass carried none. `service.mock.swift` is regenerated in the same commit, since `build-plugin-and-generate` fails on any diff.
- **`TimeoutHTTPClient`** (test double) — was `@unchecked Sendable` despite having no stored properties at all. Now plain `Sendable`.
- **`ConformanceInvoker.swift`** — `[unowned self]` → strong capture in two `Task` blocks. Safe before, but fragile: an early `return` inserted before `await task.value` would have turned it into a use-after-free rather than a compile error. The unstructured `Task` is deliberately kept — the conformance `cancelTiming` matrix needs a handle to cancel independently of the enclosing task.
- **`TimeoutTests.swift`** — two regression tests for sticky cancelation (cancel-before-start, and cancel racing start). `TimeoutTimer` creates its `DispatchWorkItem` in `init`, so a cancelation landing first is preserved by construction; these lock in a property that currently holds for a structural reason.

### Packaging and docs

- **Both podspecs** — `swift_versions = ['5.0', '6.0']`. CocoaPods sets the *pod target's* Swift version from this field independently of the integrating app's, so `build-eliza-cocoapods-example` now compiles the `Connect` pod target at Swift 6 while the example app stays at 5.0. That makes it the only Swift 6 build of these sources that goes through CocoaPods' build settings rather than SwiftPM's. `Podfile.lock` moves with it because `SPEC CHECKSUMS` hashes the podspec.
- **`README.md`** — new Requirements section. SwiftPM consumption now needs Xcode 16 / Swift 6, and an Xcode 15 consumer gets a *resolution* failure with no indication of which dependency raised the floor.

## Breaking change and release impact

**One source-breaking change**, isolated as the last of the original nine commits so it can be dropped or split out without disturbing the rest:

`BidirectionalStreamInterface`, `ClientOnlyStreamInterface`, and `ServerOnlyStreamInterface` now require `Sendable`. Their async counterparts already did — the omission looks unintentional rather than deliberate, and every conformer in this repository already declared `Sendable`, so the build required no other source changes.

The user-visible effect of the gap: `ProtocolClientInterface` is `Sendable` but vended `any BidirectionalStreamInterface<Input>`, a non-Sendable existential, so callers could not move a callback stream across an isolation boundary even though the concrete type was safe to move.

Who breaks: anyone implementing one of these three protocols on a non-`Sendable` type — realistically a hand-rolled test double that bypasses `ConnectMocks`. The fix is one line per type, and the diagnostic names it.

**This ships in a major release**, consistent with the README's Status section. The podspec `version` field is deliberately untouched at `1.2.3`; bumping it is a separate release-time commit per the convention in ed56816.

## What this deliberately does not do

- **`@unchecked Sendable` declaration sites move 20 → 19** in `Libraries/` (plus one in the test target). That is the intended outcome. Most remaining uses are structurally required, and converting them for the sake of the count would mean restructuring working code to satisfy a metric. Where a conversion was genuinely free — `PendingRequestCallbacks`, `TimeoutHTTPClient` — it was taken.
- **`URLSessionStream.writeStream` is left racy, on purpose.** `sendData(_:)` and `close()` both touch it with no lock, and `PendingRequestCallbacks` does not serialize them, so concurrent sends can interleave writes into the bound `OutputStream`. Unlike the other unchecked sites, this is a genuine latent race rather than a safe-by-convention one, and it is documented as such in-source. The fix changes throughput behavior under load and belongs in its own PR gated on conformance plus a client-streaming soak — not folded into an annotation pass.
- **A `Cancelable` outliving its `NIOHTTPClient`** reaches `EventLoop.submit` on an already-shut-down loop. SwiftNIO logs this and ignores it today but states it will become a forced crash. The NIO conformance run emits 28 such lines both before and after this branch (a run at pre-migration `6a6bc81` emits the same), so it is pre-existing. Fixing it means tying handler/`Cancelable` lifetime to the client; tracked as follow-up.

## Validation

Run against the final tree:

| Check | Result |
| --- | --- |
| `swift build --build-tests -Xswiftc -warnings-as-errors` | clean |
| `swiftlint lint --strict` | 0 violations, 103 files |
| `make testunit` | 72/72 passing |
| `make testconformance` — URLSession | 966 passed / 0 failed |
| `make testconformance` — NIO | 1681 passed / 0 failed |
| CocoaPods example (`pod install` + `xcodebuild`) | BUILD SUCCEEDED, pod target at `SWIFT_VERSION = 6.0` |
| `make buildplugins && make generate` | only the intended comment diff |

The NIO conformance run emits 28 `Cannot schedule tasks on an EventLoop that has already shut down` lines — the known pre-existing behavior described above, unchanged by this branch.

`cancelConcurrentWithStartDisarmsTimer` races 100 start/cancel pairs against a 10ms deadline, so it is the most timing-sensitive test added here. It was run 10 additional times in isolation with no failures. If it ever flakes in CI, the fix is raising the configured timeout, not weakening the assertion.
