### PR TITLE
Replace TimeoutTimer's GCD implementation with structured concurrency

### DIFF
--- a/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
+++ b/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
@@ -14,12 +14,21 @@
 
 import Foundation
 
-final class TimeoutTimer: @unchecked Sendable {
+/// Fires a callback if a configured deadline elapses before the timer is canceled.
+///
+/// Cancelation is sticky: once `cancel()` has been called the timer can never fire, even if
+/// `start(onTimeout:)` runs afterwards. `ProtocolClient` depends on this - draining pending
+/// request callbacks can synchronously reach `cancel()` before `start()`.
+final class TimeoutTimer: Sendable {
+    private enum State {
+        case ready
+        case started(Task<Void, Never>)
+        case canceled
+    }
+
     private let hasTimedOut = Locked(false)
-    private var onTimeout: (() -> Void)?
-    private let queue = DispatchQueue(label: "connectrpc.Timeout")
+    private let state = Locked<State>(.ready)
     private let timeout: TimeInterval
-    private var workItem: DispatchWorkItem! // Force-unwrapped to allow capturing self in init
 
     var timedOut: Bool {
         return self.hasTimedOut.value
@@ -31,25 +40,55 @@ final class TimeoutTimer: @unchecked Sendable {
         }
 
         self.timeout = timeout
-        self.workItem = DispatchWorkItem { [weak self] in
-            self?.hasTimedOut.value = true
-            self?.onTimeout?()
-        }
     }
 
     deinit {
         self.cancel()
     }
 
-    func start(onTimeout: @escaping () -> Void) {
-        let milliseconds = Int(self.timeout * 1_000)
-        self.queue.sync { self.onTimeout = onTimeout }
-        self.queue.asyncAfter(
-            deadline: .now() + .milliseconds(milliseconds), execute: self.workItem
-        )
+    /// Start the timer. Has no effect if `cancel()` has already been called.
+    func start(onTimeout: @escaping @Sendable () -> Void) {
+        // Clamped: `timeout` is caller-supplied, and `UInt64(negativeDouble)` traps.
+        let nanoseconds = UInt64(max(0, self.timeout * 1_000_000_000))
+        // Capturing the box rather than `self` lets `deinit` disarm an orphaned timer.
+        let hasTimedOut = self.hasTimedOut
+        let task = Task {
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds)
+            } catch {
+                return
+            }
+
+            hasTimedOut.value = true
+            // Must stay outside any lock: this re-enters `cancel()`/`deinit` via cancelation,
+            // which is the deadlock fixed in #389.
+            onTimeout()
+        }
+        let wasCanceled = self.state.perform { state -> Bool in
+            switch state {
+            case .canceled:
+                return true
+            case .ready, .started:
+                state = .started(task)
+                return false
+            }
+        }
+        if wasCanceled {
+            task.cancel()
+        }
     }
 
     func cancel() {
-        workItem.cancel()
+        let task = self.state.perform { state -> Task<Void, Never>? in
+            switch state {
+            case .started(let task):
+                state = .canceled
+                return task
+            case .ready, .canceled:
+                state = .canceled
+                return nil
+            }
+        }
+        task?.cancel()
     }
 }

