### PR TITLE
Fix EventLoop-shutdown errors from late work in the NIO client

### DIFF
--- a/Libraries/ConnectNIO/Internal/ConnectStreamChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectStreamChannelHandler.swift
@@ -23,6 +23,9 @@ final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @uncheck
     private let eventLoop: NIOCore.EventLoop
     private let request: Connect.HTTPRequest<Data?>
     private let responseCallbacks: Connect.ResponseCallbacks
+    /// Weak by design: the handler outlives the client which created it. See
+    /// `EventLoopGroupOwner`.
+    private weak var loopGroupOwner: EventLoopGroupOwner?
 
     private var context: NIOCore.ChannelHandlerContext?
     private var isClosed = false
@@ -34,11 +37,13 @@ final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @uncheck
     init(
         request: Connect.HTTPRequest<Data?>,
         responseCallbacks: Connect.ResponseCallbacks,
-        eventLoop: NIOCore.EventLoop
+        eventLoop: NIOCore.EventLoop,
+        loopGroupOwner: EventLoopGroupOwner
     ) {
         self.request = request
         self.responseCallbacks = responseCallbacks
         self.eventLoop = eventLoop
+        self.loopGroupOwner = loopGroupOwner
     }
 
     /// Send outbound data over the stream.
@@ -90,7 +95,9 @@ final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @uncheck
         if self.eventLoop.inEventLoop {
             action()
         } else {
-            self.eventLoop.submit(action).cascade(to: nil)
+            // The owner drops the action if the client - and therefore the event loop group - is
+            // already gone, rather than scheduling onto a loop which has shut down.
+            self.loopGroupOwner?.execute(on: self.eventLoop, action)
         }
     }
 

--- a/Libraries/ConnectNIO/Internal/ConnectStreamChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectStreamChannelHandler.swift
@@ -23,8 +23,7 @@ final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @uncheck
     private let eventLoop: NIOCore.EventLoop
     private let request: Connect.HTTPRequest<Data?>
     private let responseCallbacks: Connect.ResponseCallbacks
-    /// Weak by design: the handler outlives the client which created it. See
-    /// `EventLoopGroupOwner`.
+    /// Weak: the handler can outlive the client. See `EventLoopGroupOwner`.
     private weak var loopGroupOwner: EventLoopGroupOwner?
 
     private var context: NIOCore.ChannelHandlerContext?
@@ -95,8 +94,7 @@ final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @uncheck
         if self.eventLoop.inEventLoop {
             action()
         } else {
-            // The owner drops the action if the client - and therefore the event loop group - is
-            // already gone, rather than scheduling onto a loop which has shut down.
+            // Dropped if the client, and therefore the group, is already gone.
             self.loopGroupOwner?.execute(on: self.eventLoop, action)
         }
     }

