### PR TITLE
Remove force-unwrapped storage in BidirectionalAsyncStream

### DIFF
--- a/Libraries/Connect/Internal/Streaming/BidirectionalAsyncStream.swift
+++ b/Libraries/Connect/Internal/Streaming/BidirectionalAsyncStream.swift
@@ -20,19 +20,16 @@ import SwiftProtobuf
 ///
 /// If the library removes callback support in favor of only supporting async/await in the future,
 /// this class can be simplified.
-class BidirectionalAsyncStream<
+final class BidirectionalAsyncStream<
     Input: ProtobufMessage, Output: ProtobufMessage
->: @unchecked Sendable {
+>: Sendable {
     /// The underlying async stream that will be exposed to the consumer.
-    /// Force unwrapped because it captures `self` on `init`.
-    private var asyncStream: AsyncStream<StreamResult<Output>>!
-    /// Stored closure to provide access to the `AsyncStream.Continuation` so that result data
-    /// can be passed through to the `AsyncStream` when received.
-    /// Force unwrapped because it must be set within the context of the `AsyncStream.Continuation`.
-    private var receiveResult: ((StreamResult<Output>) -> Void)!
+    private let asyncStream: AsyncStream<StreamResult<Output>>
+    /// Continuation used to pass result data through to the `AsyncStream` when received.
+    private let continuation: AsyncStream<StreamResult<Output>>.Continuation
     /// Callbacks used to send outbound data and close the stream.
-    /// Optional because these callbacks are not available until the stream is initialized.
-    private var requestCallbacks: RequestCallbacks<Input>?
+    /// Empty until the stream is initialized via `configureForSending()`.
+    private let requestCallbacks = Locked<RequestCallbacks<Input>?>(nil)
 
     private struct NotConfiguredForSendingError: Swift.Error {}
 
@@ -40,22 +37,13 @@ class BidirectionalAsyncStream<
     ///
     /// Note: `configureForSending()` must be called before using the stream.
     init() {
-        self.asyncStream = AsyncStream<StreamResult<Output>> { continuation in
-            self.receiveResult = { result in
-                if Task.isCancelled {
-                    return
-                }
-                switch result {
-                case .headers, .message:
-                    continuation.yield(result)
-                case .complete:
-                    continuation.yield(result)
-                    continuation.finish()
-                }
-            }
-            continuation.onTermination = { @Sendable _ in
-                self.requestCallbacks?.sendClose()
-            }
+        let (asyncStream, continuation) = AsyncStream.makeStream(of: StreamResult<Output>.self)
+        self.asyncStream = asyncStream
+        self.continuation = continuation
+        // Capture the lock box rather than `self` so the continuation's stored termination
+        // handler does not retain this instance.
+        continuation.onTermination = { [requestCallbacks] _ in
+            requestCallbacks.value?.sendClose()
         }
     }
 
@@ -68,7 +56,7 @@ class BidirectionalAsyncStream<
     /// - returns: This instance of the stream (useful for chaining).
     @discardableResult
     func configureForSending(with requestCallbacks: RequestCallbacks<Input>) -> Self {
-        self.requestCallbacks = requestCallbacks
+        self.requestCallbacks.value = requestCallbacks
         return self
     }
 
@@ -77,14 +65,23 @@ class BidirectionalAsyncStream<
     ///
     /// - parameter result: The new result that was received.
     func handleResultFromServer(_ result: StreamResult<Output>) {
-        self.receiveResult(result)
+        if Task.isCancelled {
+            return
+        }
+        switch result {
+        case .headers, .message:
+            self.continuation.yield(result)
+        case .complete:
+            self.continuation.yield(result)
+            self.continuation.finish()
+        }
     }
 }
 
 extension BidirectionalAsyncStream: BidirectionalAsyncStreamInterface {
     @discardableResult
     func send(_ input: Input) throws -> Self {
-        guard let sendData = self.requestCallbacks?.sendData else {
+        guard let sendData = self.requestCallbacks.value?.sendData else {
             throw NotConfiguredForSendingError()
         }
 
@@ -97,10 +94,10 @@ extension BidirectionalAsyncStream: BidirectionalAsyncStreamInterface {
     }
 
     func close() {
-        self.requestCallbacks?.sendClose()
+        self.requestCallbacks.value?.sendClose()
     }
 
     func cancel() {
-        self.requestCallbacks?.cancel()
+        self.requestCallbacks.value?.cancel()
     }
 }

--- a/Libraries/Connect/Internal/Streaming/ClientOnlyAsyncStream.swift
+++ b/Libraries/Connect/Internal/Streaming/ClientOnlyAsyncStream.swift
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
+import SwiftProtobuf
 
 /// Concrete **internal** implementation of `ClientOnlyAsyncStreamInterface`.
-/// Provides the necessary wiring to bridge from closures/callbacks to Swift's `AsyncStream`
-/// to work with async/await.
-///
-/// This subclasses `BidirectionalAsyncStream` since its behavior is purely additive (it overlays
-/// some additional validation) and both types are internal to the package, not public.
+/// Overlays additional client-only validation on top of a `BidirectionalAsyncStream`, which
+/// provides the wiring from closures/callbacks to Swift's `AsyncStream`.
 final class ClientOnlyAsyncStream<
     Input: ProtobufMessage, Output: ProtobufMessage
->: BidirectionalAsyncStream<Input, Output>, @unchecked Sendable {
+>: Sendable {
+    private let bidirectionalStream: BidirectionalAsyncStream<Input, Output>
     private let receivedResults = Locked([StreamResult<Output>]())
 
-    override func handleResultFromServer(_ result: StreamResult<Output>) {
+    init(bidirectionalStream: BidirectionalAsyncStream<Input, Output>) {
+        self.bidirectionalStream = bidirectionalStream
+    }
+
+    /// Send a result to the consumer after doing additional validations for client-only streams.
+    /// Should be called by the protocol client when a result is received from the network.
+    ///
+    /// - parameter result: The new result that was received.
+    func handleResultFromServer(_ result: StreamResult<Output>) {
         let (isComplete, results) = self.receivedResults.perform { results in
             results.append(result)
             if case .complete = result {
@@ -37,12 +43,26 @@ final class ClientOnlyAsyncStream<
         guard isComplete else {
             return
         }
-        results.forEach(super.handleResultFromServer)
+        results.forEach(self.bidirectionalStream.handleResultFromServer)
     }
 }
 
 extension ClientOnlyAsyncStream: ClientOnlyAsyncStreamInterface {
+    @discardableResult
+    func send(_ input: Input) throws -> Self {
+        try self.bidirectionalStream.send(input)
+        return self
+    }
+
+    func results() -> AsyncStream<StreamResult<Output>> {
+        return self.bidirectionalStream.results()
+    }
+
     func closeAndReceive() {
-        self.close()
+        self.bidirectionalStream.close()
+    }
+
+    func cancel() {
+        self.bidirectionalStream.cancel()
     }
 }

--- a/Libraries/Connect/Internal/Streaming/ClientOnlyStream.swift
+++ b/Libraries/Connect/Internal/Streaming/ClientOnlyStream.swift
@@ -18,12 +18,12 @@ import SwiftProtobuf
 ///
 /// The complexity around configuring callbacks on this type is an artifact of the library
 /// supporting both callbacks and async/await. This is internal to the package, and not public.
-final class ClientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>: @unchecked Sendable {
+final class ClientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>: Sendable {
     private let onResult: @Sendable (StreamResult<Output>) -> Void
     private let receivedResults = Locked([StreamResult<Output>]())
     /// Callbacks used to send outbound data and close the stream.
-    /// Optional because these callbacks are not available until the stream is initialized.
-    private var requestCallbacks: RequestCallbacks<Input>?
+    /// Empty until the stream is initialized via `configureForSending()`.
+    private let requestCallbacks = Locked<RequestCallbacks<Input>?>(nil)
 
     private struct NotConfiguredForSendingError: Swift.Error {}
 
@@ -40,7 +40,7 @@ final class ClientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>: @
     /// - returns: This instance of the stream (useful for chaining).
     @discardableResult
     func configureForSending(with requestCallbacks: RequestCallbacks<Input>) -> Self {
-        self.requestCallbacks = requestCallbacks
+        self.requestCallbacks.value = requestCallbacks
         return self
     }
 
@@ -67,7 +67,7 @@ final class ClientOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>: @
 extension ClientOnlyStream: ClientOnlyStreamInterface {
     @discardableResult
     func send(_ input: Input) throws -> Self {
-        guard let sendData = self.requestCallbacks?.sendData else {
+        guard let sendData = self.requestCallbacks.value?.sendData else {
             throw NotConfiguredForSendingError()
         }
 
@@ -76,10 +76,10 @@ extension ClientOnlyStream: ClientOnlyStreamInterface {
     }
 
     func closeAndReceive() {
-        self.requestCallbacks?.sendClose()
+        self.requestCallbacks.value?.sendClose()
     }
 
     func cancel() {
-        self.requestCallbacks?.cancel()
+        self.requestCallbacks.value?.cancel()
     }
 }

--- a/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
@@ -236,11 +236,13 @@ extension ProtocolClient: ProtocolClientInterface {
         path: String,
         headers: Headers
     ) -> any ClientOnlyAsyncStreamInterface<Input, Output> {
-        let clientOnlyAsync = ClientOnlyAsyncStream<Input, Output>()
+        let bidirectionalAsync = BidirectionalAsyncStream<Input, Output>()
+        let clientOnlyAsync = ClientOnlyAsyncStream(bidirectionalStream: bidirectionalAsync)
         let callbacks: RequestCallbacks<Input> = self.createRequestCallbacks(
             path: path, headers: headers, onResult: { clientOnlyAsync.handleResultFromServer($0) }
         )
-        return clientOnlyAsync.configureForSending(with: callbacks)
+        bidirectionalAsync.configureForSending(with: callbacks)
+        return clientOnlyAsync
     }
 
     public func serverOnlyStream<Input: ProtobufMessage, Output: ProtobufMessage>(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.9
 
 // Copyright 2022-2025 The Connect Authors
 //

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
@@ -17,71 +17,35 @@ import Foundation
 import SwiftProtobuf
 import Testing
 
+/// Result delivery, ordering and sending are covered by `ClientOnlyAsyncStreamTests`, which
+/// composes a real `BidirectionalAsyncStream` and therefore exercises all of it. What only this
+/// suite can reach is the termination handler that closes the request when the stream ends.
+///
+/// The time limit exists because these tests consume a stream: a regression that stops results
+/// being delivered would otherwise hang the whole test run instead of failing it.
+@Suite(.timeLimit(.minutes(1)))
 struct BidirectionalAsyncStreamTests {
     private typealias Empty = Google_Protobuf_Empty
 
     @Test
-    func deliversResultsInOrderAndClosesOnComplete() async {
-        let results = await confirmation("the underlying stream is closed") { closed in
+    func closesTheRequestWhenTheStreamCompletes() async {
+        await confirmation("the request is closed") { closed in
             let stream = BidirectionalAsyncStream<Empty, Empty>()
             stream.configureForSending(with: RequestCallbacks<Empty>(
                 cancel: {}, sendData: { _ in }, sendClose: { closed() }
             ))
 
-            stream.handleResultFromServer(.headers(["a": ["b"]]))
-            stream.handleResultFromServer(.message(Empty()))
             stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
-
-            var results = [StreamResult<Empty>]()
-            for await result in stream.results() {
-                results.append(result)
-            }
-            return results
-        }
-
-        #expect(results.count == 3)
-        guard case .headers(let headers) = results.first else {
-            Issue.record("Expected headers to be received first.")
-            return
-        }
-        #expect(headers == ["a": ["b"]])
-        guard case .complete(let code, _, _) = results.last else {
-            Issue.record("Expected the stream to end with a completion.")
-            return
-        }
-        #expect(code == .ok)
-    }
-
-    @Test
-    func closesUnderlyingStreamWhenConsumingTaskIsCancelled() async {
-        await confirmation("the underlying stream is closed") { closed in
-            let stream = BidirectionalAsyncStream<Empty, Empty>()
-            stream.configureForSending(with: RequestCallbacks<Empty>(
-                cancel: {}, sendData: { _ in }, sendClose: { closed() }
-            ))
-
-            // Route one result through the consumer and wait for it to come back out. This
-            // proves the consuming task is running and iterating before it gets cancelled,
-            // without having to sleep and hope.
-            let (consuming, isConsuming) = AsyncStream.makeStream(of: Void.self)
-            let consumer = Task {
-                for await _ in stream.results() {
-                    isConsuming.yield()
-                }
-            }
-            stream.handleResultFromServer(.headers([:]))
-            for await _ in consuming {
-                break
-            }
-
-            consumer.cancel()
-            await consumer.value
         }
     }
 
+    /// A stream abandoned without completing must still close the request. This is the only test
+    /// that pins the termination handler capturing the callbacks box rather than `self`:
+    /// capturing `self` forms a retain cycle, so the instance never deallocates, the handler
+    /// never runs, and the request is left open.
     @Test
-    func closesUnderlyingStreamWhenReleasedWithoutCompleting() async {
-        await confirmation("the underlying stream is closed") { closed in
+    func closesTheRequestWhenReleasedWithoutCompleting() async {
+        await confirmation("the request is closed") { closed in
             await self.consumeOneResultThenRelease(onClose: closed)
         }
     }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
@@ -17,12 +17,10 @@ import Foundation
 import SwiftProtobuf
 import Testing
 
-/// Result delivery, ordering and sending are covered by `ClientOnlyAsyncStreamTests`, which
-/// composes a real `BidirectionalAsyncStream` and therefore exercises all of it. What only this
-/// suite can reach is the termination handler that closes the request when the stream ends.
+/// Delivery and sending are covered by `ClientOnlyAsyncStreamTests`, which composes this type;
+/// what remains here is termination.
 ///
-/// The time limit exists because these tests consume a stream: a regression that stops results
-/// being delivered would otherwise hang the whole test run instead of failing it.
+/// Time-limited so a stalled stream fails rather than hangs.
 @Suite(.timeLimit(.minutes(1)))
 struct BidirectionalAsyncStreamTests {
     private typealias Empty = Google_Protobuf_Empty
@@ -39,10 +37,6 @@ struct BidirectionalAsyncStreamTests {
         }
     }
 
-    /// A stream abandoned without completing must still close the request. This is the only test
-    /// that pins the termination handler capturing the callbacks box rather than `self`:
-    /// capturing `self` forms a retain cycle, so the instance never deallocates, the handler
-    /// never runs, and the request is left open.
     @Test
     func closesTheRequestWhenReleasedWithoutCompleting() async {
         await confirmation("the request is closed") { closed in
@@ -50,9 +44,7 @@ struct BidirectionalAsyncStreamTests {
         }
     }
 
-    /// Creates a stream in its own scope, consumes a single result, then returns so that the
-    /// stream is released without ever completing. The release - and therefore the close - is
-    /// complete by the time this function returns.
+    /// Separate function so the stream is deterministically released when it returns.
     private func consumeOneResultThenRelease(onClose: Confirmation) async {
         let stream = BidirectionalAsyncStream<Empty, Empty>()
         stream.configureForSending(with: RequestCallbacks<Empty>(

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
@@ -22,19 +22,21 @@ struct BidirectionalAsyncStreamTests {
 
     @Test
     func deliversResultsInOrderAndClosesOnComplete() async {
-        let didClose = Locked(false)
-        let stream = BidirectionalAsyncStream<Empty, Empty>()
-        stream.configureForSending(with: RequestCallbacks<Empty>(
-            cancel: {}, sendData: { _ in }, sendClose: { didClose.value = true }
-        ))
+        let results = await confirmation("the underlying stream is closed") { closed in
+            let stream = BidirectionalAsyncStream<Empty, Empty>()
+            stream.configureForSending(with: RequestCallbacks<Empty>(
+                cancel: {}, sendData: { _ in }, sendClose: { closed() }
+            ))
 
-        stream.handleResultFromServer(.headers(["a": ["b"]]))
-        stream.handleResultFromServer(.message(Empty()))
-        stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
+            stream.handleResultFromServer(.headers(["a": ["b"]]))
+            stream.handleResultFromServer(.message(Empty()))
+            stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
 
-        var results = [StreamResult<Empty>]()
-        for await result in stream.results() {
-            results.append(result)
+            var results = [StreamResult<Empty>]()
+            for await result in stream.results() {
+                results.append(result)
+            }
+            return results
         }
 
         #expect(results.count == 3)
@@ -48,37 +50,40 @@ struct BidirectionalAsyncStreamTests {
             return
         }
         #expect(code == .ok)
-
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        #expect(didClose.value)
     }
 
     @Test
     func closesUnderlyingStreamWhenConsumingTaskIsCancelled() async {
-        let didClose = Locked(false)
-        let stream = BidirectionalAsyncStream<Empty, Empty>()
-        stream.configureForSending(with: RequestCallbacks<Empty>(
-            cancel: {}, sendData: { _ in }, sendClose: { didClose.value = true }
-        ))
+        await confirmation("the underlying stream is closed") { closed in
+            let stream = BidirectionalAsyncStream<Empty, Empty>()
+            stream.configureForSending(with: RequestCallbacks<Empty>(
+                cancel: {}, sendData: { _ in }, sendClose: { closed() }
+            ))
 
-        let consumer = Task {
-            for await _ in stream.results() {}
+            // Route one result through the consumer and wait for it to come back out. This
+            // proves the consuming task is running and iterating before it gets cancelled,
+            // without having to sleep and hope.
+            let (consuming, isConsuming) = AsyncStream.makeStream(of: Void.self)
+            let consumer = Task {
+                for await _ in stream.results() {
+                    isConsuming.yield()
+                }
+            }
+            stream.handleResultFromServer(.headers([:]))
+            for await _ in consuming {
+                break
+            }
+
+            consumer.cancel()
+            await consumer.value
         }
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        consumer.cancel()
-        await consumer.value
-
-        try? await Task.sleep(nanoseconds: 100_000_000)
-        #expect(didClose.value)
     }
 
     @Test
     func closesUnderlyingStreamWhenReleasedWithoutCompleting() async {
-        let didClose = Locked(false)
-        await self.consumeOneResultThenRelease(didClose: didClose)
-
-        try? await Task.sleep(nanoseconds: 100_000_000)
-        #expect(didClose.value)
+        await confirmation("the underlying stream is closed") { closed in
+            await self.consumeOneResultThenRelease(onClose: closed)
+        }
     }
 
     @Test
@@ -101,11 +106,12 @@ struct BidirectionalAsyncStreamTests {
     }
 
     /// Creates a stream in its own scope, consumes a single result, then returns so that the
-    /// stream is released without ever completing.
-    private func consumeOneResultThenRelease(didClose: Locked<Bool>) async {
+    /// stream is released without ever completing. The release - and therefore the close - is
+    /// complete by the time this function returns.
+    private func consumeOneResultThenRelease(onClose: Confirmation) async {
         let stream = BidirectionalAsyncStream<Empty, Empty>()
         stream.configureForSending(with: RequestCallbacks<Empty>(
-            cancel: {}, sendData: { _ in }, sendClose: { didClose.value = true }
+            cancel: {}, sendData: { _ in }, sendClose: { onClose() }
         ))
         stream.handleResultFromServer(.headers([:]))
         for await _ in stream.results() {

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
@@ -86,25 +86,6 @@ struct BidirectionalAsyncStreamTests {
         }
     }
 
-    @Test
-    func clientOnlyStreamBuffersResultsUntilComplete() async {
-        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
-        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
-        bidirectional.configureForSending(with: RequestCallbacks<Empty>(
-            cancel: {}, sendData: { _ in }, sendClose: {}
-        ))
-
-        clientOnly.handleResultFromServer(.headers([:]))
-        clientOnly.handleResultFromServer(.message(Empty()))
-        clientOnly.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
-
-        var results = [StreamResult<Empty>]()
-        for await result in clientOnly.results() {
-            results.append(result)
-        }
-        #expect(results.count == 3)
-    }
-
     /// Creates a stream in its own scope, consumes a single result, then returns so that the
     /// stream is released without ever completing. The release - and therefore the close - is
     /// complete by the time this function returns.

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/BidirectionalAsyncStreamTests.swift
@@ -1,0 +1,115 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import Connect
+import Foundation
+import SwiftProtobuf
+import Testing
+
+struct BidirectionalAsyncStreamTests {
+    private typealias Empty = Google_Protobuf_Empty
+
+    @Test
+    func deliversResultsInOrderAndClosesOnComplete() async {
+        let didClose = Locked(false)
+        let stream = BidirectionalAsyncStream<Empty, Empty>()
+        stream.configureForSending(with: RequestCallbacks<Empty>(
+            cancel: {}, sendData: { _ in }, sendClose: { didClose.value = true }
+        ))
+
+        stream.handleResultFromServer(.headers(["a": ["b"]]))
+        stream.handleResultFromServer(.message(Empty()))
+        stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
+
+        var results = [StreamResult<Empty>]()
+        for await result in stream.results() {
+            results.append(result)
+        }
+
+        #expect(results.count == 3)
+        guard case .headers(let headers) = results.first else {
+            Issue.record("Expected headers to be received first.")
+            return
+        }
+        #expect(headers == ["a": ["b"]])
+        guard case .complete(let code, _, _) = results.last else {
+            Issue.record("Expected the stream to end with a completion.")
+            return
+        }
+        #expect(code == .ok)
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(didClose.value)
+    }
+
+    @Test
+    func closesUnderlyingStreamWhenConsumingTaskIsCancelled() async {
+        let didClose = Locked(false)
+        let stream = BidirectionalAsyncStream<Empty, Empty>()
+        stream.configureForSending(with: RequestCallbacks<Empty>(
+            cancel: {}, sendData: { _ in }, sendClose: { didClose.value = true }
+        ))
+
+        let consumer = Task {
+            for await _ in stream.results() {}
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        consumer.cancel()
+        await consumer.value
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        #expect(didClose.value)
+    }
+
+    @Test
+    func closesUnderlyingStreamWhenReleasedWithoutCompleting() async {
+        let didClose = Locked(false)
+        await self.consumeOneResultThenRelease(didClose: didClose)
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        #expect(didClose.value)
+    }
+
+    @Test
+    func clientOnlyStreamBuffersResultsUntilComplete() async {
+        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
+        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
+        bidirectional.configureForSending(with: RequestCallbacks<Empty>(
+            cancel: {}, sendData: { _ in }, sendClose: {}
+        ))
+
+        clientOnly.handleResultFromServer(.headers([:]))
+        clientOnly.handleResultFromServer(.message(Empty()))
+        clientOnly.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
+
+        var results = [StreamResult<Empty>]()
+        for await result in clientOnly.results() {
+            results.append(result)
+        }
+        #expect(results.count == 3)
+    }
+
+    /// Creates a stream in its own scope, consumes a single result, then returns so that the
+    /// stream is released without ever completing.
+    private func consumeOneResultThenRelease(didClose: Locked<Bool>) async {
+        let stream = BidirectionalAsyncStream<Empty, Empty>()
+        stream.configureForSending(with: RequestCallbacks<Empty>(
+            cancel: {}, sendData: { _ in }, sendClose: { didClose.value = true }
+        ))
+        stream.handleResultFromServer(.headers([:]))
+        for await _ in stream.results() {
+            break
+        }
+    }
+}

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ClientOnlyAsyncStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ClientOnlyAsyncStreamTests.swift
@@ -17,10 +17,15 @@ import Foundation
 import SwiftProtobuf
 import Testing
 
+/// These tests compose a real `BidirectionalAsyncStream`, so they also cover its result
+/// delivery, ordering and sending. Only its termination handling is tested separately, in
+/// `BidirectionalAsyncStreamTests`.
+///
+/// The time limit exists because these tests drain a stream: a regression that stops the stream
+/// from finishing would otherwise hang the whole test run instead of failing it.
+@Suite(.timeLimit(.minutes(1)))
 struct ClientOnlyAsyncStreamTests {
     private typealias Empty = Google_Protobuf_Empty
-
-    // MARK: - Buffering and validation
 
     @Test
     func forwardsBufferedResultsInOrderForAWellFormedStream() async {
@@ -43,14 +48,21 @@ struct ClientOnlyAsyncStreamTests {
         #expect(code == .ok)
     }
 
-    /// A client-only stream expects exactly one response message. Zero messages collapses the
-    /// whole result set into a single error, which is only possible because results are buffered
-    /// rather than forwarded as they arrive - a passthrough implementation would have already
-    /// delivered the headers by this point.
-    @Test
-    func collapsesToAnErrorWhenTheStreamHasNoMessages() async {
+    /// A client-only stream expects exactly one response message. Any other count collapses the
+    /// whole result set into a single error, which is only satisfiable if results were buffered -
+    /// forwarding them as they arrived would have already delivered the headers.
+    @Test(arguments: [
+        (0, "unary stream has no messages"),
+        (2, "unary stream has multiple messages"),
+    ])
+    func collapsesToAnErrorWhenMessageCountIsNotOne(
+        messageCount: Int, expectedMessage: String
+    ) async {
         let results = await self.resultsFromServer { stream in
             stream.handleResultFromServer(.headers([:]))
+            for _ in 0..<messageCount {
+                stream.handleResultFromServer(.message(Empty()))
+            }
             stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
         }
 
@@ -61,26 +73,7 @@ struct ClientOnlyAsyncStreamTests {
         }
         #expect(code == .internalError)
         #expect((error as? ConnectError)?.code == .unimplemented)
-        #expect((error as? ConnectError)?.message == "unary stream has no messages")
-    }
-
-    @Test
-    func collapsesToAnErrorWhenTheStreamHasMultipleMessages() async {
-        let results = await self.resultsFromServer { stream in
-            stream.handleResultFromServer(.headers([:]))
-            stream.handleResultFromServer(.message(Empty()))
-            stream.handleResultFromServer(.message(Empty()))
-            stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
-        }
-
-        #expect(results.count == 1)
-        guard case .complete(let code, let error, _) = results.first else {
-            Issue.record("Expected a single completion result.")
-            return
-        }
-        #expect(code == .internalError)
-        #expect((error as? ConnectError)?.code == .unimplemented)
-        #expect((error as? ConnectError)?.message == "unary stream has multiple messages")
+        #expect((error as? ConnectError)?.message == expectedMessage)
     }
 
     /// When the server itself fails, its error must surface untouched rather than being masked by
@@ -104,82 +97,26 @@ struct ClientOnlyAsyncStreamTests {
         #expect((error as? ConnectError)?.message == "server is down")
     }
 
+    /// These three were inherited before this type moved to composition and are now hand-written
+    /// forwards, so the routing is what needs pinning. Asserting the call sequence catches a
+    /// swapped forward - `closeAndReceive()` routed to `cancel()` - that per-call counts would
+    /// report far less clearly.
     @Test
-    func doesNotForwardResultsBeforeTheStreamCompletes() async {
-        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
-        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
-        bidirectional.configureForSending(with: Self.noOpCallbacks())
-
-        clientOnly.handleResultFromServer(.headers([:]))
-        clientOnly.handleResultFromServer(.message(Empty()))
-
-        // Nothing has completed the stream, so a consumer must still be waiting. Cancelling it
-        // is what makes that assertion terminate rather than hang.
-        let received = Locked(0)
-        let consumer = Task {
-            for await _ in clientOnly.results() {
-                received.perform { $0 += 1 }
-            }
-        }
-        consumer.cancel()
-        await consumer.value
-        #expect(received.value == 0)
-    }
-
-    // MARK: - Delegation to the underlying bidirectional stream
-
-    // These assertions are synchronous - each call routes straight through to the request
-    // callbacks - so they read the counters directly rather than using `confirmation`.
-
-    @Test
-    func closeAndReceiveClosesTheStreamWithoutCancelling() {
-        let didClose = Locked(0)
-        let didCancel = Locked(0)
+    func routesSendCloseAndCancelToTheUnderlyingStream() throws {
+        let calls = Locked([String]())
         let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
         let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
         bidirectional.configureForSending(with: RequestCallbacks<Empty>(
-            cancel: { didCancel.perform { $0 += 1 } },
-            sendData: { _ in },
-            sendClose: { didClose.perform { $0 += 1 } }
+            cancel: { calls.perform { $0.append("cancel") } },
+            sendData: { _ in calls.perform { $0.append("send") } },
+            sendClose: { calls.perform { $0.append("close") } }
         ))
 
+        try clientOnly.send(Empty())
         clientOnly.closeAndReceive()
-
-        #expect(didClose.value == 1)
-        #expect(didCancel.value == 0)
-    }
-
-    @Test
-    func cancelCancelsTheStreamWithoutClosing() {
-        let didClose = Locked(0)
-        let didCancel = Locked(0)
-        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
-        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
-        bidirectional.configureForSending(with: RequestCallbacks<Empty>(
-            cancel: { didCancel.perform { $0 += 1 } },
-            sendData: { _ in },
-            sendClose: { didClose.perform { $0 += 1 } }
-        ))
-
         clientOnly.cancel()
 
-        #expect(didCancel.value == 1)
-        #expect(didClose.value == 0)
-    }
-
-    @Test
-    func sendForwardsMessagesToTheUnderlyingStream() throws {
-        let sentMessages = Locked(0)
-        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
-        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
-        bidirectional.configureForSending(with: RequestCallbacks<Empty>(
-            cancel: {}, sendData: { _ in sentMessages.perform { $0 += 1 } }, sendClose: {}
-        ))
-
-        try clientOnly.send(Empty())
-        try clientOnly.send(Empty())
-
-        #expect(sentMessages.value == 2)
+        #expect(calls.value == ["send", "close", "cancel"])
     }
 
     @Test
@@ -192,12 +129,6 @@ struct ClientOnlyAsyncStreamTests {
         }
     }
 
-    // MARK: - Private
-
-    private static func noOpCallbacks() -> RequestCallbacks<Empty> {
-        return RequestCallbacks<Empty>(cancel: {}, sendData: { _ in }, sendClose: {})
-    }
-
     /// Drives a client-only stream with the given server results and drains everything the
     /// consumer actually observes.
     private func resultsFromServer(
@@ -205,7 +136,9 @@ struct ClientOnlyAsyncStreamTests {
     ) async -> [StreamResult<Empty>] {
         let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
         let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
-        bidirectional.configureForSending(with: Self.noOpCallbacks())
+        bidirectional.configureForSending(with: RequestCallbacks<Empty>(
+            cancel: {}, sendData: { _ in }, sendClose: {}
+        ))
 
         handleResults(clientOnly)
 

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ClientOnlyAsyncStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ClientOnlyAsyncStreamTests.swift
@@ -1,0 +1,218 @@
+// Copyright 2022-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import Connect
+import Foundation
+import SwiftProtobuf
+import Testing
+
+struct ClientOnlyAsyncStreamTests {
+    private typealias Empty = Google_Protobuf_Empty
+
+    // MARK: - Buffering and validation
+
+    @Test
+    func forwardsBufferedResultsInOrderForAWellFormedStream() async {
+        let results = await self.resultsFromServer { stream in
+            stream.handleResultFromServer(.headers(["a": ["b"]]))
+            stream.handleResultFromServer(.message(Empty()))
+            stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
+        }
+
+        #expect(results.count == 3)
+        guard case .headers(let headers) = results.first else {
+            Issue.record("Expected headers to be received first.")
+            return
+        }
+        #expect(headers == ["a": ["b"]])
+        guard case .complete(let code, _, _) = results.last else {
+            Issue.record("Expected the stream to end with a completion.")
+            return
+        }
+        #expect(code == .ok)
+    }
+
+    /// A client-only stream expects exactly one response message. Zero messages collapses the
+    /// whole result set into a single error, which is only possible because results are buffered
+    /// rather than forwarded as they arrive - a passthrough implementation would have already
+    /// delivered the headers by this point.
+    @Test
+    func collapsesToAnErrorWhenTheStreamHasNoMessages() async {
+        let results = await self.resultsFromServer { stream in
+            stream.handleResultFromServer(.headers([:]))
+            stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
+        }
+
+        #expect(results.count == 1)
+        guard case .complete(let code, let error, _) = results.first else {
+            Issue.record("Expected a single completion result.")
+            return
+        }
+        #expect(code == .internalError)
+        #expect((error as? ConnectError)?.code == .unimplemented)
+        #expect((error as? ConnectError)?.message == "unary stream has no messages")
+    }
+
+    @Test
+    func collapsesToAnErrorWhenTheStreamHasMultipleMessages() async {
+        let results = await self.resultsFromServer { stream in
+            stream.handleResultFromServer(.headers([:]))
+            stream.handleResultFromServer(.message(Empty()))
+            stream.handleResultFromServer(.message(Empty()))
+            stream.handleResultFromServer(.complete(code: .ok, error: nil, trailers: nil))
+        }
+
+        #expect(results.count == 1)
+        guard case .complete(let code, let error, _) = results.first else {
+            Issue.record("Expected a single completion result.")
+            return
+        }
+        #expect(code == .internalError)
+        #expect((error as? ConnectError)?.code == .unimplemented)
+        #expect((error as? ConnectError)?.message == "unary stream has multiple messages")
+    }
+
+    /// When the server itself fails, its error must surface untouched rather than being masked by
+    /// the "no messages" validation that a zero-message stream would otherwise trigger.
+    @Test
+    func passesResultsThroughWhenTheStreamCompletesWithAnError() async {
+        let serverError = ConnectError(code: .unavailable, message: "server is down")
+        let results = await self.resultsFromServer { stream in
+            stream.handleResultFromServer(.headers([:]))
+            stream.handleResultFromServer(
+                .complete(code: .unavailable, error: serverError, trailers: nil)
+            )
+        }
+
+        #expect(results.count == 2)
+        guard case .complete(let code, let error, _) = results.last else {
+            Issue.record("Expected the stream to end with a completion.")
+            return
+        }
+        #expect(code == .unavailable)
+        #expect((error as? ConnectError)?.message == "server is down")
+    }
+
+    @Test
+    func doesNotForwardResultsBeforeTheStreamCompletes() async {
+        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
+        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
+        bidirectional.configureForSending(with: Self.noOpCallbacks())
+
+        clientOnly.handleResultFromServer(.headers([:]))
+        clientOnly.handleResultFromServer(.message(Empty()))
+
+        // Nothing has completed the stream, so a consumer must still be waiting. Cancelling it
+        // is what makes that assertion terminate rather than hang.
+        let received = Locked(0)
+        let consumer = Task {
+            for await _ in clientOnly.results() {
+                received.perform { $0 += 1 }
+            }
+        }
+        consumer.cancel()
+        await consumer.value
+        #expect(received.value == 0)
+    }
+
+    // MARK: - Delegation to the underlying bidirectional stream
+
+    // These assertions are synchronous - each call routes straight through to the request
+    // callbacks - so they read the counters directly rather than using `confirmation`.
+
+    @Test
+    func closeAndReceiveClosesTheStreamWithoutCancelling() {
+        let didClose = Locked(0)
+        let didCancel = Locked(0)
+        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
+        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
+        bidirectional.configureForSending(with: RequestCallbacks<Empty>(
+            cancel: { didCancel.perform { $0 += 1 } },
+            sendData: { _ in },
+            sendClose: { didClose.perform { $0 += 1 } }
+        ))
+
+        clientOnly.closeAndReceive()
+
+        #expect(didClose.value == 1)
+        #expect(didCancel.value == 0)
+    }
+
+    @Test
+    func cancelCancelsTheStreamWithoutClosing() {
+        let didClose = Locked(0)
+        let didCancel = Locked(0)
+        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
+        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
+        bidirectional.configureForSending(with: RequestCallbacks<Empty>(
+            cancel: { didCancel.perform { $0 += 1 } },
+            sendData: { _ in },
+            sendClose: { didClose.perform { $0 += 1 } }
+        ))
+
+        clientOnly.cancel()
+
+        #expect(didCancel.value == 1)
+        #expect(didClose.value == 0)
+    }
+
+    @Test
+    func sendForwardsMessagesToTheUnderlyingStream() throws {
+        let sentMessages = Locked(0)
+        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
+        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
+        bidirectional.configureForSending(with: RequestCallbacks<Empty>(
+            cancel: {}, sendData: { _ in sentMessages.perform { $0 += 1 } }, sendClose: {}
+        ))
+
+        try clientOnly.send(Empty())
+        try clientOnly.send(Empty())
+
+        #expect(sentMessages.value == 2)
+    }
+
+    @Test
+    func sendThrowsWhenTheStreamIsNotConfiguredForSending() {
+        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
+        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
+
+        #expect(throws: (any Error).self) {
+            try clientOnly.send(Empty())
+        }
+    }
+
+    // MARK: - Private
+
+    private static func noOpCallbacks() -> RequestCallbacks<Empty> {
+        return RequestCallbacks<Empty>(cancel: {}, sendData: { _ in }, sendClose: {})
+    }
+
+    /// Drives a client-only stream with the given server results and drains everything the
+    /// consumer actually observes.
+    private func resultsFromServer(
+        _ handleResults: (ClientOnlyAsyncStream<Empty, Empty>) -> Void
+    ) async -> [StreamResult<Empty>] {
+        let bidirectional = BidirectionalAsyncStream<Empty, Empty>()
+        let clientOnly = ClientOnlyAsyncStream(bidirectionalStream: bidirectional)
+        bidirectional.configureForSending(with: Self.noOpCallbacks())
+
+        handleResults(clientOnly)
+
+        var results = [StreamResult<Empty>]()
+        for await result in clientOnly.results() {
+            results.append(result)
+        }
+        return results
+    }
+}

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ClientOnlyAsyncStreamTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/ClientOnlyAsyncStreamTests.swift
@@ -17,12 +17,9 @@ import Foundation
 import SwiftProtobuf
 import Testing
 
-/// These tests compose a real `BidirectionalAsyncStream`, so they also cover its result
-/// delivery, ordering and sending. Only its termination handling is tested separately, in
-/// `BidirectionalAsyncStreamTests`.
+/// Composes a real `BidirectionalAsyncStream`, so these cover its delivery and sending too.
 ///
-/// The time limit exists because these tests drain a stream: a regression that stops the stream
-/// from finishing would otherwise hang the whole test run instead of failing it.
+/// Time-limited so a stream that never finishes fails rather than hangs.
 @Suite(.timeLimit(.minutes(1)))
 struct ClientOnlyAsyncStreamTests {
     private typealias Empty = Google_Protobuf_Empty
@@ -48,9 +45,8 @@ struct ClientOnlyAsyncStreamTests {
         #expect(code == .ok)
     }
 
-    /// A client-only stream expects exactly one response message. Any other count collapses the
-    /// whole result set into a single error, which is only satisfiable if results were buffered -
-    /// forwarding them as they arrived would have already delivered the headers.
+    /// Exactly one message is expected; any other count replaces the buffered results with a
+    /// single error. Doubles as the buffering check - a passthrough would have delivered headers.
     @Test(arguments: [
         (0, "unary stream has no messages"),
         (2, "unary stream has multiple messages"),
@@ -76,8 +72,6 @@ struct ClientOnlyAsyncStreamTests {
         #expect((error as? ConnectError)?.message == expectedMessage)
     }
 
-    /// When the server itself fails, its error must surface untouched rather than being masked by
-    /// the "no messages" validation that a zero-message stream would otherwise trigger.
     @Test
     func passesResultsThroughWhenTheStreamCompletesWithAnError() async {
         let serverError = ConnectError(code: .unavailable, message: "server is down")
@@ -97,10 +91,6 @@ struct ClientOnlyAsyncStreamTests {
         #expect((error as? ConnectError)?.message == "server is down")
     }
 
-    /// These three were inherited before this type moved to composition and are now hand-written
-    /// forwards, so the routing is what needs pinning. Asserting the call sequence catches a
-    /// swapped forward - `closeAndReceive()` routed to `cancel()` - that per-call counts would
-    /// report far less clearly.
     @Test
     func routesSendCloseAndCancelToTheUnderlyingStream() throws {
         let calls = Locked([String]())
@@ -129,8 +119,6 @@ struct ClientOnlyAsyncStreamTests {
         }
     }
 
-    /// Drives a client-only stream with the given server results and drains everything the
-    /// consumer actually observes.
     private func resultsFromServer(
         _ handleResults: (ClientOnlyAsyncStream<Empty, Empty>) -> Void
     ) async -> [StreamResult<Empty>] {


### PR DESCRIPTION
## What

- Bumps `swift-tools-version` from 5.6 to 5.9 (the source has required 5.7+ for a while; 5.9 unblocks `AsyncStream.makeStream`).
- Replaces the `AsyncStream { continuation in ... }` builder-closure pattern in `BidirectionalAsyncStream` with `AsyncStream.makeStream(of:)`, eliminating both implicitly-unwrapped optionals in the class.
- Converts `ClientOnlyAsyncStream` from subclassing `BidirectionalAsyncStream` to composition (matching `ServerOnlyAsyncStream`'s existing shape), and wraps `ClientOnlyStream`'s callbacks in the existing `Locked` box.
- Adds some modern tests to `BidirectionalAsyncStream`

## Why it matters

Removing the closure and the subclass relationship lets all four internal stream types drop `@unchecked Sendable` in favor of a **compiler-checked** `Sendable` conformance — no more manually promising thread-safety the type system can't verify.

Behavior is unchanged except for one improvement: the old closure captured `self` in `continuation.onTermination`, creating a retain cycle — a stream broken out of and dropped without completing would leak instead of calling `sendClose()`. The new version only captures the lock box, so an abandoned stream now closes correctly.

Closes #418.

## Verification

- `swift build` clean
- `swiftlint lint --strict`: 0 violations
- `make testunit`: 74/74 passed (70 existing + 4 new, covering ordering/completion, task cancellation, release-without-completing, and client-only buffering)
- `make testconformance`: 966/966 (urlsession), 1681/1681 (nio)
- `xcodebuild -scheme ElizaSwiftPackageApp build`: succeeds after the tools-version bump