### PR TITLE
Raise minimum iOS deployment target to iOS 13

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -99,7 +99,7 @@ modifier_order:
     - dynamic
     - convenience
 deployment_target:
-  iOS_deployment_target: 12.0
+  iOS_deployment_target: 13.0
 
 custom_rules:
   newline_after_brace:

--- a/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp/GeneratedSources/connectrpc/eliza/v1/eliza.connect.swift
+++ b/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp/GeneratedSources/connectrpc/eliza/v1/eliza.connect.swift
@@ -18,18 +18,15 @@ import SwiftProtobuf
 internal protocol Connectrpc_Eliza_V1_ElizaServiceClientInterface: Sendable {
 
     /// Say is a unary RPC. Eliza responds to the prompt with a single sentence.
-    @available(iOS 13, *)
     func `say`(request: Connectrpc_Eliza_V1_SayRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Eliza_V1_SayResponse>
 
     /// Converse is a bidirectional RPC. The caller may exchange multiple
     /// back-and-forth messages with Eliza over a long-lived connection. Eliza
     /// responds to each ConverseRequest with a ConverseResponse.
-    @available(iOS 13, *)
     func `converse`(headers: Connect.Headers) -> any Connect.BidirectionalAsyncStreamInterface<Connectrpc_Eliza_V1_ConverseRequest, Connectrpc_Eliza_V1_ConverseResponse>
 
     /// Introduce is a server streaming RPC. Given the caller's name, Eliza
     /// returns a stream of sentences to introduce itself.
-    @available(iOS 13, *)
     func `introduce`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Connectrpc_Eliza_V1_IntroduceRequest, Connectrpc_Eliza_V1_IntroduceResponse>
 }
 
@@ -41,17 +38,14 @@ internal final class Connectrpc_Eliza_V1_ElizaServiceClient: Connectrpc_Eliza_V1
         self.client = client
     }
 
-    @available(iOS 13, *)
     internal func `say`(request: Connectrpc_Eliza_V1_SayRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Connectrpc_Eliza_V1_SayResponse> {
         return await self.client.unary(path: "/connectrpc.eliza.v1.ElizaService/Say", idempotencyLevel: .noSideEffects, request: request, headers: headers)
     }
 
-    @available(iOS 13, *)
     internal func `converse`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Connectrpc_Eliza_V1_ConverseRequest, Connectrpc_Eliza_V1_ConverseResponse> {
         return self.client.bidirectionalStream(path: "/connectrpc.eliza.v1.ElizaService/Converse", headers: headers)
     }
 
-    @available(iOS 13, *)
     internal func `introduce`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Connectrpc_Eliza_V1_IntroduceRequest, Connectrpc_Eliza_V1_IntroduceResponse> {
         return self.client.serverOnlyStream(path: "/connectrpc.eliza.v1.ElizaService/Introduce", headers: headers)
     }

--- a/Libraries/Connect/Internal/Streaming/BidirectionalAsyncStream.swift
+++ b/Libraries/Connect/Internal/Streaming/BidirectionalAsyncStream.swift
@@ -20,7 +20,6 @@ import SwiftProtobuf
 ///
 /// If the library removes callback support in favor of only supporting async/await in the future,
 /// this class can be simplified.
-@available(iOS 13, *)
 class BidirectionalAsyncStream<
     Input: ProtobufMessage, Output: ProtobufMessage
 >: @unchecked Sendable {
@@ -82,7 +81,6 @@ class BidirectionalAsyncStream<
     }
 }
 
