### PR TITLE
Fix stale ElizaSharedSources paths breaking license header CI

### DIFF
--- a/Examples/buf.gen.yaml
+++ b/Examples/buf.gen.yaml
@@ -2,10 +2,10 @@ version: v1
 plugins:
   - plugin: buf.build/apple/swift:v1.38.1
     opt: Visibility=Internal
-    out: ./ElizaSharedSources/GeneratedSources
+    out: ./ElizaSwiftPackageApp/ElizaSwiftPackageApp/GeneratedSources
   - name: connect-swift
     opt:
       - GenerateServiceMetadata=false
       - Visibility=Internal
-    out: ./ElizaSharedSources/GeneratedSources
+    out: ./ElizaSwiftPackageApp/ElizaSwiftPackageApp/GeneratedSources
     path: ../.tmp/bin/protoc-gen-connect-swift

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ EXAMPLES_PROTO_REF := e74547031f662f81a62f5e95ebaa9f7037e0c41b
 LICENSE_HEADER_VERSION := v1.35.1
 LICENSE_IGNORE := -e Package.swift \
     -e $(BIN)\/ \
-    -e Examples/ElizaSharedSources/GeneratedSources\/ \
+    -e Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp/GeneratedSources\/ \
     -e Libraries/Connect/Internal/GeneratedSources\/ \
     -e Tests/ConformanceClient/GeneratedSources\/ \
     -e Tests/UnitTests/ConnectLibraryTests/GeneratedSources\/
@@ -38,7 +38,7 @@ clean: cleangenerated ## Delete all plugins and generated outputs
 
 .PHONY: cleangenerated
 cleangenerated: ## Delete all generated outputs
-	rm -rf ./Examples/ElizaSharedSources/GeneratedSources/*
+	rm -rf ./Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp/GeneratedSources/*
 	rm -rf ./Libraries/Connect/Internal/GeneratedSources/*
 	rm -rf ./Tests/ConformanceClient/GeneratedSources/*
 	rm -rf ./Tests/UnitTests/ConnectLibraryTests/GeneratedSources/*


### PR DESCRIPTION
[#414](https://github.com/connectrpc/connect-swift/pull/414) deleted `Examples/ElizaSharedSources/` and moved the Eliza example's generated sources under `ElizaSwiftPackageApp/`, but left three references to the old path behind. This fixes all three.

### `LICENSE_IGNORE` — breaks CI today

The `Makefile`'s `LICENSE_IGNORE` still excluded the old directory, so the moved generated sources were no longer exempt and `make licenseheaders` stamped Apache headers onto `eliza.pb.swift` and `eliza.connect.swift`.

The `validate-license-headers` job runs `make licenseheaders` and then fails on a dirty tree, so this has been **failing on `main` since #414** — it was the sole failing job on [that run](https://github.com/connectrpc/connect-swift/actions/runs/30360152899), with all nine others green.

### `cleangenerated` + `buf.gen.yaml` — silently wrong, not merely inert

`cleangenerated` and both `out:` paths in `Examples/buf.gen.yaml` also still pointed at the old directory. `make generate` therefore recreated the deleted `ElizaSharedSources/` directory and wrote generated output into it, while leaving the example's real sources untouched. **Any `EXAMPLES_PROTO_REF` bump has effectively been a no-op since #414**, which is worth knowing for the next proto update.

These two have to move together — repointing `cleangenerated` on its own would delete the real generated sources while `buf generate` still wrote to the old directory.

## Verification

Ran against a freshly rebuilt plugin binary; the cached one predated current plugin sources and would have masked drift.

- `make generate` regenerates all four generated trees **byte-identically to what is committed** — zero diff, still 16 tracked generated files, nothing added or orphaned. The path change is a pure relocation.
- `ElizaSharedSources/` is no longer recreated, and output lands in the correct directory.
- `make licenseheaders` run *against those regenerated files* leaves the tree clean, so both CI gates pass together.
- The five hand-written `AppSources/*.swift` files remain covered by the license check and pass — the new exclusion is scoped to `GeneratedSources/` only.