--- a/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
+++ b/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
@@ -50,7 +50,7 @@ final class TimeoutTimer: Sendable {
     func start(onTimeout: @escaping @Sendable () -> Void) {
         // Clamped: `timeout` is caller-supplied, and `UInt64(negativeDouble)` traps.
         let nanoseconds = UInt64(max(0, self.timeout * 1_000_000_000))
-        // Capturing the box rather than `self` lets `deinit` disarm an orphaned timer.
+        // Avoid capturing `self` so `deinit` disarms the orphaned timer.
         let hasTimedOut = self.hasTimedOut
         let task = Task {
             do {

--- a/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
+++ b/Libraries/Connect/Internal/Utilities/TimeoutTimer.swift
@@ -16,22 +16,27 @@ import Foundation
 
 /// Fires a callback if a configured deadline elapses before the timer is canceled.
 ///
-/// Cancelation is sticky: once `cancel()` has been called the timer can never fire, even if
-/// `start(onTimeout:)` runs afterwards. `ProtocolClient` depends on this - draining pending
-/// request callbacks can synchronously reach `cancel()` before `start()`.
+/// `.timedOut` and `.canceled` are both terminal, so cancelation is sticky - once `cancel()` has
+/// been called the timer can never fire, even if `start(onTimeout:)` runs afterwards.
+/// `ProtocolClient` depends on this - draining pending request callbacks can synchronously reach
+/// `cancel()` before `start()`.
 final class TimeoutTimer: Sendable {
     private enum State {
         case ready
         case started(Task<Void, Never>)
+        case timedOut
         case canceled
     }
 
-    private let hasTimedOut = Locked(false)
     private let state = Locked<State>(.ready)
     private let timeout: TimeInterval
 
     var timedOut: Bool {
-        return self.hasTimedOut.value
+        if case .timedOut = self.state.value {
+            return true
+        }
+
+        return false
     }
 
     init?(config: ProtocolClientConfig) {
@@ -51,7 +56,7 @@ final class TimeoutTimer: Sendable {
         // Clamped: `timeout` is caller-supplied, and `UInt64(negativeDouble)` traps.
         let nanoseconds = UInt64(max(0, self.timeout * 1_000_000_000))
         // Avoid capturing `self` so `deinit` disarms the orphaned timer.
-        let hasTimedOut = self.hasTimedOut
+        let state = self.state
         let task = Task {
             do {
                 try await Task.sleep(nanoseconds: nanoseconds)
@@ -59,21 +64,34 @@ final class TimeoutTimer: Sendable {
                 return
             }
 
-            hasTimedOut.value = true
-            // Must stay outside any lock: this re-enters `cancel()`/`deinit` via cancelation,
-            // which is the deadlock fixed in #389.
+            // `.ready` is reachable: this task can wake before `start()` registers it below.
+            let didTimeOut = state.perform { state -> Bool in
+                switch state {
+                case .ready, .started:
+                    state = .timedOut
+                    return true
+                case .timedOut, .canceled:
+                    return false
+                }
+            }
+            guard didTimeOut else {
+                return
+            }
+
+            // Must stay outside the lock: this re-enters `timedOut`/`cancel()`/`deinit` via
+            // cancelation, which would deadlock.
             onTimeout()
         }
-        let wasCanceled = self.state.perform { state -> Bool in
+        let isTerminal = self.state.perform { state -> Bool in
             switch state {
-            case .canceled:
+            case .timedOut, .canceled:
                 return true
             case .ready, .started:
                 state = .started(task)
                 return false
             }
         }
-        if wasCanceled {
+        if isTerminal {
             task.cancel()
         }
     }
@@ -84,8 +102,12 @@ final class TimeoutTimer: Sendable {
             case .started(let task):
                 state = .canceled
                 return task
-            case .ready, .canceled:
+            case .ready:
                 state = .canceled
+                return nil
+            case .timedOut, .canceled:
+                // Terminal. `.timedOut` must survive, because `deinit` always calls `cancel()`
+                // and `ProtocolClient` reads `timedOut` while the timer is still alive.
                 return nil
             }
         }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTimerTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/TimeoutTimerTests.swift
@@ -1,0 +1,89 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import Connect
+import Foundation
+import Testing
+
+struct TimeoutTimerTests {
+    /// Generous multiple of the 50ms deadline configured by `makeConfig()`. `confirmation()`
+    /// validates its count when the body returns rather than waiting, so the body must outlast
+    /// the deadline on its own.
+    private static let waitNanoseconds: UInt64 = 500_000_000
+
+    @Test
+    func returnsNilWhenTimeoutIsNotConfigured() {
+        #expect(TimeoutTimer(config: ProtocolClientConfig(host: "http://localhost")) == nil)
+    }
+
+    @Test
+    func firesAfterTheDeadline() async throws {
+        let timer = try #require(TimeoutTimer(config: Self.makeConfig()))
+        let timedOutWhenInvoked = Locked<Bool?>(nil)
+
+        await confirmation("Deadline callback runs") { confirmed in
+            timer.start {
+                timedOutWhenInvoked.value = timer.timedOut
+                confirmed()
+            }
+            try? await Task.sleep(nanoseconds: Self.waitNanoseconds)
+        }
+
+        #expect(timer.timedOut)
+        // `ProtocolClient` reads `timedOut` from within the cancelation this callback triggers.
+        #expect(timedOutWhenInvoked.value == true)
+    }
+
+    @Test
+    func cancelAfterStartPreventsFiring() async throws {
+        let timer = try #require(TimeoutTimer(config: Self.makeConfig()))
+
+        await confirmation("Deadline callback never runs", expectedCount: 0) { confirmed in
+            timer.start { confirmed() }
+            timer.cancel()
+            try? await Task.sleep(nanoseconds: Self.waitNanoseconds)
+        }
+
+        #expect(!timer.timedOut)
+    }
+
+    @Test
+    func cancelBeforeStartPreventsFiring() async throws {
+        let timer = try #require(TimeoutTimer(config: Self.makeConfig()))
+
+        await confirmation("Deadline callback never runs", expectedCount: 0) { confirmed in
+            timer.cancel()
+            timer.start { confirmed() }
+            try? await Task.sleep(nanoseconds: Self.waitNanoseconds)
+        }
+
+        #expect(!timer.timedOut)
+    }
+
+    @Test
+    func deallocationPreventsFiring() async throws {
+        try await confirmation("Deadline callback never runs", expectedCount: 0) { confirmed in
+            do {
+                let timer = try #require(TimeoutTimer(config: Self.makeConfig()))
+                timer.start { confirmed() }
+            }
+
+            try? await Task.sleep(nanoseconds: Self.waitNanoseconds)
+        }
+    }
+
+    private static func makeConfig() -> ProtocolClientConfig {
+        return ProtocolClientConfig(host: "http://localhost", timeout: 0.05)
+    }
+}


### PR DESCRIPTION
Fixes #417.

`TimeoutTimer` was the last GCD consumer in `Libraries/`. Now that the deployment floor is iOS 13 / macOS 10.15 / tvOS 13 / watchOS 6 — exactly the Swift Concurrency back-deployment floor — it can use `Task` and `Task.sleep(nanoseconds:)` instead.

This removes the per-RPC `DispatchQueue`, the force-unwrapped `DispatchWorkItem!`, and the mutable `var onTimeout`. Every stored property is now a `let`, so the type conforms to `Sendable` without `@unchecked`. No call site changes were required.

Two deviations from the issue's proposal, both deliberate:

- **Cancelation is kept sticky** via a small `Locked<State>`. The old `DispatchWorkItem` was built in `init`, so a `cancel()` arriving before `start()` permanently disarmed the timer. A plain `Locked<Task?>` would make that cancel a no-op and let the later `start()` arm a live timer — and that ordering is reachable: in `createRequestCallbacks`, `setCallbacks` synchronously drains a queued `cancel()` through `receiveClose` before `start()` is reached.
- **The timeout is clamped** with `max(0, ...)`, because `ProtocolClientConfig.timeout` is public and unvalidated and `UInt64(negativeDouble)` traps where the previous `Int` conversion did not.

`onTimeout()` is still invoked outside any lock held by the type, since cancelation can re-enter `cancel()` or `deinit` — the deadlock fixed in #389.

Also adds `TimeoutTimerTests`, which the type previously lacked, covering firing, cancel-after-start, cancel-before-start, deallocation, and the requirement that `hasTimedOut` is set before the callback runs. Each case was checked against a deliberately mutated implementation to confirm it actually fails when the behavior regresses.

## Verification

- `swift build --build-tests -Xswiftc -warnings-as-errors`
- `swift test` — 75 tests pass
- Timeout suites soaked 20x to check for added flakiness and hangs at the 10ms timeout
- `swiftlint lint --strict` — 0 violations
- `make testconformance` — URLSession 966/966, NIO 1681/1681

One note on conformance: the first full urlsession run hit a flaky failure in `server-stream/error-with-no-responses`. It passed 20/20 in isolation and clean on five subsequent full runs, and the same flake shape reproduces against the unmodified implementation on `main`, so it is not introduced by this change.