-@available(iOS 13, *)
 extension BidirectionalAsyncStream: BidirectionalAsyncStreamInterface {
     @discardableResult
     func send(_ input: Input) throws -> Self {

--- a/Libraries/Connect/Internal/Streaming/ClientOnlyAsyncStream.swift
+++ b/Libraries/Connect/Internal/Streaming/ClientOnlyAsyncStream.swift
@@ -20,7 +20,6 @@ import Foundation
 ///
 /// This subclasses `BidirectionalAsyncStream` since its behavior is purely additive (it overlays
 /// some additional validation) and both types are internal to the package, not public.
-@available(iOS 13, *)
 final class ClientOnlyAsyncStream<
     Input: ProtobufMessage, Output: ProtobufMessage
 >: BidirectionalAsyncStream<Input, Output>, @unchecked Sendable {
@@ -42,7 +41,6 @@ final class ClientOnlyAsyncStream<
     }
 }
 
-@available(iOS 13, *)
 extension ClientOnlyAsyncStream: ClientOnlyAsyncStreamInterface {
     func closeAndReceive() {
         self.close()

--- a/Libraries/Connect/Internal/Streaming/ServerOnlyAsyncStream.swift
+++ b/Libraries/Connect/Internal/Streaming/ServerOnlyAsyncStream.swift
@@ -15,7 +15,6 @@
 import SwiftProtobuf
 
 /// Concrete **internal** implementation of `ServerOnlyAsyncStreamInterface`.
-@available(iOS 13, *)
 final class ServerOnlyAsyncStream<Input: ProtobufMessage, Output: ProtobufMessage>: Sendable {
     private let bidirectionalStream: BidirectionalAsyncStream<Input, Output>
 
@@ -24,7 +23,6 @@ final class ServerOnlyAsyncStream<Input: ProtobufMessage, Output: ProtobufMessag
     }
 }
 
-@available(iOS 13, *)
 extension ServerOnlyAsyncStream: ServerOnlyAsyncStreamInterface {
     func send(_ input: Input) throws {
         try self.bidirectionalStream.send(input)

--- a/Libraries/Connect/Internal/Unary/UnaryAsyncWrapper.swift
+++ b/Libraries/Connect/Internal/Unary/UnaryAsyncWrapper.swift
@@ -21,7 +21,6 @@ import SwiftProtobuf
 /// For discussions on why this is necessary, see:
 /// https://forums.swift.org/t/how-to-use-withtaskcancellationhandler-properly/54341/37
 /// https://stackoverflow.com/q/71898080
-@available(iOS 13, *)
 actor UnaryAsyncWrapper<Output: ProtobufMessage> {
     private var cancelable: Cancelable?
     private let sendUnary: PerformClosure

--- a/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
@@ -206,7 +206,6 @@ extension ProtocolClient: ProtocolClientInterface {
 
     // MARK: - Async/await
 
-    @available(iOS 13, *)
     public func unary<Input: ProtobufMessage, Output: ProtobufMessage>(
         path: String,
         idempotencyLevel: IdempotencyLevel,
@@ -221,7 +220,6 @@ extension ProtocolClient: ProtocolClientInterface {
         }.send()
     }
 
-    @available(iOS 13, *)
     public func bidirectionalStream<Input: ProtobufMessage, Output: ProtobufMessage>(
         path: String,
         headers: Headers
@@ -234,7 +232,6 @@ extension ProtocolClient: ProtocolClientInterface {
         return bidirectionalAsync.configureForSending(with: callbacks)
     }
 
-    @available(iOS 13, *)
     public func clientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>(
         path: String,
         headers: Headers
@@ -246,7 +243,6 @@ extension ProtocolClient: ProtocolClientInterface {
         return clientOnlyAsync.configureForSending(with: callbacks)
     }
 
-    @available(iOS 13, *)
     public func serverOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>(
         path: String,
         headers: Headers

--- a/Libraries/Connect/Public/Interfaces/ProtocolClientInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/ProtocolClientInterface.swift
@@ -109,7 +109,6 @@ public protocol ProtocolClientInterface: Sendable {
     /// - parameter headers: The outbound request headers to include.
     ///
     /// - returns: The response which is returned asynchronously.
-    @available(iOS 13, *)
     func unary<Input: ProtobufMessage, Output: ProtobufMessage>(
         path: String,
         idempotencyLevel: IdempotencyLevel,
@@ -129,7 +128,6 @@ public protocol ProtocolClientInterface: Sendable {
     /// - parameter headers: The outbound request headers to include.
     ///
     /// - returns: An interface for sending and receiving data over the stream using async/await.
-    @available(iOS 13, *)
     func bidirectionalStream<Input: ProtobufMessage, Output: ProtobufMessage>(
         path: String,
         headers: Headers
@@ -147,7 +145,6 @@ public protocol ProtocolClientInterface: Sendable {
     /// - parameter headers: The outbound request headers to include.
     ///
     /// - returns: An interface for sending and receiving data over the stream using async/await.
-    @available(iOS 13, *)
     func clientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>(
         path: String,
         headers: Headers
@@ -165,7 +162,6 @@ public protocol ProtocolClientInterface: Sendable {
     /// - parameter headers: The outbound request headers to include.
     ///
     /// - returns: An interface for sending and receiving data over the stream using async/await.
-    @available(iOS 13, *)
     func serverOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>(
         path: String,
         headers: Headers

--- a/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/BidirectionalAsyncStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/BidirectionalAsyncStreamInterface.swift
@@ -15,7 +15,6 @@
 import SwiftProtobuf
 
 /// Represents a bidirectional stream that can be interacted with using async/await.
-@available(iOS 13, *)
 public protocol BidirectionalAsyncStreamInterface<Input, Output>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage

--- a/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/ClientOnlyAsyncStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/ClientOnlyAsyncStreamInterface.swift
@@ -16,7 +16,6 @@ import SwiftProtobuf
 
 /// Represents a client-only stream (a stream where the client streams data to the server and
 /// eventually receives a response) that can be interacted with using async/await.
-@available(iOS 13, *)
 public protocol ClientOnlyAsyncStreamInterface<Input, Output>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage

--- a/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/ServerOnlyAsyncStreamInterface.swift
+++ b/Libraries/Connect/Public/Interfaces/Streaming/AsyncAwait/ServerOnlyAsyncStreamInterface.swift
@@ -16,7 +16,6 @@ import SwiftProtobuf
 
 /// Represents a server-only stream (a stream where the server streams data to the client after
 /// receiving an initial request) that can be interacted with using async/await.
-@available(iOS 13, *)
 public protocol ServerOnlyAsyncStreamInterface<Input, Output>: Sendable {
     /// The input (request) message type.
     associatedtype Input: ProtobufMessage

--- a/Libraries/ConnectMocks/MockBidirectionalAsyncStream.swift
+++ b/Libraries/ConnectMocks/MockBidirectionalAsyncStream.swift
@@ -24,7 +24,6 @@ import SwiftProtobuf
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)` or by
 /// subclassing and overriding `results()`.
-@available(iOS 13, *)
 open class MockBidirectionalAsyncStream<
     Input: ProtobufMessage,
     Output: ProtobufMessage

--- a/Libraries/ConnectMocks/MockBidirectionalStream.swift
+++ b/Libraries/ConnectMocks/MockBidirectionalStream.swift
@@ -23,7 +23,6 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
-@available(iOS 13, *)
 open class MockBidirectionalStream<
     Input: ProtobufMessage,
     Output: ProtobufMessage

--- a/Libraries/ConnectMocks/MockClientOnlyAsyncStream.swift
+++ b/Libraries/ConnectMocks/MockClientOnlyAsyncStream.swift
@@ -23,7 +23,6 @@ import SwiftProtobuf
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)` or by
 /// subclassing and overriding `results()`.
-@available(iOS 13, *)
 open class MockClientOnlyAsyncStream<
     Input: ProtobufMessage,
     Output: ProtobufMessage

--- a/Libraries/ConnectMocks/MockClientOnlyStream.swift
+++ b/Libraries/ConnectMocks/MockClientOnlyStream.swift
@@ -22,7 +22,6 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
-@available(iOS 13, *)
 open class MockClientOnlyStream<
     Input: ProtobufMessage,
     Output: ProtobufMessage

--- a/Libraries/ConnectMocks/MockServerOnlyAsyncStream.swift
+++ b/Libraries/ConnectMocks/MockServerOnlyAsyncStream.swift
@@ -24,7 +24,6 @@ import SwiftProtobuf
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)` or by
 /// subclassing and overriding `results()`.
-@available(iOS 13, *)
 open class MockServerOnlyAsyncStream<
     Input: ProtobufMessage,
     Output: ProtobufMessage

--- a/Libraries/ConnectMocks/MockServerOnlyStream.swift
+++ b/Libraries/ConnectMocks/MockServerOnlyStream.swift
@@ -23,7 +23,6 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
-@available(iOS 13, *)
 open class MockServerOnlyStream<
     Input: ProtobufMessage,
     Output: ProtobufMessage

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "Connect",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v13),
         .macOS(.v10_15),
         .tvOS(.v13),
         .watchOS(.v6)

--- a/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
+++ b/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
@@ -64,7 +64,6 @@ final class ConnectMockGenerator: Generator {
         self.printLine("///")
         self.printLine("/// Note: This class does not handle thread-safe locking, but provides")
         self.printLine("/// `@unchecked Sendable` conformance to simplify testing and mocking.")
-        self.printLine("@available(iOS 13, *)")
         self.printLine(
             """
             \(self.typeVisibility) class \(service.mockName(using: self.namer)): \
@@ -232,7 +231,7 @@ private extension MethodDescriptor {
         if self.options.deprecated {
             // swiftlint:disable line_length
             return """
-            @available(iOS, introduced: 12, deprecated: 12, message: "This RPC has been marked as deprecated in its `.proto` file.")
+            @available(iOS, introduced: 13, deprecated: 13, message: "This RPC has been marked as deprecated in its `.proto` file.")
             @available(macOS, introduced: 10.15, deprecated: 10.15, message: "This RPC has been marked as deprecated in its `.proto` file.")
             @available(tvOS, introduced: 13, deprecated: 13, message: "This RPC has been marked as deprecated in its `.proto` file.")
             @available(watchOS, introduced: 6, deprecated: 6, message: "This RPC has been marked as deprecated in its `.proto` file.")

--- a/Plugins/ConnectSwiftPlugin/ConnectClientGenerator.swift
+++ b/Plugins/ConnectSwiftPlugin/ConnectClientGenerator.swift
@@ -138,7 +138,9 @@ final class ConnectClientGenerator: Generator {
     private func printAsyncAwaitMethodInterface(for method: MethodDescriptor) {
         self.printLine()
         self.printCommentsIfNeeded(for: method)
-        self.printLine(method.asyncAwaitAvailabilityAnnotation())
+        if let availabilityAnnotation = method.asyncAwaitAvailabilityAnnotation() {
+            self.printLine(availabilityAnnotation)
+        }
         self.printLine(
             method.asyncAwaitSignature(
                 using: self.namer, includeDefaults: false, options: self.options
@@ -170,7 +172,9 @@ final class ConnectClientGenerator: Generator {
 
     private func printAsyncAwaitMethodImplementation(for method: MethodDescriptor) {
         self.printLine()
-        self.printLine(method.asyncAwaitAvailabilityAnnotation())
+        if let availabilityAnnotation = method.asyncAwaitAvailabilityAnnotation() {
+            self.printLine(availabilityAnnotation)
+        }
         self.printLine(
             "\(self.visibility) "
             + method.asyncAwaitSignature(
@@ -213,7 +217,7 @@ private extension MethodDescriptor {
         if self.options.deprecated {
             // swiftlint:disable line_length
             return """
-            @available(iOS, introduced: 12, deprecated: 12, message: "This RPC has been marked as deprecated in its `.proto` file.")
+            @available(iOS, introduced: 13, deprecated: 13, message: "This RPC has been marked as deprecated in its `.proto` file.")
             @available(macOS, introduced: 10.15, deprecated: 10.15, message: "This RPC has been marked as deprecated in its `.proto` file.")
             @available(tvOS, introduced: 13, deprecated: 13, message: "This RPC has been marked as deprecated in its `.proto` file.")
             @available(watchOS, introduced: 6, deprecated: 6, message: "This RPC has been marked as deprecated in its `.proto` file.")
@@ -224,12 +228,12 @@ private extension MethodDescriptor {
         }
     }
 
-    func asyncAwaitAvailabilityAnnotation() -> String {
+    func asyncAwaitAvailabilityAnnotation() -> String? {
         if self.options.deprecated {
             // swiftlint:disable:next line_length
             return "@available(iOS, introduced: 13, deprecated: 13, message: \"This RPC has been marked as deprecated in its `.proto` file.\")"
         } else {
-            return "@available(iOS 13, *)"
+            return nil
         }
     }
 

--- a/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/service.connect.swift
+++ b/Tests/ConformanceClient/GeneratedSources/connectrpc/conformance/v1/service.connect.swift
@@ -30,7 +30,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     /// Servers should allow the response definition to be unset in the request and
     /// if it is, set no response headers or trailers and return no response data.
     /// The returned payload should only contain the request info.
-    @available(iOS 13, *)
     func `unary`(request: Connectrpc_Conformance_V1_UnaryRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Conformance_V1_UnaryResponse>
 
     /// A server-streaming operation. The request indicates the response headers,
@@ -53,7 +52,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     /// and return without error if one is not. Stream headers and trailers should
     /// still be set on the stream if provided regardless of whether a response is
     /// sent or an error is thrown.
-    @available(iOS 13, *)
     func `serverStream`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Connectrpc_Conformance_V1_ServerStreamRequest, Connectrpc_Conformance_V1_ServerStreamResponse>
 
     /// A client-streaming operation. The first request indicates the response
@@ -74,7 +72,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     /// Servers should allow the response definition to be unset in the request and
     /// if it is, set no response headers or trailers and return no response data.
     /// The returned payload should only contain the request info.
-    @available(iOS 13, *)
     func `clientStream`(headers: Connect.Headers) -> any Connect.ClientOnlyAsyncStreamInterface<Connectrpc_Conformance_V1_ClientStreamRequest, Connectrpc_Conformance_V1_ClientStreamResponse>
 
     /// A bidirectional-streaming operation. The first request indicates the response
@@ -124,18 +121,15 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     ///
     /// - if the response_delay_ms duration is specified, the server should wait that
     ///   long in between sending each response message.
-    @available(iOS 13, *)
     func `bidiStream`(headers: Connect.Headers) -> any Connect.BidirectionalAsyncStreamInterface<Connectrpc_Conformance_V1_BidiStreamRequest, Connectrpc_Conformance_V1_BidiStreamResponse>
 
     /// A unary endpoint that the server should not implement and should instead
     /// return an unimplemented error when invoked.
-    @available(iOS 13, *)
     func `unimplemented`(request: Connectrpc_Conformance_V1_UnimplementedRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Conformance_V1_UnimplementedResponse>
 
     /// A unary endpoint denoted as having no side effects (i.e. idempotent).
     /// Implementations should use an HTTP GET when invoking this endpoint and
     /// leverage query parameters to send data.
-    @available(iOS 13, *)
     func `idempotentUnary`(request: Connectrpc_Conformance_V1_IdempotentUnaryRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Conformance_V1_IdempotentUnaryResponse>
 }
 
@@ -147,32 +141,26 @@ internal final class Connectrpc_Conformance_V1_ConformanceServiceClient: Connect
         self.client = client
     }
 
-    @available(iOS 13, *)
     internal func `unary`(request: Connectrpc_Conformance_V1_UnaryRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Connectrpc_Conformance_V1_UnaryResponse> {
         return await self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/Unary", idempotencyLevel: .unknown, request: request, headers: headers)
     }
 
-    @available(iOS 13, *)
     internal func `serverStream`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Connectrpc_Conformance_V1_ServerStreamRequest, Connectrpc_Conformance_V1_ServerStreamResponse> {
         return self.client.serverOnlyStream(path: "/connectrpc.conformance.v1.ConformanceService/ServerStream", headers: headers)
     }
 
-    @available(iOS 13, *)
     internal func `clientStream`(headers: Connect.Headers = [:]) -> any Connect.ClientOnlyAsyncStreamInterface<Connectrpc_Conformance_V1_ClientStreamRequest, Connectrpc_Conformance_V1_ClientStreamResponse> {
         return self.client.clientOnlyStream(path: "/connectrpc.conformance.v1.ConformanceService/ClientStream", headers: headers)
     }
 
-    @available(iOS 13, *)
     internal func `bidiStream`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Connectrpc_Conformance_V1_BidiStreamRequest, Connectrpc_Conformance_V1_BidiStreamResponse> {
         return self.client.bidirectionalStream(path: "/connectrpc.conformance.v1.ConformanceService/BidiStream", headers: headers)
     }
 
-    @available(iOS 13, *)
     internal func `unimplemented`(request: Connectrpc_Conformance_V1_UnimplementedRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Connectrpc_Conformance_V1_UnimplementedResponse> {
         return await self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/Unimplemented", idempotencyLevel: .unknown, request: request, headers: headers)
     }
 
-    @available(iOS 13, *)
     internal func `idempotentUnary`(request: Connectrpc_Conformance_V1_IdempotentUnaryRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Connectrpc_Conformance_V1_IdempotentUnaryResponse> {
         return await self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary", idempotencyLevel: .noSideEffects, request: request, headers: headers)
     }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectMocksTests/ConnectMocksTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectMocksTests/ConnectMocksTests.swift
@@ -22,7 +22,6 @@ import Testing
 struct ConnectMocksTests {
     // MARK: - Unary
 
-    @available(iOS 13, *)
     @Test
     func mockUnaryCallbacks() {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
@@ -38,7 +37,6 @@ struct ConnectMocksTests {
         #expect(receivedMessage.value?.payload.data.count == 1)
     }
 
-    @available(iOS 13, *)
     @Test
     func mockUnaryAsyncAwait() async {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
@@ -53,7 +51,6 @@ struct ConnectMocksTests {
 
     // MARK: - Bidirectional stream
 
-    @available(iOS 13, *)
     @Test
     func mockBidirectionalStreamCallbacks() {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
@@ -93,7 +90,6 @@ struct ConnectMocksTests {
         #expect(client.mockBidiStream.isClosed)
     }
 
-    @available(iOS 13, *)
     @Test
     func mockBidirectionalStreamAsyncAwait() async throws {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
@@ -134,7 +130,6 @@ struct ConnectMocksTests {
 
     // MARK: - Server-only stream
 
-    @available(iOS 13, *)
     @Test
     func mockServerOnlyStreamCallbacks() {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
@@ -165,7 +160,6 @@ struct ConnectMocksTests {
         #expect(receivedResults.value == expectedResults)
     }
 
-    @available(iOS 13, *)
     @Test
     func mockServerOnlyStreamAsyncAwait() async throws {
         let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ConnectEndStreamResponseTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ConnectEndStreamResponseTests.swift
@@ -17,7 +17,6 @@ import Foundation
 import Testing
 
 struct ConnectEndStreamResponseTests {
-    @available(iOS 13, *)
     @Test
     func lowercasesAllHeaderKeys() throws {
         let dictionary = [
@@ -32,7 +31,6 @@ struct ConnectEndStreamResponseTests {
         #expect(response.metadata == ["somekey": ["foo"], "otherkey1": ["BAR", "bAz"]])
     }
 
-    @available(iOS 13, *)
     @Test
     func allowsOmittedErrorAndMetadata() throws {
         let data = try JSONSerialization.data(withJSONObject: [String: Any]())
@@ -41,7 +39,6 @@ struct ConnectEndStreamResponseTests {
         #expect(response.metadata == nil)
     }
 
-    @available(iOS 13, *)
     @Test
     func deserializesError() throws {
         let dictionary = [

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift
@@ -18,7 +18,6 @@ import SwiftProtobuf
 import Testing
 
 struct ConnectErrorTests {
-    @available(iOS 13, *)
     @Test
     func deserializingFullErrorAndUnpackingDetails() throws {
         let expectedDetails = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "foo/bar" }
@@ -32,7 +31,6 @@ struct ConnectErrorTests {
         #expect(error.metadata.isEmpty)
     }
 
-    @available(iOS 13, *)
     @Test
     func deserializingFullErrorAndUnpackingDetailsWithUnpaddedBase64() throws {
         let expectedDetails = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "foo/bar" }
@@ -46,7 +44,6 @@ struct ConnectErrorTests {
         #expect(error.metadata.isEmpty)
     }
 
-    @available(iOS 13, *)
     @Test
     func deserializingFullErrorAndUnpackingMultipleDetails() throws {
         let expectedDetails1 = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "foo/bar" }
@@ -61,7 +58,6 @@ struct ConnectErrorTests {
         #expect(error.metadata.isEmpty)
     }
 
-    @available(iOS 13, *)
     @Test
     func deserializingErrorUsingHelperFunctionLowercasesHeaderKeys() throws {
         let expectedDetails = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "a/b/c" }
@@ -83,7 +79,6 @@ struct ConnectErrorTests {
         #expect(error.metadata == ["somekey": ["foo"], "otherkey1": ["BAR", "bAz"]])
     }
 
-    @available(iOS 13, *)
     @Test
     func deserializingErrorUsingHelperFunctionCombinesHeadersAndTrailers() throws {
         let expectedDetails = Connectrpc_Conformance_V1_RawHTTPRequest.with { $0.uri = "a/b/c" }
@@ -112,7 +107,6 @@ struct ConnectErrorTests {
         ])
     }
 
-    @available(iOS 13, *)
     @Test
     func deserializingSimpleError() throws {
         let errorDictionary = [

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
@@ -17,7 +17,6 @@ import Foundation
 import Testing
 
 struct EnvelopeTests {
-    @available(iOS 13, *)
     @Test
     func packingAndUnpackingCompressedMessage() throws {
         let originalData = Data(repeating: 0xa, count: 50)
@@ -35,7 +34,6 @@ struct EnvelopeTests {
         #expect(unpacked.headerByte == 1) // Compression flag = true
     }
 
-    @available(iOS 13, *)
     @Test
     func packingAndUnpackingUncompressedMessageBecauseCompressionMinBytesIsNil() throws {
         let originalData = Data(repeating: 0xa, count: 50)
@@ -51,7 +49,6 @@ struct EnvelopeTests {
         #expect(unpacked.headerByte == 0) // Compression flag = false
     }
 
-    @available(iOS 13, *)
     @Test
     func packingAndUnpackingUncompressedMessageBecauseMessageIsTooSmall() throws {
         let originalData = Data(repeating: 0xa, count: 50)
@@ -69,7 +66,6 @@ struct EnvelopeTests {
         #expect(unpacked.headerByte == 0) // Compression flag = false
     }
 
-    @available(iOS 13, *)
     @Test
     func throwsWhenUnpackingCompressedMessageWithoutDecompressionPool() throws {
         let originalData = Data(repeating: 0xa, count: 50)
@@ -87,7 +83,6 @@ struct EnvelopeTests {
         }
     }
 
-    @available(iOS 13, *)
     @Test
     func messageLengthOfIncompleteData() {
         // Messages are incomplete if they do not contain enough data for the 5-byte prefix

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/GzipCompressionPoolTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/GzipCompressionPoolTests.swift
@@ -17,7 +17,6 @@ import Foundation
 import Testing
 
 struct GzipCompressionPoolTests {
-    @available(iOS 13, *)
     @Test
     func decompressingGzippedFile() throws {
         let compressedData = try self.gzippedFileData()
@@ -28,7 +27,6 @@ struct GzipCompressionPoolTests {
         #expect(decompressedText == self.expectedUnzippedFileText())
     }
 
-    @available(iOS 13, *)
     @Test
     func compressingAndDecompressingData() throws {
         let original = try #require(self.expectedUnzippedFileText().data(using: .utf8))
@@ -41,7 +39,6 @@ struct GzipCompressionPoolTests {
         #expect(decompressed == original)
     }
 
-    @available(iOS 13, *)
     @Test
     func doesNotGzipDataThatIsAlreadyGzipped() throws {
         let compressed = try self.gzippedFileData()

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorChainIterationTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorChainIterationTests.swift
@@ -16,7 +16,6 @@
 import Testing
 
 struct InterceptorChainIterationTests {
-    @available(iOS 13, *)
     @Test
     func executingNonFailing() {
         let initialValue = ""
@@ -34,7 +33,6 @@ struct InterceptorChainIterationTests {
         #expect(result.value == "ab")
     }
 
-    @available(iOS 13, *)
     @Test
     func executingNonFailingReversed() {
         let initialValue = ""
@@ -52,7 +50,6 @@ struct InterceptorChainIterationTests {
         #expect(result.value == "ba")
     }
 
-    @available(iOS 13, *)
     @Test
     func executingLinkedNonFailing() {
         let result = Locked(0)
@@ -74,7 +71,6 @@ struct InterceptorChainIterationTests {
         #expect(result.value == 12 + 1 + 3)
     }
 
-    @available(iOS 13, *)
     @Test
     func executingFailableWithoutError() {
         let result = Locked<Result<String, ConnectError>?>(nil)
@@ -91,7 +87,6 @@ struct InterceptorChainIterationTests {
         #expect((try? result.value?.get()) == "ab")
     }
 
-    @available(iOS 13, *)
     @Test
     func executingFailableWithoutErrorReversed() {
         let result = Locked<Result<String, ConnectError>?>(nil)
@@ -108,7 +103,6 @@ struct InterceptorChainIterationTests {
         #expect((try? result.value?.get()) == "ba")
     }
 
-    @available(iOS 13, *)
     @Test
     func executingFailableWithError() {
         let result = Locked<Result<String, ConnectError>?>(nil)
@@ -129,7 +123,6 @@ struct InterceptorChainIterationTests {
         #expect(throws: ConnectError.self) { try result.value?.get() }
     }
 
-    @available(iOS 13, *)
     @Test
     func executingLinkedFailableWithoutError() {
         let result = Locked<Result<Int, ConnectError>?>(nil)
@@ -151,7 +144,6 @@ struct InterceptorChainIterationTests {
         #expect((try? result.value?.get()) == 12 + 1 + 3)
     }
 
-    @available(iOS 13, *)
     @Test
     func executingLinkedFailableWithErrorOnFirstIteration() {
         let result = Locked<Result<Int, ConnectError>?>(nil)
@@ -177,7 +169,6 @@ struct InterceptorChainIterationTests {
         #expect(throws: ConnectError.self) { try result.value?.get() }
     }
 
-    @available(iOS 13, *)
     @Test
     func executingLinkedFailableWithErrorOnTransform() {
         let result = Locked<Result<Int, ConnectError>?>(nil)
@@ -203,7 +194,6 @@ struct InterceptorChainIterationTests {
         #expect(throws: ConnectError.self) { try result.value?.get() }
     }
 
-    @available(iOS 13, *)
     @Test
     func executingLinkedFailableWithErrorOnSecondIteration() {
         let result = Locked<Result<Int, ConnectError>?>(nil)

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorFactoryTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorFactoryTests.swift
@@ -24,7 +24,6 @@ private final class MockUnaryAndStreamInterceptor: UnaryInterceptor, StreamInter
 struct InterceptorFactoryTests {
     private let config = ProtocolClientConfig(host: "localhost")
 
-    @available(iOS 13, *)
     @Test
     func instantiatesUnaryInterceptorForUnary() {
         let factory = InterceptorFactory { _ in MockUnaryInterceptor() }
@@ -33,7 +32,6 @@ struct InterceptorFactoryTests {
         )
     }
 
-    @available(iOS 13, *)
     @Test
     func instantiatesStreamInterceptorForStream() {
         let factory = InterceptorFactory { _ in MockStreamInterceptor() }
@@ -42,7 +40,6 @@ struct InterceptorFactoryTests {
         )
     }
 
-    @available(iOS 13, *)
     @Test
     func instantiatesCombinedInterceptorForStreamAndUnary() {
         let factory = InterceptorFactory { _ in MockUnaryAndStreamInterceptor() }
@@ -54,14 +51,12 @@ struct InterceptorFactoryTests {
         )
     }
 
-    @available(iOS 13, *)
     @Test
     func doesNotInstantiateUnaryInterceptorForStream() {
         let factory = InterceptorFactory { _ in MockUnaryInterceptor() }
         #expect(factory.createStream(with: self.config) == nil)
     }
 
-    @available(iOS 13, *)
     @Test
     func doesNotInstantiateStreamInterceptorForUnary() {
         let factory = InterceptorFactory { _ in MockStreamInterceptor() }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorIntegrationTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/InterceptorIntegrationTests.swift
@@ -23,7 +23,6 @@ import Testing
 /// `TimeoutTests`, which also performs live networking) still run concurrently with it.
 @Suite(.serialized)
 struct InterceptorIntegrationTests {
-    @available(iOS 13, *)
     @Test
     func unaryInterceptorSuccess() async {
         let trackedSteps = Locked([InterceptorStep]())
@@ -59,7 +58,6 @@ struct InterceptorIntegrationTests {
         ])
     }
 
-    @available(iOS 13, *)
     @Test
     func streamInterceptorSuccess() async throws {
         let trackedSteps = Locked([InterceptorStep]())
@@ -197,7 +195,6 @@ struct InterceptorIntegrationTests {
         ))
     }
 
-    @available(iOS 13, *)
     @Test
     func unaryInterceptorCanFailOutboundRequest() async {
         let trackedSteps = Locked([InterceptorStep]())
@@ -231,7 +228,6 @@ struct InterceptorIntegrationTests {
         ])
     }
 
-    @available(iOS 13, *)
     @Test
     func streamInterceptorCanFailOutboundRequest() async {
         let trackedSteps = Locked([InterceptorStep]())
@@ -267,7 +263,6 @@ struct InterceptorIntegrationTests {
         ])
     }
 
-    @available(iOS 13, *)
     @Test
     func streamDoesNotPassRequestDataToInterceptorsUntilRequestHeadersAreSent() async throws {
         let trackedSteps = Locked([InterceptorStep]())

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/JSONCodecTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/JSONCodecTests.swift
@@ -33,7 +33,6 @@ struct JSONCodecTests {
         proto.rawQueryParams = [.init()]
     }
 
-    @available(iOS 13, *)
     @Test
     func serializingAndDeserializingWithDefaultOptions() throws {
         let codec = JSONCodec()
@@ -41,7 +40,6 @@ struct JSONCodecTests {
         #expect(try codec.deserialize(source: serialized) == self.message)
     }
 
-    @available(iOS 13, *)
     @Test
     func serializingAndDeserializingWithEnumsAsInts() throws {
         let codec = JSONCodec(alwaysEncodeEnumsAsInts: true, preserveProtobufFieldNames: false)
@@ -53,7 +51,6 @@ struct JSONCodecTests {
         #expect(try codec.deserialize(source: serialized) == self.message)
     }
 
-    @available(iOS 13, *)
     @Test
     func serializingAndDeserializingWithEnumsAsStrings() throws {
         let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: false)
@@ -67,7 +64,6 @@ struct JSONCodecTests {
         #expect(try codec.deserialize(source: serialized) == self.message)
     }
 
-    @available(iOS 13, *)
     @Test
     func serializingAndDeserializingWithProtobufFieldNames() throws {
         let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: true)
@@ -84,7 +80,6 @@ struct JSONCodecTests {
         #expect(try codec.deserialize(source: serialized) == self.message)
     }
 
-    @available(iOS 13, *)
     @Test
     func serializingAndDeserializingWithCamelCaseFieldNames() throws {
         let codec = JSONCodec(alwaysEncodeEnumsAsInts: false, preserveProtobufFieldNames: false)

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtoCodecTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtoCodecTests.swift
@@ -31,7 +31,6 @@ struct ProtoCodecTests {
         ]
     }
 
-    @available(iOS 13, *)
     @Test
     func serializingAndDeserializing() throws {
         let codec = ProtoCodec()

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -21,7 +21,6 @@ private final class NoopInterceptor1: UnaryInterceptor, StreamInterceptor {}
 private final class NoopInterceptor2: UnaryInterceptor, StreamInterceptor {}
 
 struct ProtocolClientConfigTests {
-    @available(iOS 13, *)
     @Test
     func defaultResponseCompressionPoolIncludesGzip() {
         let config = ProtocolClientConfig(host: "https://connectrpc.com")
@@ -29,7 +28,6 @@ struct ProtocolClientConfigTests {
         #expect(config.acceptCompressionPoolNames() == ["gzip"])
     }
 
-    @available(iOS 13, *)
     @Test
     func shouldCompressDataLargerThanMinBytes() {
         let data = Data(repeating: 0xa, count: 50)
@@ -39,7 +37,6 @@ struct ProtocolClientConfigTests {
         #expect(compression.shouldCompress(data))
     }
 
-    @available(iOS 13, *)
     @Test
     func shouldNotCompressDataSmallerThanMinBytes() {
         let data = Data(repeating: 0xa, count: 50)
@@ -49,7 +46,6 @@ struct ProtocolClientConfigTests {
         #expect(compression.shouldCompress(data) == false)
     }
 
-    @available(iOS 13, *)
     @Test
     func creatingURLsWithVariousHosts() {
         let rpcPath = Connectrpc_Conformance_V1_ConformanceServiceClient.Metadata.Methods.unary.path
@@ -91,7 +87,6 @@ struct ProtocolClientConfigTests {
         )
     }
 
-    @available(iOS 13, *)
     @Test
     func addsConnectInterceptorLastWhenUsingConnectProtocol() {
         let config = ProtocolClientConfig(
@@ -105,7 +100,6 @@ struct ProtocolClientConfigTests {
         #expect(config.interceptors[1].createStream(with: config) is ConnectInterceptor)
     }
 
-    @available(iOS 13, *)
     @Test
     func addsGRPCWebInterceptorLastWhenUsingGRPCWebProtocol() {
         let config = ProtocolClientConfig(
@@ -119,7 +113,6 @@ struct ProtocolClientConfigTests {
         #expect(config.interceptors[1].createStream(with: config) is GRPCWebInterceptor)
     }
 
-    @available(iOS 13, *)
     @Test
     func addsProtocolInterceptorLastWhenUsingOtherProtocol() {
         let config = ProtocolClientConfig(
@@ -135,7 +128,6 @@ struct ProtocolClientConfigTests {
         #expect(config.interceptors[1].createStream(with: config) is NoopInterceptor2)
     }
 
-    @available(iOS 13, *)
     @Test
     func unaryGETRequestWithNoSideEffects() {
         let request = HTTPRequest<Data?>(
@@ -168,7 +160,6 @@ struct ProtocolClientConfigTests {
         ).shouldUseUnaryGET(for: request) == false)
     }
 
-    @available(iOS 13, *)
     @Test
     func unaryGETRequestWithIdempotentSideEffects() {
         let request = HTTPRequest<Data?>(
@@ -201,7 +192,6 @@ struct ProtocolClientConfigTests {
         ).shouldUseUnaryGET(for: request) == false)
     }
 
-    @available(iOS 13, *)
     @Test
     func unaryGETRequestWithUnknownSideEffects() {
         let request = HTTPRequest<Data?>(
@@ -234,7 +224,6 @@ struct ProtocolClientConfigTests {
         ).shouldUseUnaryGET(for: request) == false)
     }
 
-    @available(iOS 13, *)
     @Test
     func transformToGETWithoutRequestCompression() {
         let request = HTTPRequest<Data?>(
@@ -261,7 +250,6 @@ struct ProtocolClientConfigTests {
         )
     }
 
-    @available(iOS 13, *)
     @Test
     func transformToGETUsesURLSafeBase64() {
         // Data bytes [0x3E, 0x3F, 0xBF, 0xFF] produce "+P+//w==" in standard base64
@@ -288,7 +276,6 @@ struct ProtocolClientConfigTests {
         #expect(url.contains("message=Pj-__w"), "Expected raw URL-safe base64 encoding")
     }
 
-    @available(iOS 13, *)
     @Test
     func transformToGETWithRequestCompression() {
         let compressedRequest = HTTPRequest<Data?>(

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ServiceMetadataTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ServiceMetadataTests.swift
@@ -16,7 +16,6 @@ import Connect
 import Testing
 
 struct ServiceMetadataTests {
-    @available(iOS 13, *)
     @Test
     func methodSpecsAreGeneratedCorrectlyForService() {
         #expect(

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTests.swift
@@ -17,7 +17,6 @@ import Foundation
 import Testing
 
 struct TimeoutTests {
-    @available(iOS 13, *)
     @Test
     func unaryRequestTimesOut() async {
         let client = self.makeClient()
@@ -30,7 +29,6 @@ struct TimeoutTests {
         #expect(response.error?.message == "request exceeded allowed timeout")
     }
 
-    @available(iOS 13, *)
     @Test
     func streamRequestTimesOut() async throws {
         let client = self.makeClient()

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/URLSessionStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/URLSessionStreamTests.swift
@@ -21,7 +21,6 @@ struct URLSessionStreamTests {
     /// initial send and when it resends a request after a recoverable error. A streamed request
     /// body cannot be replayed, and returning the same already-opened stream on a resend crashes
     /// CFNetwork. The stream must therefore be vended only once.
-    @available(iOS 13, *)
     @Test
     func vendsRequestBodyStreamOnlyOnce() {
         let stream = URLSessionStream(
@@ -46,7 +45,6 @@ struct URLSessionStreamTests {
     /// A second `needNewBodyStream` cancels the task because the bound body cannot be replayed.
     /// That cancelation must surface as `.unavailable` (retriable connection failure), not
     /// `.canceled`, and `receiveClose` must fire exactly once.
-    @available(iOS 13, *)
     @Test
     func resendCancelationIsRemappedToUnavailableExactlyOnce() async {
         await confirmation("receiveClose", expectedCount: 1) { confirm in

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.connect.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.connect.swift
@@ -47,7 +47,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     /// Servers should allow the response definition to be unset in the request and
     /// if it is, set no response headers or trailers and return no response data.
     /// The returned payload should only contain the request info.
-    @available(iOS 13, *)
     func `unary`(request: Connectrpc_Conformance_V1_UnaryRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Conformance_V1_UnaryResponse>
 
     /// A server-streaming operation. The request indicates the response headers,
@@ -92,7 +91,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     /// and return without error if one is not. Stream headers and trailers should
     /// still be set on the stream if provided regardless of whether a response is
     /// sent or an error is thrown.
-    @available(iOS 13, *)
     func `serverStream`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Connectrpc_Conformance_V1_ServerStreamRequest, Connectrpc_Conformance_V1_ServerStreamResponse>
 
     /// A client-streaming operation. The first request indicates the response
@@ -133,7 +131,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     /// Servers should allow the response definition to be unset in the request and
     /// if it is, set no response headers or trailers and return no response data.
     /// The returned payload should only contain the request info.
-    @available(iOS 13, *)
     func `clientStream`(headers: Connect.Headers) -> any Connect.ClientOnlyAsyncStreamInterface<Connectrpc_Conformance_V1_ClientStreamRequest, Connectrpc_Conformance_V1_ClientStreamResponse>
 
     /// A bidirectional-streaming operation. The first request indicates the response
@@ -232,7 +229,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     ///
     /// - if the response_delay_ms duration is specified, the server should wait that
     ///   long in between sending each response message.
-    @available(iOS 13, *)
     func `bidiStream`(headers: Connect.Headers) -> any Connect.BidirectionalAsyncStreamInterface<Connectrpc_Conformance_V1_BidiStreamRequest, Connectrpc_Conformance_V1_BidiStreamResponse>
 
     /// A unary endpoint that the server should not implement and should instead
@@ -242,7 +238,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
 
     /// A unary endpoint that the server should not implement and should instead
     /// return an unimplemented error when invoked.
-    @available(iOS 13, *)
     func `unimplemented`(request: Connectrpc_Conformance_V1_UnimplementedRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Conformance_V1_UnimplementedResponse>
 
     /// A unary endpoint denoted as having no side effects (i.e. idempotent).
@@ -254,7 +249,6 @@ internal protocol Connectrpc_Conformance_V1_ConformanceServiceClientInterface: S
     /// A unary endpoint denoted as having no side effects (i.e. idempotent).
     /// Implementations should use an HTTP GET when invoking this endpoint and
     /// leverage query parameters to send data.
-    @available(iOS 13, *)
     func `idempotentUnary`(request: Connectrpc_Conformance_V1_IdempotentUnaryRequest, headers: Connect.Headers) async -> ResponseMessage<Connectrpc_Conformance_V1_IdempotentUnaryResponse>
 }
 
@@ -271,7 +265,6 @@ internal final class Connectrpc_Conformance_V1_ConformanceServiceClient: Connect
         return self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/Unary", idempotencyLevel: .unknown, request: request, headers: headers, completion: completion)
     }
 
-    @available(iOS 13, *)
     internal func `unary`(request: Connectrpc_Conformance_V1_UnaryRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Connectrpc_Conformance_V1_UnaryResponse> {
         return await self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/Unary", idempotencyLevel: .unknown, request: request, headers: headers)
     }
@@ -280,7 +273,6 @@ internal final class Connectrpc_Conformance_V1_ConformanceServiceClient: Connect
         return self.client.serverOnlyStream(path: "/connectrpc.conformance.v1.ConformanceService/ServerStream", headers: headers, onResult: onResult)
     }
 
-    @available(iOS 13, *)
     internal func `serverStream`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Connectrpc_Conformance_V1_ServerStreamRequest, Connectrpc_Conformance_V1_ServerStreamResponse> {
         return self.client.serverOnlyStream(path: "/connectrpc.conformance.v1.ConformanceService/ServerStream", headers: headers)
     }
@@ -289,7 +281,6 @@ internal final class Connectrpc_Conformance_V1_ConformanceServiceClient: Connect
         return self.client.clientOnlyStream(path: "/connectrpc.conformance.v1.ConformanceService/ClientStream", headers: headers, onResult: onResult)
     }
 
-    @available(iOS 13, *)
     internal func `clientStream`(headers: Connect.Headers = [:]) -> any Connect.ClientOnlyAsyncStreamInterface<Connectrpc_Conformance_V1_ClientStreamRequest, Connectrpc_Conformance_V1_ClientStreamResponse> {
         return self.client.clientOnlyStream(path: "/connectrpc.conformance.v1.ConformanceService/ClientStream", headers: headers)
     }
@@ -298,7 +289,6 @@ internal final class Connectrpc_Conformance_V1_ConformanceServiceClient: Connect
         return self.client.bidirectionalStream(path: "/connectrpc.conformance.v1.ConformanceService/BidiStream", headers: headers, onResult: onResult)
     }
 
-    @available(iOS 13, *)
     internal func `bidiStream`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Connectrpc_Conformance_V1_BidiStreamRequest, Connectrpc_Conformance_V1_BidiStreamResponse> {
         return self.client.bidirectionalStream(path: "/connectrpc.conformance.v1.ConformanceService/BidiStream", headers: headers)
     }
@@ -308,7 +298,6 @@ internal final class Connectrpc_Conformance_V1_ConformanceServiceClient: Connect
         return self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/Unimplemented", idempotencyLevel: .unknown, request: request, headers: headers, completion: completion)
     }
 
-    @available(iOS 13, *)
     internal func `unimplemented`(request: Connectrpc_Conformance_V1_UnimplementedRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Connectrpc_Conformance_V1_UnimplementedResponse> {
         return await self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/Unimplemented", idempotencyLevel: .unknown, request: request, headers: headers)
     }
@@ -318,7 +307,6 @@ internal final class Connectrpc_Conformance_V1_ConformanceServiceClient: Connect
         return self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary", idempotencyLevel: .noSideEffects, request: request, headers: headers, completion: completion)
     }
 
-    @available(iOS 13, *)
     internal func `idempotentUnary`(request: Connectrpc_Conformance_V1_IdempotentUnaryRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Connectrpc_Conformance_V1_IdempotentUnaryResponse> {
         return await self.client.unary(path: "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary", idempotencyLevel: .noSideEffects, request: request, headers: headers)
     }

--- a/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.mock.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/GeneratedSources/connectrpc/conformance/v1/service.mock.swift
@@ -20,7 +20,6 @@ import SwiftProtobuf
 ///
 /// Note: This class does not handle thread-safe locking, but provides
 /// `@unchecked Sendable` conformance to simplify testing and mocking.
-@available(iOS 13, *)
 internal class Connectrpc_Conformance_V1_ConformanceServiceClientMock: Connectrpc_Conformance_V1_ConformanceServiceClientInterface, @unchecked Sendable {
     private var cancellables = [Combine.AnyCancellable]()
 

--- a/Tests/UnitTests/ConnectPluginUtilitiesTests/FilePathComponentsTests.swift
+++ b/Tests/UnitTests/ConnectPluginUtilitiesTests/FilePathComponentsTests.swift
@@ -66,7 +66,6 @@ struct FilePathComponentsTests {
         ),
     ]
 
-    @available(iOS 13, *)
     @Test(arguments: Self.testCases)
     func splitsProtoFilePath(testCase: TestCase) {
         let components = FilePathComponents(path: testCase.path)
@@ -88,7 +87,6 @@ struct FilePathComponentsTests {
     }
 }
 
-@available(iOS 13, *)
 extension FilePathComponentsTests.TestCase: CustomTestStringConvertible {
     var testDescription: String {
         self.path


### PR DESCRIPTION
Raises the minimum iOS deployment target from 12 to 13. Only iOS moves — macOS 10.15, tvOS 13, and watchOS 6 are already the iOS-13-era releases and the Swift concurrency back-deployment floors.

iOS 12 was supported in name only. Every async/await API was already gated behind `@available(iOS 13, *)`, so iOS 12 consumers could only ever reach the callback surface. That's why all 126 removed annotations named iOS and no other platform.

## Changes

- `Package.swift`: `.iOS(.v12)` → `.iOS(.v13)`
- `.swiftlint.yml`: `iOS_deployment_target` 12.0 → 13.0
- Both codegen plugins stop emitting `@available(iOS 13, *)`; `asyncAwaitAvailabilityAnnotation()` now returns `String?` and is guarded at its call sites, matching the existing callback counterpart
- The deprecated-RPC template's iOS `introduced`/`deprecated` moves 12 → 13, making it consistent with the async variant
- Deletes the 126 resulting dead annotations: 93 hand-written across 30 files, 31 regenerated via `make generate`

These land in one commit out of necessity. Moving the SwiftLint deployment target without the deletions turns all 126 sites into `--strict` violations; deleting them before the floor moves fails to compile, since actors and `AsyncStream` are unavailable at iOS 12.

## Breaking change

This belongs in the 2.0.0 major. Consumers below iOS 13 get a SwiftPM resolution error rather than a runtime failure:

```
error: The package product 'Connect' requires minimum platform version 13.0 for the iOS platform, but this target supports 12.0
```

The generator and the library must be upgraded together — 2.0.0 generator output omits the availability annotation and will not compile against a 1.x library in an iOS 12 app. Worth calling out in the release notes.

## Verification

- `swiftlint lint --strict` — 0 violations in 103 files (the rule flagged exactly 93 sites before the deletions, which served as the worklist)
- `make testunit` — 70 tests, 15 suites, all pass
- `make testconformance` — 1681 passed, 0 failed, both urlsession and nio configs
- iOS and macOS library builds pass; Eliza example app builds. tvOS/watchOS were not built locally (platform support not installed) and rely on CI.
- Verified the downstream break is loud and compile-time by resolving a throwaway package declaring `.iOS(.v12)` against this branch.

## Follow-ups

This PR is deliberately scoped to the floor bump and the dead-annotation cleanup — no behavioral changes. Simplifications that take advantage of the new floor will be filed as separate pull requests, so this one stays easy to review and revert.