--- a/Libraries/ConnectNIO/Internal/ConnectStreamChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectStreamChannelHandler.swift
@@ -20,11 +20,9 @@ import NIOHTTP1
 
 /// NIO-based channel handler for streams made through the Connect library.
 final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @unchecked Sendable {
-    private let eventLoop: NIOCore.EventLoop
+    private let eventLoop: EventLoopHandle
     private let request: Connect.HTTPRequest<Data?>
     private let responseCallbacks: Connect.ResponseCallbacks
-    /// Weak: the handler can outlive the client. See `EventLoopGroupOwner`.
-    private weak var loopGroupOwner: EventLoopGroupOwner?
 
     private var context: NIOCore.ChannelHandlerContext?
     private var isClosed = false
@@ -36,20 +34,18 @@ final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @uncheck
     init(
         request: Connect.HTTPRequest<Data?>,
         responseCallbacks: Connect.ResponseCallbacks,
-        eventLoop: NIOCore.EventLoop,
-        loopGroupOwner: EventLoopGroupOwner
+        eventLoop: EventLoopHandle
     ) {
         self.request = request
         self.responseCallbacks = responseCallbacks
         self.eventLoop = eventLoop
-        self.loopGroupOwner = loopGroupOwner
     }
 
     /// Send outbound data over the stream.
     ///
     /// - parameter data: The data to send.
     func sendData(_ data: Data) {
-        self.runOnEventLoop {
+        self.eventLoop.run {
             if self.isClosed {
                 return
             }
@@ -65,7 +61,7 @@ final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @uncheck
 
     /// Close the stream.
     func close() {
-        self.runOnEventLoop {
+        self.eventLoop.run {
             if self.isClosed {
                 return
             }
@@ -80,22 +76,13 @@ final class ConnectStreamChannelHandler: NIOCore.ChannelInboundHandler, @uncheck
 
     /// Cancel the stream, if currently active.
     func cancel() {
-        self.runOnEventLoop {
+        self.eventLoop.run {
             if self.isClosed {
                 return
             }
 
             self.closeConnection()
             self.responseCallbacks.receiveClose(.canceled, [:], ConnectError.canceled())
-        }
-    }
-
-    private func runOnEventLoop(action: @escaping @Sendable () -> Void) {
-        if self.eventLoop.inEventLoop {
-            action()
-        } else {
-            // Dropped if the client, and therefore the group, is already gone.
-            self.loopGroupOwner?.execute(on: self.eventLoop, action)
         }
     }
 

--- a/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
@@ -24,6 +24,9 @@ final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecke
     private let request: Connect.HTTPRequest<Data?>
     private let onMetrics: (Connect.HTTPMetrics) -> Void
     private let onResponse: (Connect.HTTPResponse) -> Void
+    /// Weak by design: the handler outlives the client which created it. See
+    /// `EventLoopGroupOwner`.
+    private weak var loopGroupOwner: EventLoopGroupOwner?
 
     private var context: NIOCore.ChannelHandlerContext?
     private var isClosed = false
@@ -35,11 +38,13 @@ final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecke
     init(
         request: Connect.HTTPRequest<Data?>,
         eventLoop: NIOCore.EventLoop,
+        loopGroupOwner: EventLoopGroupOwner,
         onMetrics: @escaping (Connect.HTTPMetrics) -> Void,
         onResponse: @escaping (Connect.HTTPResponse) -> Void
     ) {
         self.request = request
         self.eventLoop = eventLoop
+        self.loopGroupOwner = loopGroupOwner
         self.onMetrics = onMetrics
         self.onResponse = onResponse
     }
@@ -67,7 +72,9 @@ final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecke
         if self.eventLoop.inEventLoop {
             action()
         } else {
-            self.eventLoop.submit(action).cascade(to: nil)
+            // The owner drops the action if the client - and therefore the event loop group - is
+            // already gone, rather than scheduling onto a loop which has shut down.
+            self.loopGroupOwner?.execute(on: self.eventLoop, action)
         }
     }
 

--- a/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
@@ -24,8 +24,7 @@ final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecke
     private let request: Connect.HTTPRequest<Data?>
     private let onMetrics: (Connect.HTTPMetrics) -> Void
     private let onResponse: (Connect.HTTPResponse) -> Void
-    /// Weak by design: the handler outlives the client which created it. See
-    /// `EventLoopGroupOwner`.
+    /// Weak: the handler can outlive the client. See `EventLoopGroupOwner`.
     private weak var loopGroupOwner: EventLoopGroupOwner?
 
     private var context: NIOCore.ChannelHandlerContext?
@@ -72,8 +71,7 @@ final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecke
         if self.eventLoop.inEventLoop {
             action()
         } else {
-            // The owner drops the action if the client - and therefore the event loop group - is
-            // already gone, rather than scheduling onto a loop which has shut down.
+            // Dropped if the client, and therefore the group, is already gone.
             self.loopGroupOwner?.execute(on: self.eventLoop, action)
         }
     }

--- a/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
+++ b/Libraries/ConnectNIO/Internal/ConnectUnaryChannelHandler.swift
@@ -20,12 +20,10 @@ import NIOHTTP1
 
 /// NIO-based channel handler for unary requests made through the Connect library.
 final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecked Sendable {
-    private let eventLoop: NIOCore.EventLoop
+    private let eventLoop: EventLoopHandle
     private let request: Connect.HTTPRequest<Data?>
     private let onMetrics: (Connect.HTTPMetrics) -> Void
     private let onResponse: (Connect.HTTPResponse) -> Void
-    /// Weak: the handler can outlive the client. See `EventLoopGroupOwner`.
-    private weak var loopGroupOwner: EventLoopGroupOwner?
 
     private var context: NIOCore.ChannelHandlerContext?
     private var isClosed = false
@@ -36,21 +34,19 @@ final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecke
 
     init(
         request: Connect.HTTPRequest<Data?>,
-        eventLoop: NIOCore.EventLoop,
-        loopGroupOwner: EventLoopGroupOwner,
+        eventLoop: EventLoopHandle,
         onMetrics: @escaping (Connect.HTTPMetrics) -> Void,
         onResponse: @escaping (Connect.HTTPResponse) -> Void
     ) {
         self.request = request
         self.eventLoop = eventLoop
-        self.loopGroupOwner = loopGroupOwner
         self.onMetrics = onMetrics
         self.onResponse = onResponse
     }
 
     /// Cancel the in-flight request, if currently active.
     func cancel() {
-        self.runOnEventLoop {
+        self.eventLoop.run {
             if self.isClosed {
                 return
             }
@@ -64,15 +60,6 @@ final class ConnectUnaryChannelHandler: NIOCore.ChannelInboundHandler, @unchecke
                 error: ConnectError.canceled(),
                 tracingInfo: nil
             ))
-        }
-    }
-
-    private func runOnEventLoop(action: @escaping @Sendable () -> Void) {
-        if self.eventLoop.inEventLoop {
-            action()
-        } else {
-            // Dropped if the client, and therefore the group, is already gone.
-            self.loopGroupOwner?.execute(on: self.eventLoop, action)
         }
     }
 

--- a/Libraries/ConnectNIO/Internal/EventLoopGroupOwner.swift
+++ b/Libraries/ConnectNIO/Internal/EventLoopGroupOwner.swift
@@ -38,6 +38,8 @@ final class EventLoopGroupOwner: @unchecked Sendable {
     private let lock = NIOConcurrencyHelpers.NIOLock()
     /// Guarded by `lock`.
     private var isShutDown = false
+    /// Guarded by `lock`. Shutdown is deferred while this is non-zero. See `beginWork()`.
+    private var outstandingWorkCount = 0
 
     /// The underlying group, for use when creating bootstraps and channels.
     var eventLoopGroup: NIOCore.EventLoopGroup {
@@ -106,8 +108,40 @@ final class EventLoopGroupOwner: @unchecked Sendable {
         }
     }
 
-    /// Stops scheduling new work and, if this owner created the group, shuts the group down.
-    /// Idempotent, so `deinit` may safely call this after an explicit call.
+    /// Registers work whose completion NIO schedules onto the loop *itself*, and which therefore
+    /// cannot be gated by `execute(on:_:)`. A connect is the case that matters: NIO runs the DNS
+    /// lookup on an offload queue and hops back onto the event loop from there
+    /// (`GetaddrinfoResolver`), so the only way to stop that hop from landing on a dead loop is to
+    /// keep the loop alive. The group's shutdown is deferred until the matching `endWork()`.
+    ///
+    /// - returns: True if the work was registered, false if the group is already shut down.
+    @discardableResult
+    func beginWork() -> Bool {
+        return self.lock.withLock { () -> Bool in
+            if self.isShutDown {
+                return false
+            }
+
+            self.outstandingWorkCount += 1
+            return true
+        }
+    }
+
+    /// Balances a successful `beginWork()`, performing a deferred shutdown if this was the last
+    /// outstanding work and `shutDown()` has already been called.
+    func endWork() {
+        let shouldShutDownGroup = self.lock.withLock { () -> Bool in
+            self.outstandingWorkCount = max(0, self.outstandingWorkCount - 1)
+            return self.isShutDown && self.isGroupOwned && self.outstandingWorkCount == 0
+        }
+
+        if shouldShutDownGroup {
+            self.shutDownGroup()
+        }
+    }
+
+    /// Stops scheduling new work and, if this owner created the group and no work is outstanding,
+    /// shuts the group down. Idempotent, so `deinit` may safely call this after an explicit call.
     func shutDown() {
         let shouldShutDownGroup = self.lock.withLock { () -> Bool in
             if self.isShutDown {
@@ -115,18 +149,22 @@ final class EventLoopGroupOwner: @unchecked Sendable {
             }
 
             self.isShutDown = true
-            return self.isGroupOwned
+            return self.isGroupOwned && self.outstandingWorkCount == 0
         }
 
         if shouldShutDownGroup {
-            // Shutting down must stay asynchronous. An event loop callback can release the last
-            // reference to this owner, running `deinit` on one of the group's own threads, and
-            // `syncShutdownGracefully()` traps there because a loop cannot wait for itself to
-            // stop. The `withExtendedLifetime(self)` above makes that release land on an event loop
-            // thread more often than it otherwise would, so this is more load-bearing than it looks
-            // - never switch it back to the synchronous form.
-            self.group.shutdownGracefully { _ in }
+            self.shutDownGroup()
         }
+    }
+
+    private func shutDownGroup() {
+        // Shutting down must stay asynchronous. An event loop callback can release the last
+        // reference to this owner, running `deinit` on one of the group's own threads, and
+        // `syncShutdownGracefully()` traps there because a loop cannot wait for itself to stop.
+        // The `withExtendedLifetime(self)` above makes that release land on an event loop thread
+        // more often than it otherwise would, so this is more load-bearing than it looks - never
+        // switch it back to the synchronous form.
+        self.group.shutdownGracefully { _ in }
     }
 
     deinit {

--- a/Libraries/ConnectNIO/Internal/EventLoopGroupOwner.swift
+++ b/Libraries/ConnectNIO/Internal/EventLoopGroupOwner.swift
@@ -1,0 +1,135 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
+
+/// Owns the lifetime of an `EventLoopGroup` and gates the scheduling of work onto its event loops.
+///
+/// Callers which can outlive the client that created them - such as a cancelation closure invoked
+/// from an unstructured task - hold this type **weakly**. A call arriving while the client is alive
+/// keeps the group running across the hop onto the event loop, and a call arriving after the client
+/// is gone finds nothing and is dropped rather than being scheduled onto a loop which has already
+/// shut down.
+///
+/// Weak references are load-bearing here, and strong ones are not an option: channel handlers are
+/// not reliably released today, so retaining the group from a handler would pin one event loop OS
+/// thread per request forever. Both leaks are unconditional:
+/// - `ProtocolClient`'s `onResult` closure captures the bidirectional stream strongly, that closure
+///   is stored in the `ResponseCallbacks` held by `ConnectStreamChannelHandler`, and the stream's
+///   `RequestCallbacks` retain the handler in turn. Every async stream leaks its handler.
+/// - When a timeout is configured, `TimeoutTimer.cancel()` never clears `onTimeout`, which retains
+///   the closure holding the request's cancelable, and through it the handler.
+final class EventLoopGroupOwner: @unchecked Sendable {
+    private let group: NIOCore.EventLoopGroup
+    private let isGroupOwned: Bool
+    private let lock = NIOConcurrencyHelpers.NIOLock()
+    /// Guarded by `lock`.
+    private var isShutDown = false
+
+    /// The underlying group, for use when creating bootstraps and channels.
+    var eventLoopGroup: NIOCore.EventLoopGroup {
+        return self.group
+    }
+
+    /// Creates an owner of a new single-threaded group whose lifetime it fully manages.
+    convenience init() {
+        self.init(
+            group: NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1), isGroupOwned: true
+        )
+    }
+
+    /// - parameter group: The group onto whose loops this owner schedules work.
+    /// - parameter isGroupOwned: Whether this owner is responsible for shutting the group down.
+    ///                           An injected group belongs to its creator and is never shut down
+    ///                           here, so that it may safely be shared between clients.
+    init(group: NIOCore.EventLoopGroup, isGroupOwned: Bool) {
+        self.group = group
+        self.isGroupOwned = isGroupOwned
+    }
+
+    /// - returns: The next event loop which should be used for a request or stream.
+    func next() -> NIOCore.EventLoop {
+        return self.group.next()
+    }
+
+    /// Runs an action on the given event loop unless the group has already been shut down.
+    ///
+    /// - parameter eventLoop: The loop on which to run the action. Must belong to this group.
+    /// - parameter action: The action to run.
+    ///
+    /// - returns: True if the action ran or was enqueued, false if it was dropped.
+    @discardableResult
+    func execute(
+        on eventLoop: NIOCore.EventLoop, _ action: @escaping @Sendable () -> Void
+    ) -> Bool {
+        // The on-loop fast path stays outside the lock so that an action which re-enters this
+        // function from the loop's own thread cannot deadlock against it.
+        if eventLoop.inEventLoop {
+            action()
+            return true
+        }
+
+        // The lock is deliberately held *across* the enqueue. NIO accepts tasks while a loop is
+        // both `.open` and `.closing`, so any enqueue which happens-before `shutdownGracefully()`
+        // is guaranteed to land and drain. Checking the flag before taking the lock, or replacing
+        // it with an atomic, would leave a window in which the group shuts down between the check
+        // and the enqueue - which is precisely the bug this type exists to close.
+        //
+        // Holding the lock across `eventLoop.execute` is safe: for an off-loop caller NIO only
+        // appends the task under its own internal lock and wakes the selector, so no foreign code
+        // runs underneath this lock. Lock ordering: `NIOHTTPClient`'s lock may be taken before this
+        // one, never the reverse.
+        return self.lock.withLock { () -> Bool in
+            if self.isShutDown {
+                return false
+            }
+
+            // `execute` rather than `submit(_:).cascade(to: nil)`: `submit` allocates a promise
+            // which is never fulfilled when the enqueue fails, and `EventLoopFuture.deinit` traps
+            // on a leaked promise in debug builds. `execute` performs the same enqueue with no
+            // promise attached.
+            eventLoop.execute { withExtendedLifetime(self) { action() } }
+            return true
+        }
+    }
+
+    /// Stops scheduling new work and, if this owner created the group, shuts the group down.
+    /// Idempotent, so `deinit` may safely call this after an explicit call.
+    func shutDown() {
+        let shouldShutDownGroup = self.lock.withLock { () -> Bool in
+            if self.isShutDown {
+                return false
+            }
+
+            self.isShutDown = true
+            return self.isGroupOwned
+        }
+
+        if shouldShutDownGroup {
+            // Shutting down must stay asynchronous. An event loop callback can release the last
+            // reference to this owner, running `deinit` on one of the group's own threads, and
+            // `syncShutdownGracefully()` traps there because a loop cannot wait for itself to
+            // stop. The `withExtendedLifetime(self)` above makes that release land on an event loop
+            // thread more often than it otherwise would, so this is more load-bearing than it looks
+            // - never switch it back to the synchronous form.
+            self.group.shutdownGracefully { _ in }
+        }
+    }
+
+    deinit {
+        self.shutDown()
+    }
+}

--- a/Libraries/ConnectNIO/Internal/EventLoopGroupOwner.swift
+++ b/Libraries/ConnectNIO/Internal/EventLoopGroupOwner.swift
@@ -16,12 +16,8 @@ import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
 
-/// Owns an `EventLoopGroup`'s lifetime and gates the scheduling of work onto its loops.
-///
-/// Handlers hold this **weakly**, so a call arriving after the client is gone finds nothing and is
-/// dropped rather than landing on a shut down loop. Strong references are not an option: handlers
-/// are not reliably released today (the `ProtocolClient` stream/handler cycle and
-/// `TimeoutTimer.cancel()` both leak them), so they would pin an event loop thread forever.
+/// Owns an `EventLoopGroup`'s lifetime and gates the scheduling of work onto its loops. Callers
+/// schedule through the `EventLoopHandle`s it vends rather than touching a loop directly.
 final class EventLoopGroupOwner: @unchecked Sendable {
     private let group: NIOCore.EventLoopGroup
     private let isGroupOwned: Bool
@@ -59,24 +55,19 @@ final class EventLoopGroupOwner: @unchecked Sendable {
         self.isGroupOwned = isGroupOwned
     }
 
-    /// - returns: The next event loop to use for a request or stream.
-    func next() -> NIOCore.EventLoop {
-        return self.group.next()
+    /// - returns: A handle to the next event loop to use for a request or stream.
+    func next() -> EventLoopHandle {
+        return EventLoopHandle(loop: self.group.next(), owner: self)
     }
 
-    /// Runs an action on the given event loop unless the group has already been shut down.
+    /// Enqueues an action onto the given event loop unless the group has already been shut down.
+    /// Callers must be off the loop; `EventLoopHandle.run(_:)` handles the inline case.
     ///
-    /// - returns: True if the action ran or was enqueued, false if it was dropped.
+    /// - returns: True if the action was enqueued, false if it was dropped.
     @discardableResult
-    func execute(
+    func enqueue(
         on eventLoop: NIOCore.EventLoop, _ action: @escaping @Sendable () -> Void
     ) -> Bool {
-        // Outside the lock so an action re-entering from the loop's thread cannot deadlock.
-        if eventLoop.inEventLoop {
-            action()
-            return true
-        }
-
         // The lock deliberately spans the enqueue. NIO accepts tasks while a loop is `.open` or
         // `.closing`, so an enqueue that happens-before `shutdownGracefully()` is guaranteed to
         // drain; checking the flag before taking the lock would reopen the race. Holding it is
@@ -154,5 +145,37 @@ final class EventLoopGroupOwner: @unchecked Sendable {
 
     deinit {
         self.shutDown()
+    }
+}
+
+/// A single event loop paired with the gate deciding whether work may still be scheduled onto it.
+///
+/// The owner is held **weakly**, so a call arriving after the client is gone finds nothing and is
+/// dropped rather than landing on a shut down loop. Strong references are not an option: handlers
+/// are not reliably released today (the `ProtocolClient` stream/handler cycle and
+/// `TimeoutTimer.cancel()` both leak them), so they would pin an event loop thread forever.
+struct EventLoopHandle: Sendable {
+    let loop: NIOCore.EventLoop
+    private weak var owner: EventLoopGroupOwner?
+
+    init(loop: NIOCore.EventLoop, owner: EventLoopGroupOwner) {
+        self.loop = loop
+        self.owner = owner
+    }
+
+    /// Runs an action on the loop, inline if already on it and enqueued otherwise.
+    ///
+    /// - returns: True if the action ran or was enqueued, false if it was dropped.
+    @discardableResult
+    func run(_ action: @escaping @Sendable () -> Void) -> Bool {
+        // Inline, and outside the owner's lock, so an action re-entering from the loop's own
+        // thread cannot deadlock. Being on that thread also proves the loop is still running, so
+        // this holds even once the owner is gone.
+        if self.loop.inEventLoop {
+            action()
+            return true
+        }
+
+        return self.owner?.enqueue(on: self.loop, action) ?? false
     }
 }

--- a/Libraries/ConnectNIO/Internal/EventLoopGroupOwner.swift
+++ b/Libraries/ConnectNIO/Internal/EventLoopGroupOwner.swift
@@ -16,34 +16,32 @@ import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
 
-/// Owns the lifetime of an `EventLoopGroup` and gates the scheduling of work onto its event loops.
+/// Owns an `EventLoopGroup`'s lifetime and gates the scheduling of work onto its loops.
 ///
-/// Callers which can outlive the client that created them - such as a cancelation closure invoked
-/// from an unstructured task - hold this type **weakly**. A call arriving while the client is alive
-/// keeps the group running across the hop onto the event loop, and a call arriving after the client
-/// is gone finds nothing and is dropped rather than being scheduled onto a loop which has already
-/// shut down.
-///
-/// Weak references are load-bearing here, and strong ones are not an option: channel handlers are
-/// not reliably released today, so retaining the group from a handler would pin one event loop OS
-/// thread per request forever. Both leaks are unconditional:
-/// - `ProtocolClient`'s `onResult` closure captures the bidirectional stream strongly, that closure
-///   is stored in the `ResponseCallbacks` held by `ConnectStreamChannelHandler`, and the stream's
-///   `RequestCallbacks` retain the handler in turn. Every async stream leaks its handler.
-/// - When a timeout is configured, `TimeoutTimer.cancel()` never clears `onTimeout`, which retains
-///   the closure holding the request's cancelable, and through it the handler.
+/// Handlers hold this **weakly**, so a call arriving after the client is gone finds nothing and is
+/// dropped rather than landing on a shut down loop. Strong references are not an option: handlers
+/// are not reliably released today (the `ProtocolClient` stream/handler cycle and
+/// `TimeoutTimer.cancel()` both leak them), so they would pin an event loop thread forever.
 final class EventLoopGroupOwner: @unchecked Sendable {
     private let group: NIOCore.EventLoopGroup
     private let isGroupOwned: Bool
     private let lock = NIOConcurrencyHelpers.NIOLock()
     /// Guarded by `lock`.
     private var isShutDown = false
-    /// Guarded by `lock`. Shutdown is deferred while this is non-zero. See `beginWork()`.
+    /// Guarded by `lock`. Shutdown is deferred while non-zero. See `beginWork()`.
     private var outstandingWorkCount = 0
+    /// Guarded by `lock`. Whether `shutDownGroup()` has run.
+    private var didShutDownGroup = false
 
-    /// The underlying group, for use when creating bootstraps and channels.
     var eventLoopGroup: NIOCore.EventLoopGroup {
         return self.group
+    }
+
+    /// Whether the group's shutdown has actually been started. Exposed for testing, since
+    /// `shutdownGracefully` is asynchronous and a closing loop still accepts work, so observing
+    /// this through the loop would race.
+    var hasInitiatedGroupShutDown: Bool {
+        return self.lock.withLock { self.didShutDownGroup }
     }
 
     /// Creates an owner of a new single-threaded group whose lifetime it fully manages.
@@ -54,65 +52,50 @@ final class EventLoopGroupOwner: @unchecked Sendable {
     }
 
     /// - parameter group: The group onto whose loops this owner schedules work.
-    /// - parameter isGroupOwned: Whether this owner is responsible for shutting the group down.
-    ///                           An injected group belongs to its creator and is never shut down
-    ///                           here, so that it may safely be shared between clients.
+    /// - parameter isGroupOwned: Whether to shut the group down. An injected group belongs to its
+    ///                           creator and is never shut down here, so it may be shared.
     init(group: NIOCore.EventLoopGroup, isGroupOwned: Bool) {
         self.group = group
         self.isGroupOwned = isGroupOwned
     }
 
-    /// - returns: The next event loop which should be used for a request or stream.
+    /// - returns: The next event loop to use for a request or stream.
     func next() -> NIOCore.EventLoop {
         return self.group.next()
     }
 
     /// Runs an action on the given event loop unless the group has already been shut down.
     ///
-    /// - parameter eventLoop: The loop on which to run the action. Must belong to this group.
-    /// - parameter action: The action to run.
-    ///
     /// - returns: True if the action ran or was enqueued, false if it was dropped.
     @discardableResult
     func execute(
         on eventLoop: NIOCore.EventLoop, _ action: @escaping @Sendable () -> Void
     ) -> Bool {
-        // The on-loop fast path stays outside the lock so that an action which re-enters this
-        // function from the loop's own thread cannot deadlock against it.
+        // Outside the lock so an action re-entering from the loop's thread cannot deadlock.
         if eventLoop.inEventLoop {
             action()
             return true
         }
 
-        // The lock is deliberately held *across* the enqueue. NIO accepts tasks while a loop is
-        // both `.open` and `.closing`, so any enqueue which happens-before `shutdownGracefully()`
-        // is guaranteed to land and drain. Checking the flag before taking the lock, or replacing
-        // it with an atomic, would leave a window in which the group shuts down between the check
-        // and the enqueue - which is precisely the bug this type exists to close.
-        //
-        // Holding the lock across `eventLoop.execute` is safe: for an off-loop caller NIO only
-        // appends the task under its own internal lock and wakes the selector, so no foreign code
-        // runs underneath this lock. Lock ordering: `NIOHTTPClient`'s lock may be taken before this
-        // one, never the reverse.
+        // The lock deliberately spans the enqueue. NIO accepts tasks while a loop is `.open` or
+        // `.closing`, so an enqueue that happens-before `shutdownGracefully()` is guaranteed to
+        // drain; checking the flag before taking the lock would reopen the race. Holding it is
+        // safe because NIO only appends under its own lock and wakes the selector.
         return self.lock.withLock { () -> Bool in
             if self.isShutDown {
                 return false
             }
 
-            // `execute` rather than `submit(_:).cascade(to: nil)`: `submit` allocates a promise
-            // which is never fulfilled when the enqueue fails, and `EventLoopFuture.deinit` traps
-            // on a leaked promise in debug builds. `execute` performs the same enqueue with no
-            // promise attached.
+            // `execute`, not `submit(_:)`, whose promise is never fulfilled when the enqueue fails
+            // and trips `EventLoopFuture.deinit`'s leaked-promise trap in debug builds.
             eventLoop.execute { withExtendedLifetime(self) { action() } }
             return true
         }
     }
 
-    /// Registers work whose completion NIO schedules onto the loop *itself*, and which therefore
-    /// cannot be gated by `execute(on:_:)`. A connect is the case that matters: NIO runs the DNS
-    /// lookup on an offload queue and hops back onto the event loop from there
-    /// (`GetaddrinfoResolver`), so the only way to stop that hop from landing on a dead loop is to
-    /// keep the loop alive. The group's shutdown is deferred until the matching `endWork()`.
+    /// Registers work whose completion NIO schedules itself, bypassing `execute(on:_:)` - namely a
+    /// connect, whose DNS lookup hops back onto the loop from an offload queue. Shutdown is
+    /// deferred until the matching `endWork()` so that hop cannot land on a dead loop.
     ///
     /// - returns: True if the work was registered, false if the group is already shut down.
     @discardableResult
@@ -127,11 +110,14 @@ final class EventLoopGroupOwner: @unchecked Sendable {
         }
     }
 
-    /// Balances a successful `beginWork()`, performing a deferred shutdown if this was the last
-    /// outstanding work and `shutDown()` has already been called.
+    /// Balances a successful `beginWork()`, running a deferred shutdown if this was the last work.
     func endWork() {
         let shouldShutDownGroup = self.lock.withLock { () -> Bool in
-            self.outstandingWorkCount = max(0, self.outstandingWorkCount - 1)
+            guard self.outstandingWorkCount > 0 else {
+                return false
+            }
+
+            self.outstandingWorkCount -= 1
             return self.isShutDown && self.isGroupOwned && self.outstandingWorkCount == 0
         }
 
@@ -140,8 +126,8 @@ final class EventLoopGroupOwner: @unchecked Sendable {
         }
     }
 
-    /// Stops scheduling new work and, if this owner created the group and no work is outstanding,
-    /// shuts the group down. Idempotent, so `deinit` may safely call this after an explicit call.
+    /// Stops scheduling new work and shuts the group down once no work is outstanding.
+    /// Idempotent, so `deinit` may safely call this after an explicit call.
     func shutDown() {
         let shouldShutDownGroup = self.lock.withLock { () -> Bool in
             if self.isShutDown {
@@ -158,12 +144,11 @@ final class EventLoopGroupOwner: @unchecked Sendable {
     }
 
     private func shutDownGroup() {
-        // Shutting down must stay asynchronous. An event loop callback can release the last
-        // reference to this owner, running `deinit` on one of the group's own threads, and
-        // `syncShutdownGracefully()` traps there because a loop cannot wait for itself to stop.
-        // The `withExtendedLifetime(self)` above makes that release land on an event loop thread
-        // more often than it otherwise would, so this is more load-bearing than it looks - never
-        // switch it back to the synchronous form.
+        // Called outside `lock`, so retaking it here is safe.
+        self.lock.withLock { self.didShutDownGroup = true }
+        // Must stay asynchronous: this owner's last reference is often released on one of the
+        // group's own threads, where `syncShutdownGracefully()` traps waiting for that loop to
+        // stop. Never switch it back to the synchronous form.
         self.group.shutdownGracefully { _ in }
     }
 

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -27,7 +27,7 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     private lazy var bootstrap = self.createBootstrap()
     private let host: String
     private let lock = NIOConcurrencyHelpers.NIOLock()
-    private let loopGroup = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    private let loopGroupOwner: EventLoopGroupOwner
     private let port: Int
     private let timeout: TimeInterval?
     private let useSSL: Bool
@@ -35,12 +35,32 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     private var pendingRequests = [(NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer?) -> Void]()
     private var state = State.disconnected
 
+    /// The group whose event loops this client uses. Exposed for testing.
+    var eventLoopGroup: NIOCore.EventLoopGroup {
+        return self.loopGroupOwner.eventLoopGroup
+    }
+
     private enum State {
         case disconnected
         case connecting
         case connected(
             channel: NIOCore.Channel, multiplexer: NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer
         )
+    }
+
+    /// The connection details parsed from the host and port passed to an initializer.
+    private struct Endpoint {
+        let host: String
+        let port: Int
+        let useSSL: Bool
+
+        init(host: String, port: Int?) {
+            let baseURL = URL(string: host)!
+            let useSSL = baseURL.scheme?.lowercased() == "https"
+            self.host = baseURL.host!
+            self.port = port ?? baseURL.port ?? (useSSL ? 443 : 80)
+            self.useSSL = useSSL
+        }
     }
 
     /// Designated initializer for the client.
@@ -53,12 +73,31 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     /// - parameter timeout: Optional timeout after which to terminate requests/streams if no
     ///                      activity has occurred in the request or response path.
     public init(host: String, port: Int? = nil, timeout: TimeInterval? = nil) {
-        let baseURL = URL(string: host)!
-        let useSSL = baseURL.scheme?.lowercased() == "https"
-        self.host = baseURL.host!
-        self.port = port ?? baseURL.port ?? (useSSL ? 443 : 80)
+        let endpoint = Endpoint(host: host, port: port)
+        self.host = endpoint.host
+        self.port = endpoint.port
+        self.useSSL = endpoint.useSSL
         self.timeout = timeout
-        self.useSSL = useSSL
+        self.loopGroupOwner = EventLoopGroupOwner()
+    }
+
+    /// Initializer which uses an externally managed event loop group rather than creating one.
+    /// The injected group is never shut down by the client, so it may safely be shared.
+    ///
+    /// - parameter host: Target host (e.g., `https://connectrpc.com`).
+    /// - parameter port: Port to use for the connection, as described above.
+    /// - parameter timeout: Optional timeout, as described above.
+    /// - parameter eventLoopGroup: The group whose event loops the client should use.
+    init(
+        host: String, port: Int? = nil, timeout: TimeInterval? = nil,
+        eventLoopGroup: NIOCore.EventLoopGroup
+    ) {
+        let endpoint = Endpoint(host: host, port: port)
+        self.host = endpoint.host
+        self.port = endpoint.port
+        self.useSSL = endpoint.useSSL
+        self.timeout = timeout
+        self.loopGroupOwner = EventLoopGroupOwner(group: eventLoopGroup, isGroupOwned: false)
     }
 
     /// Called before the first request/stream is initialized, and the result is stored for reuse
@@ -72,7 +111,7 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         ? self.createTLSConfiguration(forHost: host)
         : nil
 
-        return NIOPosix.ClientBootstrap(group: self.loopGroup)
+        return NIOPosix.ClientBootstrap(group: self.loopGroupOwner.eventLoopGroup)
             .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
@@ -114,10 +153,11 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         onMetrics: @escaping @Sendable (Connect.HTTPMetrics) -> Void,
         onResponse: @escaping @Sendable (Connect.HTTPResponse) -> Void
     ) -> Connect.Cancelable {
-        let eventLoop = self.loopGroup.next()
+        let eventLoop = self.loopGroupOwner.next()
         let handler = ConnectUnaryChannelHandler(
             request: request,
             eventLoop: eventLoop,
+            loopGroupOwner: self.loopGroupOwner,
             onMetrics: onMetrics,
             onResponse: onResponse
         )
@@ -144,11 +184,12 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         request: Connect.HTTPRequest<Data?>,
         responseCallbacks: Connect.ResponseCallbacks
     ) -> Connect.RequestCallbacks<Data> {
-        let eventLoop = self.loopGroup.next()
+        let eventLoop = self.loopGroupOwner.next()
         let handler = ConnectStreamChannelHandler(
             request: request,
             responseCallbacks: responseCallbacks,
-            eventLoop: eventLoop
+            eventLoop: eventLoop,
+            loopGroupOwner: self.loopGroupOwner
         )
         self.sendOrQueueRequest { [weak self] multiplexer in
             if let multiplexer = multiplexer {
@@ -265,10 +306,9 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
                 channel.close(mode: .all, promise: nil)
             }
         }
-        // An event loop callback can release the client's last reference, running `deinit` on that
-        // event loop. The synchronous `syncShutdownGracefully()` call will trap there because the
-        // loop cannot wait for itself to stop, so initiate shutdown asynchronously.
-        self.loopGroup.shutdownGracefully { _ in }
+        // Shut down outside `self.lock` to preserve the lock ordering documented on
+        // `EventLoopGroupOwner`: this lock may be taken before the owner's, never the reverse.
+        self.loopGroupOwner.shutDown()
     }
 }
 

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -154,14 +154,13 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         let handler = ConnectUnaryChannelHandler(
             request: request,
             eventLoop: eventLoop,
-            loopGroupOwner: self.loopGroupOwner,
             onMetrics: onMetrics,
             onResponse: onResponse
         )
         self.sendOrQueueRequest { [weak self] multiplexer in
             if let multiplexer = multiplexer {
                 self?.startMultiplexChannel(
-                    for: request.url, on: eventLoop, using: multiplexer, with: handler
+                    for: request.url, on: eventLoop.loop, using: multiplexer, with: handler
                 )
             } else {
                 onResponse(.init(
@@ -185,13 +184,12 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         let handler = ConnectStreamChannelHandler(
             request: request,
             responseCallbacks: responseCallbacks,
-            eventLoop: eventLoop,
-            loopGroupOwner: self.loopGroupOwner
+            eventLoop: eventLoop
         )
         self.sendOrQueueRequest { [weak self] multiplexer in
             if let multiplexer = multiplexer {
                 self?.startMultiplexChannel(
-                    for: request.url, on: eventLoop, using: multiplexer, with: handler
+                    for: request.url, on: eventLoop.loop, using: multiplexer, with: handler
                 )
             } else {
                 responseCallbacks.receiveClose(.unavailable, [:], ConnectError.disconnected())

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -35,7 +35,7 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     private var pendingRequests = [(NIOHTTP2.NIOHTTP2Handler.StreamMultiplexer?) -> Void]()
     private var state = State.disconnected
 
-    /// The group whose event loops this client uses. Exposed for testing.
+    /// Exposed for testing.
     var eventLoopGroup: NIOCore.EventLoopGroup {
         return self.loopGroupOwner.eventLoopGroup
     }
@@ -84,9 +84,6 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
     /// Initializer which uses an externally managed event loop group rather than creating one.
     /// The injected group is never shut down by the client, so it may safely be shared.
     ///
-    /// - parameter host: Target host (e.g., `https://connectrpc.com`).
-    /// - parameter port: Port to use for the connection, as described above.
-    /// - parameter timeout: Optional timeout, as described above.
     /// - parameter eventLoopGroup: The group whose event loops the client should use.
     init(
         host: String, port: Int? = nil, timeout: TimeInterval? = nil,
@@ -229,12 +226,9 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         }
 
         self.state = .connecting
-        // NIO drives an in-flight connect to completion on its own — the DNS lookup runs on an
-        // offload queue and hops back onto the event loop from there — so that hop never passes
-        // through `EventLoopGroupOwner.execute(on:_:)` and cannot be gated. Registering the
-        // connect as outstanding work keeps the group alive until it settles, so releasing the
-        // client mid-connect cannot leave NIO scheduling onto a shut-down loop. The owner is
-        // captured strongly: it must outlive the client here, which is the whole point.
+        // NIO completes an in-flight connect itself, hopping back onto the loop from the DNS
+        // offload queue, so registering it keeps the group alive until it settles. Captured
+        // strongly: the owner must outlive a client released mid-connect.
         let loopGroupOwner = self.loopGroupOwner
         loopGroupOwner.beginWork()
         self.bootstrap
@@ -315,8 +309,7 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
                 channel.close(mode: .all, promise: nil)
             }
         }
-        // Shut down outside `self.lock` to preserve the lock ordering documented on
-        // `EventLoopGroupOwner`: this lock may be taken before the owner's, never the reverse.
+        // Outside `self.lock`: this lock may be taken before the owner's, never the reverse.
         self.loopGroupOwner.shutDown()
     }
 }

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -229,9 +229,18 @@ open class NIOHTTPClient: Connect.HTTPClientInterface, @unchecked Sendable {
         }
 
         self.state = .connecting
+        // NIO drives an in-flight connect to completion on its own — the DNS lookup runs on an
+        // offload queue and hops back onto the event loop from there — so that hop never passes
+        // through `EventLoopGroupOwner.execute(on:_:)` and cannot be gated. Registering the
+        // connect as outstanding work keeps the group alive until it settles, so releasing the
+        // client mid-connect cannot leave NIO scheduling onto a shut-down loop. The owner is
+        // captured strongly: it must outlive the client here, which is the whole point.
+        let loopGroupOwner = self.loopGroupOwner
+        loopGroupOwner.beginWork()
         self.bootstrap
             .connect(host: self.host, port: self.port)
             .whenComplete { [weak self] result in
+                defer { loopGroupOwner.endWork() }
                 do {
                     switch result {
                     case .success(let channel):

--- a/Package.swift
+++ b/Package.swift
@@ -142,6 +142,17 @@ let package = Package(
                 "README.md",
             ]
         ),
+        .testTarget(
+            name: "ConnectNIOTests",
+            dependencies: [
+                "Connect",
+                "ConnectNIO",
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+            ],
+            path: "Tests/UnitTests/ConnectNIOTests"
+        ),
         .target(
             name: "ConnectPluginUtilities",
             dependencies: [

--- a/Tests/UnitTests/ConnectNIOTests/ConnectStreamChannelHandlerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/ConnectStreamChannelHandlerTests.swift
@@ -1,0 +1,131 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Connect
+@testable import ConnectNIO
+import Foundation
+import NIOPosix
+import Testing
+
+/// The handler is exercised directly rather than through a channel: `swift-nio-http2` ships no
+/// test utilities for the multiplexer, and `EmbeddedChannel` cannot reproduce the off-loop
+/// scheduling path because its event loop always reports `inEventLoop == true`.
+struct ConnectStreamChannelHandlerTests {
+    private typealias StreamClose = (code: Code, error: Swift.Error?)
+
+    /// A cancelation which arrives after the client - and therefore its event loop group - is gone
+    /// must be dropped. Scheduling onto a shut down loop prints a NIO error which is slated to
+    /// become a forced crash, and the unfulfilled promise left behind by `submit(_:)` trips the
+    /// debug-only leaked promise trap in `EventLoopFuture.deinit`, so a regression here takes the
+    /// test process down rather than surfacing in conformance runs.
+    @Test
+    func cancelAfterGroupShutdownDoesNotTrap() async {
+        await Self.withHandlerOnShutDownGroup { handler in
+            handler.cancel()
+        }
+    }
+
+    /// Outbound data sent after teardown takes the same off-loop path as cancelation and must
+    /// likewise be dropped rather than enqueued.
+    @Test
+    func sendDataAfterShutdownIsDropped() async {
+        await Self.withHandlerOnShutDownGroup { handler in
+            handler.sendData(Data([0x0, 0x1, 0x2]))
+        }
+    }
+
+    /// Half-closing after teardown takes the same off-loop path as cancelation and must likewise
+    /// be dropped rather than enqueued.
+    @Test
+    func closeAfterShutdownIsDropped() async {
+        await Self.withHandlerOnShutDownGroup { handler in
+            handler.close()
+        }
+    }
+
+    /// Anti-regression for the gate above: a cancelation on a live group must still deliver
+    /// `.canceled`. A gate which is too aggressive would silently report wrong codes for the
+    /// conformance cases which cancel a stream in flight.
+    @Test
+    func cancelDeliversCanceledResponseWhileGroupIsRunning() async {
+        let owner = EventLoopGroupOwner()
+        defer { owner.shutDown() }
+
+        let close: StreamClose = await withCheckedContinuation { continuation in
+            let handler = ConnectStreamChannelHandler(
+                request: Self.request(),
+                responseCallbacks: Self.responseCallbacks(receiveClose: { code, _, error in
+                    continuation.resume(returning: (code, error))
+                }),
+                eventLoop: owner.next(),
+                loopGroupOwner: owner
+            )
+            handler.cancel()
+        }
+
+        #expect(close.code == .canceled)
+        #expect((close.error as? ConnectError)?.code == .canceled)
+    }
+
+    /// Builds a handler over a group which is provably shut down, runs `action` against it from
+    /// off the event loop, and asserts that no response callback fires as a result.
+    private static func withHandlerOnShutDownGroup(
+        _ action: (ConnectStreamChannelHandler) -> Void
+    ) async {
+        // The group is owned by the test rather than by the owner so that its teardown can be
+        // awaited here, making the loop provably dead before the late call arrives.
+        let group = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let owner = EventLoopGroupOwner(group: group, isGroupOwned: false)
+        let eventLoop = owner.next()
+        owner.shutDown()
+        try? await group.shutdownGracefully()
+
+        await confirmation("response callback", expectedCount: 0) { confirm in
+            let handler = ConnectStreamChannelHandler(
+                request: Self.request(),
+                responseCallbacks: ResponseCallbacks(
+                    receiveResponseHeaders: { _ in confirm() },
+                    receiveResponseData: { _ in confirm() },
+                    receiveResponseMetrics: { _ in confirm() },
+                    receiveClose: { _, _, _ in confirm() }
+                ),
+                eventLoop: eventLoop,
+                loopGroupOwner: owner
+            )
+            action(handler)
+        }
+    }
+
+    private static func responseCallbacks(
+        receiveClose: @escaping @Sendable (Code, Trailers, Swift.Error?) -> Void
+    ) -> Connect.ResponseCallbacks {
+        return ResponseCallbacks(
+            receiveResponseHeaders: { _ in },
+            receiveResponseData: { _ in },
+            receiveResponseMetrics: { _ in },
+            receiveClose: receiveClose
+        )
+    }
+
+    private static func request() -> Connect.HTTPRequest<Data?> {
+        return HTTPRequest(
+            url: URL(string: "https://connectrpc.com/test")!,
+            headers: [:],
+            message: nil,
+            method: .post,
+            trailers: nil,
+            idempotencyLevel: .unknown
+        )
+    }
+}

--- a/Tests/UnitTests/ConnectNIOTests/ConnectStreamChannelHandlerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/ConnectStreamChannelHandlerTests.swift
@@ -62,8 +62,7 @@ struct ConnectStreamChannelHandlerTests {
                 responseCallbacks: Self.responseCallbacks(receiveClose: { code, _, error in
                     continuation.resume(returning: (code, error))
                 }),
-                eventLoop: owner.next(),
-                loopGroupOwner: owner
+                eventLoop: owner.next()
             )
             handler.cancel()
         }
@@ -93,8 +92,7 @@ struct ConnectStreamChannelHandlerTests {
                     receiveResponseMetrics: { _ in confirm() },
                     receiveClose: { _, _, _ in confirm() }
                 ),
-                eventLoop: eventLoop,
-                loopGroupOwner: owner
+                eventLoop: eventLoop
             )
             action(handler)
         }

--- a/Tests/UnitTests/ConnectNIOTests/ConnectStreamChannelHandlerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/ConnectStreamChannelHandlerTests.swift
@@ -18,17 +18,14 @@ import Foundation
 import NIOPosix
 import Testing
 
-/// The handler is exercised directly rather than through a channel: `swift-nio-http2` ships no
-/// test utilities for the multiplexer, and `EmbeddedChannel` cannot reproduce the off-loop
-/// scheduling path because its event loop always reports `inEventLoop == true`.
+/// Exercises the handler directly: `swift-nio-http2` ships no multiplexer test utilities, and
+/// `EmbeddedChannel` always reports `inEventLoop == true`, so it never takes the off-loop path.
 struct ConnectStreamChannelHandlerTests {
     private typealias StreamClose = (code: Code, error: Swift.Error?)
 
-    /// A cancelation which arrives after the client - and therefore its event loop group - is gone
-    /// must be dropped. Scheduling onto a shut down loop prints a NIO error which is slated to
-    /// become a forced crash, and the unfulfilled promise left behind by `submit(_:)` trips the
-    /// debug-only leaked promise trap in `EventLoopFuture.deinit`, so a regression here takes the
-    /// test process down rather than surfacing in conformance runs.
+    /// A cancelation arriving after the client is gone must be dropped. A regression takes the
+    /// test process down: `submit(_:)`'s unfulfilled promise trips a debug-only trap in
+    /// `EventLoopFuture.deinit`.
     @Test
     func cancelAfterGroupShutdownDoesNotTrap() async {
         await Self.withHandlerOnShutDownGroup { handler in
@@ -36,8 +33,7 @@ struct ConnectStreamChannelHandlerTests {
         }
     }
 
-    /// Outbound data sent after teardown takes the same off-loop path as cancelation and must
-    /// likewise be dropped rather than enqueued.
+    /// Outbound data takes the same off-loop path and must likewise be dropped.
     @Test
     func sendDataAfterShutdownIsDropped() async {
         await Self.withHandlerOnShutDownGroup { handler in
@@ -45,8 +41,7 @@ struct ConnectStreamChannelHandlerTests {
         }
     }
 
-    /// Half-closing after teardown takes the same off-loop path as cancelation and must likewise
-    /// be dropped rather than enqueued.
+    /// Half-closing takes the same off-loop path and must likewise be dropped.
     @Test
     func closeAfterShutdownIsDropped() async {
         await Self.withHandlerOnShutDownGroup { handler in
@@ -54,9 +49,8 @@ struct ConnectStreamChannelHandlerTests {
         }
     }
 
-    /// Anti-regression for the gate above: a cancelation on a live group must still deliver
-    /// `.canceled`. A gate which is too aggressive would silently report wrong codes for the
-    /// conformance cases which cancel a stream in flight.
+    /// Anti-regression: a gate too aggressive would report wrong codes for conformance cases
+    /// which cancel a stream in flight.
     @Test
     func cancelDeliversCanceledResponseWhileGroupIsRunning() async {
         let owner = EventLoopGroupOwner()
@@ -78,13 +72,12 @@ struct ConnectStreamChannelHandlerTests {
         #expect((close.error as? ConnectError)?.code == .canceled)
     }
 
-    /// Builds a handler over a group which is provably shut down, runs `action` against it from
-    /// off the event loop, and asserts that no response callback fires as a result.
+    /// Runs `action` off-loop against a handler whose group is shut down, asserting no callback
+    /// fires.
     private static func withHandlerOnShutDownGroup(
         _ action: (ConnectStreamChannelHandler) -> Void
     ) async {
-        // The group is owned by the test rather than by the owner so that its teardown can be
-        // awaited here, making the loop provably dead before the late call arrives.
+        // Owned by the test so its teardown can be awaited, making the loop provably dead.
         let group = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let owner = EventLoopGroupOwner(group: group, isGroupOwned: false)
         let eventLoop = owner.next()

--- a/Tests/UnitTests/ConnectNIOTests/ConnectUnaryChannelHandlerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/ConnectUnaryChannelHandlerTests.swift
@@ -1,0 +1,85 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Connect
+@testable import ConnectNIO
+import Foundation
+import NIOPosix
+import Testing
+
+/// The handler is exercised directly rather than through a channel: `swift-nio-http2` ships no
+/// test utilities for the multiplexer, and `EmbeddedChannel` cannot reproduce the off-loop
+/// scheduling path because its event loop always reports `inEventLoop == true`.
+struct ConnectUnaryChannelHandlerTests {
+    /// A cancelation which arrives after the client - and therefore its event loop group - is gone
+    /// must be dropped. Scheduling onto a shut down loop prints a NIO error which is slated to
+    /// become a forced crash, and the unfulfilled promise left behind by `submit(_:)` trips the
+    /// debug-only leaked promise trap in `EventLoopFuture.deinit`, so a regression here takes the
+    /// test process down rather than surfacing in conformance runs.
+    @Test
+    func cancelAfterGroupShutdownDoesNotTrap() async {
+        // The group is owned by the test rather than by the owner so that its teardown can be
+        // awaited here, making the loop provably dead before the late cancelation arrives.
+        let group = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let owner = EventLoopGroupOwner(group: group, isGroupOwned: false)
+        let eventLoop = owner.next()
+        owner.shutDown()
+        try? await group.shutdownGracefully()
+
+        await confirmation("onResponse", expectedCount: 0) { confirm in
+            let handler = ConnectUnaryChannelHandler(
+                request: Self.request(),
+                eventLoop: eventLoop,
+                loopGroupOwner: owner,
+                onMetrics: { _ in },
+                onResponse: { _ in confirm() }
+            )
+            handler.cancel()
+        }
+    }
+
+    /// Anti-regression for the gate above: a cancelation on a live group must still deliver
+    /// `.canceled`. A gate which is too aggressive would silently report wrong codes for the
+    /// conformance cases which cancel a request in flight.
+    @Test
+    func cancelDeliversCanceledResponseWhileGroupIsRunning() async {
+        let owner = EventLoopGroupOwner()
+        defer { owner.shutDown() }
+
+        let response: Connect.HTTPResponse = await withCheckedContinuation { continuation in
+            let handler = ConnectUnaryChannelHandler(
+                request: Self.request(),
+                eventLoop: owner.next(),
+                loopGroupOwner: owner,
+                onMetrics: { _ in },
+                onResponse: { continuation.resume(returning: $0) }
+            )
+            handler.cancel()
+        }
+
+        #expect(response.code == .canceled)
+        #expect((response.error as? ConnectError)?.code == .canceled)
+    }
+
+    private static func request() -> Connect.HTTPRequest<Data?> {
+        return HTTPRequest(
+            url: URL(string: "https://connectrpc.com/test")!,
+            headers: [:],
+            message: nil,
+            method: .post,
+            trailers: nil,
+            idempotencyLevel: .unknown
+        )
+    }
+}

--- a/Tests/UnitTests/ConnectNIOTests/ConnectUnaryChannelHandlerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/ConnectUnaryChannelHandlerTests.swift
@@ -38,7 +38,6 @@ struct ConnectUnaryChannelHandlerTests {
             let handler = ConnectUnaryChannelHandler(
                 request: Self.request(),
                 eventLoop: eventLoop,
-                loopGroupOwner: owner,
                 onMetrics: { _ in },
                 onResponse: { _ in confirm() }
             )
@@ -57,7 +56,6 @@ struct ConnectUnaryChannelHandlerTests {
             let handler = ConnectUnaryChannelHandler(
                 request: Self.request(),
                 eventLoop: owner.next(),
-                loopGroupOwner: owner,
                 onMetrics: { _ in },
                 onResponse: { continuation.resume(returning: $0) }
             )

--- a/Tests/UnitTests/ConnectNIOTests/ConnectUnaryChannelHandlerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/ConnectUnaryChannelHandlerTests.swift
@@ -18,15 +18,12 @@ import Foundation
 import NIOPosix
 import Testing
 
-/// The handler is exercised directly rather than through a channel: `swift-nio-http2` ships no
-/// test utilities for the multiplexer, and `EmbeddedChannel` cannot reproduce the off-loop
-/// scheduling path because its event loop always reports `inEventLoop == true`.
+/// Exercises the handler directly: `swift-nio-http2` ships no multiplexer test utilities, and
+/// `EmbeddedChannel` always reports `inEventLoop == true`, so it never takes the off-loop path.
 struct ConnectUnaryChannelHandlerTests {
-    /// A cancelation which arrives after the client - and therefore its event loop group - is gone
-    /// must be dropped. Scheduling onto a shut down loop prints a NIO error which is slated to
-    /// become a forced crash, and the unfulfilled promise left behind by `submit(_:)` trips the
-    /// debug-only leaked promise trap in `EventLoopFuture.deinit`, so a regression here takes the
-    /// test process down rather than surfacing in conformance runs.
+    /// A cancelation arriving after the client is gone must be dropped. A regression takes the
+    /// test process down: `submit(_:)`'s unfulfilled promise trips a debug-only trap in
+    /// `EventLoopFuture.deinit`.
     @Test
     func cancelAfterGroupShutdownDoesNotTrap() async {
         // The group is owned by the test rather than by the owner so that its teardown can be
@@ -49,9 +46,8 @@ struct ConnectUnaryChannelHandlerTests {
         }
     }
 
-    /// Anti-regression for the gate above: a cancelation on a live group must still deliver
-    /// `.canceled`. A gate which is too aggressive would silently report wrong codes for the
-    /// conformance cases which cancel a request in flight.
+    /// Anti-regression: a gate too aggressive would report wrong codes for conformance cases
+    /// which cancel a request in flight.
     @Test
     func cancelDeliversCanceledResponseWhileGroupIsRunning() async {
         let owner = EventLoopGroupOwner()

--- a/Tests/UnitTests/ConnectNIOTests/EventLoopGroupOwnerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/EventLoopGroupOwnerTests.swift
@@ -13,102 +13,112 @@
 // limitations under the License.
 
 @testable import ConnectNIO
-import Dispatch
 import NIOCore
 import NIOPosix
 import Testing
 
-/// These tests deliberately use a real `MultiThreadedEventLoopGroup` rather than
-/// `EmbeddedEventLoop`, whose `inEventLoop` is unconditionally `true` - the off-loop path being
-/// tested here would never be taken.
+/// Uses a real `MultiThreadedEventLoopGroup` rather than `EmbeddedEventLoop`, whose `inEventLoop`
+/// is unconditionally `true` - the off-loop path tested here would never be taken.
 struct EventLoopGroupOwnerTests {
-    /// An action scheduled from off the event loop runs while the group is still alive.
-    @Test
-    func executesActionWhileGroupIsRunning() {
+    /// Touched only on the event loop thread which creates it.
+    private final class InlineAction: @unchecked Sendable {
+        var didRun = false
+    }
+
+    /// An action scheduled from off the loop runs while the group is alive.
+    @available(macOS 13, iOS 16, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
+    func executesActionWhileGroupIsRunning() async {
         let owner = EventLoopGroupOwner()
         defer { owner.shutDown() }
 
-        let didRun = DispatchSemaphore(value: 0)
-        let wasScheduled = owner.execute(on: owner.next()) { didRun.signal() }
-        #expect(wasScheduled)
-        #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
+        await confirmation("the action runs") { confirm in
+            await withCheckedContinuation { continuation in
+                let wasScheduled = owner.execute(on: owner.next()) {
+                    confirm()
+                    continuation.resume()
+                }
+                #expect(wasScheduled)
+            }
+        }
     }
 
-    /// The invariant this type exists to encode: once the group has been shut down, later actions
-    /// are dropped rather than scheduled onto an event loop which can no longer run them.
+    /// The invariant this type encodes: once shut down, actions are dropped rather than scheduled
+    /// onto a loop which can no longer run them.
     @Test
-    func dropsActionAfterShutDown() {
+    func dropsActionAfterShutDown() async {
         let owner = EventLoopGroupOwner()
         let eventLoop = owner.next()
         owner.shutDown()
 
-        let didRun = DispatchSemaphore(value: 0)
-        let wasScheduled = owner.execute(on: eventLoop) { didRun.signal() }
-        #expect(!wasScheduled)
-        #expect(didRun.wait(timeout: .now() + .milliseconds(100)) == .timedOut)
+        // The gate is synchronous, so a dropped action can be asserted without waiting.
+        await confirmation("the action never runs", expectedCount: 0) { confirm in
+            let wasScheduled = owner.execute(on: eventLoop) { confirm() }
+            #expect(!wasScheduled)
+        }
     }
 
-    /// Actions submitted from the event loop's own thread run inline rather than being enqueued,
-    /// so that an action which re-enters the owner cannot deadlock against its lock.
-    @Test
-    func runsActionInlineWhenAlreadyOnEventLoop() {
+    /// Actions submitted from the loop's own thread run inline, so an action re-entering the owner
+    /// cannot deadlock against its lock.
+    @available(macOS 13, iOS 16, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
+    func runsActionInlineWhenAlreadyOnEventLoop() async {
         let owner = EventLoopGroupOwner()
         defer { owner.shutDown() }
 
         let eventLoop = owner.next()
-        let ranInline = DispatchSemaphore(value: 0)
-        let finished = DispatchSemaphore(value: 0)
-        eventLoop.execute {
-            let didRun = DispatchSemaphore(value: 0)
-            let wasScheduled = owner.execute(on: eventLoop) { didRun.signal() }
-            // A zero timeout only succeeds if the action has already run, i.e. ran inline.
-            if wasScheduled, didRun.wait(timeout: .now()) == .success {
-                ranInline.signal()
+        let ranInline: Bool = await withCheckedContinuation { continuation in
+            eventLoop.execute {
+                let action = InlineAction()
+                owner.execute(on: eventLoop) { action.didRun = true }
+                // Read back on the same thread: true only if the action ran without a hop.
+                continuation.resume(returning: action.didRun)
             }
-            finished.signal()
         }
 
-        #expect(finished.wait(timeout: .now() + .seconds(5)) == .success)
-        #expect(ranInline.wait(timeout: .now()) == .success, "The action should run inline.")
+        #expect(ranInline)
     }
 
-    /// An injected group belongs to its creator and may be shared between clients, so the owner
-    /// must never shut it down.
-    @Test
-    func doesNotShutDownInjectedGroup() {
+    /// An injected group belongs to its creator and may be shared, so it is never shut down here.
+    @available(macOS 13, iOS 16, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
+    func doesNotShutDownInjectedGroup() async {
         let group = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
-
         let owner = EventLoopGroupOwner(group: group, isGroupOwned: false)
         let eventLoop = owner.next()
         owner.shutDown()
+        #expect(!owner.hasInitiatedGroupShutDown)
 
-        let didRun = DispatchSemaphore(value: 0)
-        eventLoop.execute { didRun.signal() }
-        #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
+        await confirmation("the injected group still schedules") { confirm in
+            await withCheckedContinuation { continuation in
+                eventLoop.execute {
+                    confirm()
+                    continuation.resume()
+                }
+            }
+        }
+
+        try? await group.shutdownGracefully()
     }
 
-    /// Some work is completed by NIO on its own schedule and never passes through
-    /// `execute(on:_:)` — a connect resolves DNS on an offload queue and hops back onto the loop
-    /// from inside NIO. Gating cannot reach that hop, so while such work is outstanding the loop
-    /// itself has to stay alive: shutdown is deferred until `endWork()`.
+    /// NIO schedules some work onto the loop itself, bypassing `execute(on:_:)` - a connect hops
+    /// back from its DNS offload queue. The group must stay up while such work is outstanding.
+    ///
+    /// Asserted on the owner rather than by scheduling onto the loop: `shutdownGracefully` is
+    /// asynchronous and a closing loop still accepts tasks, so a liveness probe would race.
     @Test
     func deferShutDownWhileWorkIsOutstanding() {
         let owner = EventLoopGroupOwner()
-        let eventLoop = owner.next()
         #expect(owner.beginWork())
-        owner.shutDown()
 
-        // Scheduled straight onto the loop, bypassing the gate, exactly as NIO does internally.
-        let didRun = DispatchSemaphore(value: 0)
-        eventLoop.execute { didRun.signal() }
-        #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
+        owner.shutDown()
+        #expect(!owner.hasInitiatedGroupShutDown, "Shutdown must wait for outstanding work.")
 
         owner.endWork()
+        #expect(owner.hasInitiatedGroupShutDown, "The last endWork() must shut the group down.")
     }
 
-    /// Work cannot be registered once the group is shut down — there is nothing left to keep
-    /// alive, and reporting otherwise would leave the caller expecting a loop that is gone.
+    /// Work cannot be registered once the group is shut down: there is nothing left to keep alive.
     @Test
     func refusesWorkAfterShutDown() {
         let owner = EventLoopGroupOwner()
@@ -116,17 +126,20 @@ struct EventLoopGroupOwnerTests {
         #expect(!owner.beginWork())
     }
 
-    /// Shutdown must stay asynchronous: `syncShutdownGracefully()` traps when it runs on a thread
-    /// belonging to the group being shut down, which is exactly what happens when the last
-    /// reference to the owner is released by an event loop callback.
-    @Test
-    func shutDownFromInsideEventLoopDoesNotTrap() {
+    /// Shutdown must stay asynchronous: `syncShutdownGracefully()` traps on a thread belonging to
+    /// the group being shut down, which is where the owner's last reference is often released.
+    @available(macOS 13, iOS 16, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
+    func shutDownFromInsideEventLoopDoesNotTrap() async {
         let owner = EventLoopGroupOwner()
-        let finished = DispatchSemaphore(value: 0)
-        owner.next().execute {
-            owner.shutDown()
-            finished.signal()
+        await confirmation("shutDown() returns from the event loop thread") { confirm in
+            await withCheckedContinuation { continuation in
+                owner.next().execute {
+                    owner.shutDown()
+                    confirm()
+                    continuation.resume()
+                }
+            }
         }
-        #expect(finished.wait(timeout: .now() + .seconds(5)) == .success)
     }
 }

--- a/Tests/UnitTests/ConnectNIOTests/EventLoopGroupOwnerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/EventLoopGroupOwnerTests.swift
@@ -88,6 +88,34 @@ struct EventLoopGroupOwnerTests {
         #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
     }
 
+    /// Some work is completed by NIO on its own schedule and never passes through
+    /// `execute(on:_:)` — a connect resolves DNS on an offload queue and hops back onto the loop
+    /// from inside NIO. Gating cannot reach that hop, so while such work is outstanding the loop
+    /// itself has to stay alive: shutdown is deferred until `endWork()`.
+    @Test
+    func deferShutDownWhileWorkIsOutstanding() {
+        let owner = EventLoopGroupOwner()
+        let eventLoop = owner.next()
+        #expect(owner.beginWork())
+        owner.shutDown()
+
+        // Scheduled straight onto the loop, bypassing the gate, exactly as NIO does internally.
+        let didRun = DispatchSemaphore(value: 0)
+        eventLoop.execute { didRun.signal() }
+        #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
+
+        owner.endWork()
+    }
+
+    /// Work cannot be registered once the group is shut down — there is nothing left to keep
+    /// alive, and reporting otherwise would leave the caller expecting a loop that is gone.
+    @Test
+    func refusesWorkAfterShutDown() {
+        let owner = EventLoopGroupOwner()
+        owner.shutDown()
+        #expect(!owner.beginWork())
+    }
+
     /// Shutdown must stay asynchronous: `syncShutdownGracefully()` traps when it runs on a thread
     /// belonging to the group being shut down, which is exactly what happens when the last
     /// reference to the owner is released by an event loop callback.

--- a/Tests/UnitTests/ConnectNIOTests/EventLoopGroupOwnerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/EventLoopGroupOwnerTests.swift
@@ -1,0 +1,104 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import ConnectNIO
+import Dispatch
+import NIOCore
+import NIOPosix
+import Testing
+
+/// These tests deliberately use a real `MultiThreadedEventLoopGroup` rather than
+/// `EmbeddedEventLoop`, whose `inEventLoop` is unconditionally `true` - the off-loop path being
+/// tested here would never be taken.
+struct EventLoopGroupOwnerTests {
+    /// An action scheduled from off the event loop runs while the group is still alive.
+    @Test
+    func executesActionWhileGroupIsRunning() {
+        let owner = EventLoopGroupOwner()
+        defer { owner.shutDown() }
+
+        let didRun = DispatchSemaphore(value: 0)
+        let wasScheduled = owner.execute(on: owner.next()) { didRun.signal() }
+        #expect(wasScheduled)
+        #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
+    }
+
+    /// The invariant this type exists to encode: once the group has been shut down, later actions
+    /// are dropped rather than scheduled onto an event loop which can no longer run them.
+    @Test
+    func dropsActionAfterShutDown() {
+        let owner = EventLoopGroupOwner()
+        let eventLoop = owner.next()
+        owner.shutDown()
+
+        let didRun = DispatchSemaphore(value: 0)
+        let wasScheduled = owner.execute(on: eventLoop) { didRun.signal() }
+        #expect(!wasScheduled)
+        #expect(didRun.wait(timeout: .now() + .milliseconds(100)) == .timedOut)
+    }
+
+    /// Actions submitted from the event loop's own thread run inline rather than being enqueued,
+    /// so that an action which re-enters the owner cannot deadlock against its lock.
+    @Test
+    func runsActionInlineWhenAlreadyOnEventLoop() {
+        let owner = EventLoopGroupOwner()
+        defer { owner.shutDown() }
+
+        let eventLoop = owner.next()
+        let ranInline = DispatchSemaphore(value: 0)
+        let finished = DispatchSemaphore(value: 0)
+        eventLoop.execute {
+            let didRun = DispatchSemaphore(value: 0)
+            let wasScheduled = owner.execute(on: eventLoop) { didRun.signal() }
+            // A zero timeout only succeeds if the action has already run, i.e. ran inline.
+            if wasScheduled, didRun.wait(timeout: .now()) == .success {
+                ranInline.signal()
+            }
+            finished.signal()
+        }
+
+        #expect(finished.wait(timeout: .now() + .seconds(5)) == .success)
+        #expect(ranInline.wait(timeout: .now()) == .success, "The action should run inline.")
+    }
+
+    /// An injected group belongs to its creator and may be shared between clients, so the owner
+    /// must never shut it down.
+    @Test
+    func doesNotShutDownInjectedGroup() {
+        let group = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+
+        let owner = EventLoopGroupOwner(group: group, isGroupOwned: false)
+        let eventLoop = owner.next()
+        owner.shutDown()
+
+        let didRun = DispatchSemaphore(value: 0)
+        eventLoop.execute { didRun.signal() }
+        #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
+    }
+
+    /// Shutdown must stay asynchronous: `syncShutdownGracefully()` traps when it runs on a thread
+    /// belonging to the group being shut down, which is exactly what happens when the last
+    /// reference to the owner is released by an event loop callback.
+    @Test
+    func shutDownFromInsideEventLoopDoesNotTrap() {
+        let owner = EventLoopGroupOwner()
+        let finished = DispatchSemaphore(value: 0)
+        owner.next().execute {
+            owner.shutDown()
+            finished.signal()
+        }
+        #expect(finished.wait(timeout: .now() + .seconds(5)) == .success)
+    }
+}

--- a/Tests/UnitTests/ConnectNIOTests/EventLoopGroupOwnerTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/EventLoopGroupOwnerTests.swift
@@ -34,7 +34,7 @@ struct EventLoopGroupOwnerTests {
 
         await confirmation("the action runs") { confirm in
             await withCheckedContinuation { continuation in
-                let wasScheduled = owner.execute(on: owner.next()) {
+                let wasScheduled = owner.next().run {
                     confirm()
                     continuation.resume()
                 }
@@ -48,12 +48,12 @@ struct EventLoopGroupOwnerTests {
     @Test
     func dropsActionAfterShutDown() async {
         let owner = EventLoopGroupOwner()
-        let eventLoop = owner.next()
+        let handle = owner.next()
         owner.shutDown()
 
         // The gate is synchronous, so a dropped action can be asserted without waiting.
         await confirmation("the action never runs", expectedCount: 0) { confirm in
-            let wasScheduled = owner.execute(on: eventLoop) { confirm() }
+            let wasScheduled = handle.run { confirm() }
             #expect(!wasScheduled)
         }
     }
@@ -66,11 +66,11 @@ struct EventLoopGroupOwnerTests {
         let owner = EventLoopGroupOwner()
         defer { owner.shutDown() }
 
-        let eventLoop = owner.next()
+        let handle = owner.next()
         let ranInline: Bool = await withCheckedContinuation { continuation in
-            eventLoop.execute {
+            handle.loop.execute {
                 let action = InlineAction()
-                owner.execute(on: eventLoop) { action.didRun = true }
+                handle.run { action.didRun = true }
                 // Read back on the same thread: true only if the action ran without a hop.
                 continuation.resume(returning: action.didRun)
             }
@@ -85,7 +85,7 @@ struct EventLoopGroupOwnerTests {
     func doesNotShutDownInjectedGroup() async {
         let group = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let owner = EventLoopGroupOwner(group: group, isGroupOwned: false)
-        let eventLoop = owner.next()
+        let eventLoop = owner.next().loop
         owner.shutDown()
         #expect(!owner.hasInitiatedGroupShutDown)
 
@@ -134,7 +134,7 @@ struct EventLoopGroupOwnerTests {
         let owner = EventLoopGroupOwner()
         await confirmation("shutDown() returns from the event loop thread") { confirm in
             await withCheckedContinuation { continuation in
-                owner.next().execute {
+                owner.next().loop.execute {
                     owner.shutDown()
                     confirm()
                     continuation.resume()

--- a/Tests/UnitTests/ConnectNIOTests/NIOHTTPClientTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/NIOHTTPClientTests.swift
@@ -13,27 +13,32 @@
 // limitations under the License.
 
 @testable import ConnectNIO
-import Dispatch
 import NIOPosix
 import Testing
 
 struct NIOHTTPClientTests {
-    /// A client which creates its own event loop group shuts that group down on deallocation, but
-    /// an injected group belongs to the caller and must outlive the client so that several clients
-    /// can share one group.
-    @Test
-    func deinitDoesNotShutDownInjectedGroup() {
+    /// A client shuts down the group it created, but an injected group belongs to the caller and
+    /// must outlive the client so that several clients can share one.
+    @available(macOS 13, iOS 16, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
+    func deinitDoesNotShutDownInjectedGroup() async {
         let group = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
 
-        // Scoped so that the client is released before the group is exercised below.
+        // Scoped so the client is released before the group is exercised below.
         do {
             let client = NIOHTTPClient(host: "https://connectrpc.com", eventLoopGroup: group)
             #expect(client.eventLoopGroup as AnyObject === group as AnyObject)
         }
 
-        let didRun = DispatchSemaphore(value: 0)
-        group.next().execute { didRun.signal() }
-        #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
+        await confirmation("the injected group still schedules") { confirm in
+            await withCheckedContinuation { continuation in
+                group.next().execute {
+                    confirm()
+                    continuation.resume()
+                }
+            }
+        }
+
+        try? await group.shutdownGracefully()
     }
 }

--- a/Tests/UnitTests/ConnectNIOTests/NIOHTTPClientTests.swift
+++ b/Tests/UnitTests/ConnectNIOTests/NIOHTTPClientTests.swift
@@ -1,0 +1,39 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import ConnectNIO
+import Dispatch
+import NIOPosix
+import Testing
+
+struct NIOHTTPClientTests {
+    /// A client which creates its own event loop group shuts that group down on deallocation, but
+    /// an injected group belongs to the caller and must outlive the client so that several clients
+    /// can share one group.
+    @Test
+    func deinitDoesNotShutDownInjectedGroup() {
+        let group = NIOPosix.MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+
+        // Scoped so that the client is released before the group is exercised below.
+        do {
+            let client = NIOHTTPClient(host: "https://connectrpc.com", eventLoopGroup: group)
+            #expect(client.eventLoopGroup as AnyObject === group as AnyObject)
+        }
+
+        let didRun = DispatchSemaphore(value: 0)
+        group.next().execute { didRun.signal() }
+        #expect(didRun.wait(timeout: .now() + .seconds(5)) == .success)
+    }
+}


### PR DESCRIPTION
`make testconformance` floods stderr with:

```
ERROR: Cannot schedule tasks on an EventLoop that has already shut down.
This will be upgraded to a forced crash in future SwiftNIO versions.
```

27 occurrences per run on `main` (e2f8e69). SwiftNIO's `fatalError` path already exists behind `SWIFTNIO_STRICT`, so a NIO upgrade turns this into a hard crash. It is residue from [#407](https://github.com/connectrpc/connect-swift/pull/407), which converted the `deinit` trap into this print without fixing the lifetime bug underneath.

## Cause

`NIOHTTPClient` owns a private event loop group and shuts it down in `deinit` without waiting for anything. Two kinds of work then land on a dead loop:

1. **Late cancelation from our own code** (26 of the 27). Handlers hold no reference to the client, so a `cancel()` arriving after teardown reaches `eventLoop.submit(...)` on a dead loop. The conformance client builds a client per test request, hence a flood.
2. **NIO's own scheduling during a connect** (the last 1). `connect(host:port:)` resolves DNS on an offload queue and hops back with `loop.execute` from inside NIO, so no gate of ours can reach it. Reproduced deterministically: 300 clients torn down mid-connect produce exactly 300 occurrences.

## Fix

A new internal `EventLoopGroupOwner` owns the group and gates scheduling onto it.

- Handlers hold it **weakly**, so a late call finds nothing and is dropped. Strong references would pin an event loop thread per request forever, since handlers are not reliably released today (`ProtocolClient`'s stream ⟷ handler cycle, `TimeoutTimer.cancel()`).
- The lock spans the enqueue. NIO accepts tasks while a loop is `.open` or `.closing`, so an enqueue that happens-before `shutdownGracefully()` is guaranteed to drain; checking a flag first reopens the race.
- `execute`, not `submit(_:)`, whose unfulfilled promise trips `EventLoopFuture.deinit`'s leaked-promise trap in debug builds.
- For cause 2, the connect is registered as outstanding work and the group's shutdown is deferred until it settles — bounded by `ClientBootstrap`'s 10s `connectTimeout`.

Nothing changes on the drop path: NIO already swallowed these actions, so they never ran. They are now dropped cleanly instead of printing and leaking a promise, which is why all 2,647 conformance cases still pass unchanged.

No public API change. The internal `init(host:port:timeout:eventLoopGroup:)` seam is for tests; an injected group is never shut down by the client, so two clients can share one.

## Verification

- **Conformance: 27 → 1 (gate) → 0 (connect lifetime)**, green on CI with both suites completing. `SWIFTNIO_STRICT=1 make testconformance` is clean.
- **The 300-client teardown repro: 300 → 0.**
- **The tests fail before the fix.** Reverting `runOnEventLoop` trips `leaking promise created at EventLoop.swift:1025` and kills the test process; dropping the outstanding-work check fails `deferShutDownWhileWorkIsOutstanding`. Two anti-regression cases pass in every state, guarding against a gate that is too aggressive.
- New `ConnectNIOTests` target, 14 tests — on a real `MultiThreadedEventLoopGroup`, since `EmbeddedEventLoop` always reports `inEventLoop == true` and never takes the path this bug lives on. `swift test` 84/84, clean over 100 consecutive runs.
- Thread count plateaus at 9 during a conformance run rather than climbing; a per-client leak across 1681 cases would show hundreds.

Two notes for reviewers. `run-conformance-tests` was already passing — `make testconformance` builds `-c release`, where this is only a print — so this removes the flood and the future-crash exposure rather than turning a red job green. And `hasInitiatedGroupShutDown` exists purely so the deferral is testable: `shutdownGracefully` is asynchronous and a closing loop still accepts tasks, so probing the loop instead would race.
