### PR TITLE
Adopt the `package` access level for PackageInternal APIs

### DIFF
--- a/Libraries/Connect/Internal/Interceptors/ConnectInterceptor.swift
+++ b/Libraries/Connect/Internal/Interceptors/ConnectInterceptor.swift
@@ -158,7 +158,7 @@ extension ConnectInterceptor: StreamInterceptor {
 
     @Sendable
     func handleStreamRawInput(_ input: Data, proceed: @escaping (Data) -> Void) {
-        proceed(Envelope._packMessage(input, using: self.config.requestCompression))
+        proceed(Envelope.packMessage(input, using: self.config.requestCompression))
     }
 
     @Sendable
@@ -190,7 +190,7 @@ extension ConnectInterceptor: StreamInterceptor {
                 let responseCompressionPool = self.streamResponseHeaders.value?[
                     HeaderConstants.connectStreamingContentEncoding
                 ]?.first.flatMap { self.config.responseCompressionPool(forName: $0) }
-                if responseCompressionPool == nil && Envelope._isCompressed(data) {
+                if responseCompressionPool == nil && Envelope.isCompressed(data) {
                     proceed(.complete(
                         code: .internalError, error: ConnectError(
                             code: .internalError, message: "received unexpected compressed message"
@@ -199,7 +199,7 @@ extension ConnectInterceptor: StreamInterceptor {
                     return
                 }
 
-                let (headerByte, message) = try Envelope._unpackMessage(
+                let (headerByte, message) = try Envelope.unpackMessage(
                     data, compressionPool: responseCompressionPool
                 )
                 let isEndStream = 0b00000010 & headerByte != 0

--- a/Libraries/Connect/Internal/Interceptors/GRPCWebInterceptor.swift
+++ b/Libraries/Connect/Internal/Interceptors/GRPCWebInterceptor.swift
@@ -32,12 +32,12 @@ extension GRPCWebInterceptor: UnaryInterceptor {
         proceed: @escaping (Result<HTTPRequest<Data?>, ConnectError>) -> Void
     ) {
         // gRPC-Web unary payloads are enveloped.
-        let envelopedRequestBody = Envelope._packMessage(
+        let envelopedRequestBody = Envelope.packMessage(
             request.message ?? Data(), using: self.config.requestCompression
         )
         proceed(.success(HTTPRequest(
             url: request.url,
-            headers: request.headers._addingGRPCHeaders(using: self.config, grpcWeb: true),
+            headers: request.headers.addingGRPCHeaders(using: self.config, grpcWeb: true),
             message: envelopedRequestBody,
             method: request.method,
             trailers: nil,
@@ -57,7 +57,7 @@ extension GRPCWebInterceptor: UnaryInterceptor {
         }
 
         guard let responseData = response.message, !responseData.isEmpty else {
-            let (grpcCode, connectError) = ConnectError._parseGRPCHeaders(
+            let (grpcCode, connectError) = ConnectError.parseGRPCHeaders(
                 response.headers,
                 trailers: response.trailers
             )
@@ -102,7 +102,7 @@ extension GRPCWebInterceptor: UnaryInterceptor {
         let compressionPool = response.headers[HeaderConstants.grpcContentEncoding]?
             .first
             .flatMap { self.config.responseCompressionPool(forName: $0) }
-        if compressionPool == nil && Envelope._isCompressed(responseData) {
+        if compressionPool == nil && Envelope.isCompressed(responseData) {
             proceed(HTTPResponse(
                 code: .internalError, headers: response.headers, message: nil,
                 trailers: response.trailers,
@@ -120,9 +120,9 @@ extension GRPCWebInterceptor: UnaryInterceptor {
             //    message data.
             // 2. The (headers and length prefixed) trailers data.
             // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
-            let firstChunkLength = Envelope._messageLength(forPackedData: responseData)
-            let prefixedFirstChunkLength = Envelope._prefixLength + firstChunkLength
-            let firstChunk = try Envelope._unpackMessage(
+            let firstChunkLength = Envelope.messageLength(forPackedData: responseData)
+            let prefixedFirstChunkLength = Envelope.prefixLength + firstChunkLength
+            let firstChunk = try Envelope.unpackMessage(
                 Data(responseData.prefix(upTo: prefixedFirstChunkLength)),
                 compressionPool: compressionPool
             )
@@ -135,7 +135,7 @@ extension GRPCWebInterceptor: UnaryInterceptor {
             } else {
                 let trailersData = Data(responseData.suffix(from: prefixedFirstChunkLength))
                 let unpackedTrailers = try Trailers.fromGRPCHeadersBlock(
-                    try Envelope._unpackMessage(
+                    try Envelope.unpackMessage(
                         trailersData, compressionPool: compressionPool
                     ).unpacked
                 )
@@ -165,7 +165,7 @@ extension GRPCWebInterceptor: StreamInterceptor {
     ) {
         proceed(.success(HTTPRequest(
             url: request.url,
-            headers: request.headers._addingGRPCHeaders(using: self.config, grpcWeb: true),
+            headers: request.headers.addingGRPCHeaders(using: self.config, grpcWeb: true),
             message: request.message,
             method: request.method,
             trailers: nil,
@@ -175,7 +175,7 @@ extension GRPCWebInterceptor: StreamInterceptor {
 
     @Sendable
     func handleStreamRawInput(_ input: Data, proceed: @escaping (Data) -> Void) {
-        proceed(Envelope._packMessage(input, using: self.config.requestCompression))
+        proceed(Envelope.packMessage(input, using: self.config.requestCompression))
     }
 
     @Sendable
@@ -198,11 +198,11 @@ extension GRPCWebInterceptor: StreamInterceptor {
                 return
             }
 
-            if let grpcCode = headers._grpcStatus() {
+            if let grpcCode = headers.grpcStatus() {
                 // Headers-only response.
                 proceed(.complete(
                     code: grpcCode,
-                    error: ConnectError._parseGRPCHeaders(nil, trailers: headers).error,
+                    error: ConnectError.parseGRPCHeaders(nil, trailers: headers).error,
                     trailers: headers
                 ))
             } else {
@@ -215,13 +215,13 @@ extension GRPCWebInterceptor: StreamInterceptor {
                 let responseCompressionPool = self.streamResponseHeaders.value?[
                     HeaderConstants.grpcContentEncoding
                 ]?.first.flatMap { self.config.responseCompressionPool(forName: $0) }
-                let (headerByte, unpackedData) = try Envelope._unpackMessage(
+                let (headerByte, unpackedData) = try Envelope.unpackMessage(
                     data, compressionPool: responseCompressionPool
                 )
                 let isTrailers = 0b10000000 & headerByte != 0
                 if isTrailers {
                     let trailers = try Trailers.fromGRPCHeadersBlock(unpackedData)
-                    let (grpcCode, error) = ConnectError._parseGRPCHeaders(
+                    let (grpcCode, error) = ConnectError.parseGRPCHeaders(
                         self.streamResponseHeaders.value, trailers: trailers
                     )
                     if grpcCode == .ok {
@@ -290,7 +290,7 @@ private extension Trailers {
 
 private extension HTTPResponse {
     func withHandledGRPCWebTrailers(_ trailers: Trailers, message: Data?) -> Self {
-        let (grpcCode, error) = ConnectError._parseGRPCHeaders(self.headers, trailers: trailers)
+        let (grpcCode, error) = ConnectError.parseGRPCHeaders(self.headers, trailers: trailers)
         if grpcCode != .ok || error != nil {
             return HTTPResponse(
                 // Rewrite the gRPC code if it is "ok" but `connectError` is non-nil.

--- a/Libraries/Connect/PackageInternal/ConnectError+GRPC.swift
+++ b/Libraries/Connect/PackageInternal/ConnectError+GRPC.swift
@@ -15,9 +15,6 @@
 import Foundation
 
 extension ConnectError {
-    /// **This should not be considered part of Connect's public/stable interface, and is subject
-    /// to change. When the compiler supports it, this should be package-internal.**
-    ///
     /// Parses gRPC headers and/or trailers to obtain the status and any potential error.
     ///
     /// - parameter headers: Headers received from the server.
@@ -25,16 +22,11 @@ extension ConnectError {
     ///                       passed in the headers block for gRPC-Web.
     ///
     /// - returns: A tuple containing the gRPC status code and an optional error.
-    @available(
-        swift,
-        deprecated: 100.0,
-        message: "This is an internal-only API which will be made package-private in Swift 6."
-    )
-    public static func _parseGRPCHeaders(
+    package static func parseGRPCHeaders(
         _ headers: Headers?, trailers: Trailers?
     ) -> (grpcCode: Code, error: ConnectError?) {
         // "Trailers-only" responses can be sent in the headers or trailers block.
-        guard let grpcCode = trailers?._grpcStatus() ?? headers?._grpcStatus() else {
+        guard let grpcCode = trailers?.grpcStatus() ?? headers?.grpcStatus() else {
             return (.unknown, ConnectError(code: .unknown, message: "RPC response missing status"))
         }
 

--- a/Libraries/Connect/PackageInternal/Envelope.swift
+++ b/Libraries/Connect/PackageInternal/Envelope.swift
@@ -15,23 +15,10 @@
 import Foundation
 import SwiftProtobuf
 
-/// **This should not be considered part of Connect's public/stable interface, and is subject
-/// to change. When the compiler supports it, this should be package-internal.**
-///
 /// Provides functionality for packing and unpacking (headers and length prefixed) messages.
-@available(
-    swift,
-    deprecated: 100.0,
-    message: "This is an internal-only API which will be made package-private in Swift 6."
-)
-public enum Envelope {
+package enum Envelope {
     /// The total number of bytes that will prefix a message.
-    @available(
-        swift,
-        deprecated: 100.0,
-        message: "This is an internal-only API which will be made package-private in Swift 6."
-    )
-    public static var _prefixLength: Int {
+    package static var prefixLength: Int {
         return 5 // Header flags (1 byte) + message length (4 bytes)
     }
 
@@ -45,12 +32,7 @@ public enum Envelope {
     /// - parameter compression: Configuration to use for compressing the message.
     ///
     /// - returns: Serialized/enveloped data for transmission.
-    @available(
-        swift,
-        deprecated: 100.0,
-        message: "This is an internal-only API which will be made package-private in Swift 6."
-    )
-    public static func _packMessage(
+    package static func packMessage(
         _ source: Data, using compression: ProtocolClientConfig.RequestCompression?
     ) -> Data {
         var buffer = Data()
@@ -85,12 +67,7 @@ public enum Envelope {
     ///
     /// - returns: A tuple that includes the header byte and the un-prefixed and decompressed
     ///            message.
-    @available(
-        swift,
-        deprecated: 100.0,
-        message: "This is an internal-only API which will be made package-private in Swift 6."
-    )
-    public static func _unpackMessage(
+    package static func unpackMessage(
         _ source: Data, compressionPool: CompressionPool?
     ) throws -> (headerByte: UInt8, unpacked: Data) {
         if source.isEmpty {
@@ -99,7 +76,7 @@ public enum Envelope {
 
         let headerByte = source[0]
         let isCompressed = 0b00000001 & headerByte != 0
-        let messageData = Data(source.dropFirst(self._prefixLength))
+        let messageData = Data(source.dropFirst(self.prefixLength))
         if isCompressed {
             guard let compressionPool = compressionPool else {
                 throw Error.missingExpectedCompressionPool
@@ -116,12 +93,7 @@ public enum Envelope {
     /// - parameter packedData: The packed data to analyze.
     ///
     /// - returns: True if the data is compressed.
-    @available(
-        swift,
-        deprecated: 100.0,
-        message: "This is an internal-only API which will be made package-private in Swift 6."
-    )
-    public static func _isCompressed(_ packedData: Data) -> Bool {
+    package static func isCompressed(_ packedData: Data) -> Bool {
         return !packedData.isEmpty && (0b00000001 & packedData[0] != 0)
     }
 
@@ -136,13 +108,8 @@ public enum Envelope {
     /// - returns: The length of the next expected message in the packed data. If multiple chunks
     ///            are specified, this will return the length of the first. Returns -1 if there is
     ///            not enough prefix data to determine the message length.
-    @available(
-        swift,
-        deprecated: 100.0,
-        message: "This is an internal-only API which will be made package-private in Swift 6."
-    )
-    public static func _messageLength(forPackedData data: Data) -> Int {
-        guard data.count >= self._prefixLength else {
+    package static func messageLength(forPackedData data: Data) -> Int {
+        guard data.count >= self.prefixLength else {
             return -1
         }
 

--- a/Libraries/Connect/PackageInternal/Headers+gRPC.swift
+++ b/Libraries/Connect/PackageInternal/Headers+gRPC.swift
@@ -15,9 +15,6 @@
 import Foundation
 
 extension Headers {
-    /// **This should not be considered part of Connect's public/stable interface, and is subject
-    /// to change. When the compiler supports it, this should be package-internal.**
-    ///
     /// Adds required headers to gRPC and gRPC-Web requests/streams.
     ///
     /// - parameter config: The configuration to use for adding headers (i.e., for compression
@@ -25,12 +22,7 @@ extension Headers {
     /// - parameter grpcWeb: Should be true if using gRPC-Web, false if gRPC.
     ///
     /// - returns: A set of updated headers.
-    @available(
-        swift,
-        deprecated: 100.0,
-        message: "This is an internal-only API which will be made package-private in Swift 6."
-    )
-    public func _addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
+    package func addingGRPCHeaders(using config: ProtocolClientConfig, grpcWeb: Bool) -> Self {
         var headers = self
         headers[HeaderConstants.grpcAcceptEncoding] = config
             .acceptCompressionPoolNames()

--- a/Libraries/Connect/PackageInternal/Trailers+gRPC.swift
+++ b/Libraries/Connect/PackageInternal/Trailers+gRPC.swift
@@ -13,18 +13,10 @@
 // limitations under the License.
 
 extension Trailers {
-    /// **This should not be considered part of Connect's public/stable interface, and is subject
-    /// to change. When the compiler supports it, this should be package-internal.**
-    ///
     /// Identifies the status code from gRPC and gRPC-Web trailers.
     ///
     /// - returns: The gRPC status code, if specified.
-    @available(
-        swift,
-        deprecated: 100.0,
-        message: "This is an internal-only API which will be made package-private in Swift 6."
-    )
-    public func _grpcStatus() -> Code? {
+    package func grpcStatus() -> Code? {
         return self[HeaderConstants.grpcStatus]?
             .first
             .flatMap(Int.init)

--- a/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
+++ b/Libraries/Connect/Public/Implementation/Clients/ProtocolClient.swift
@@ -297,12 +297,12 @@ extension ProtocolClient: ProtocolClientInterface {
                     // Handle cases where multiple messages are received in a single chunk.
                     responseBuffer += data
                     while true {
-                        let messageLength = Envelope._messageLength(forPackedData: responseBuffer)
+                        let messageLength = Envelope.messageLength(forPackedData: responseBuffer)
                         if messageLength < 0 {
                             return
                         }
 
-                        let prefixedMessageLength = Envelope._prefixLength + messageLength
+                        let prefixedMessageLength = Envelope.prefixLength + messageLength
                         guard responseBuffer.count >= prefixedMessageLength else {
                             return
                         }

--- a/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
+++ b/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
@@ -34,13 +34,13 @@ extension GRPCInterceptor: UnaryInterceptor {
         proceed: @escaping (Result<HTTPRequest<Data?>, ConnectError>) -> Void
     ) {
         // gRPC unary payloads are enveloped.
-        let envelopedRequestBody = Envelope._packMessage(
+        let envelopedRequestBody = Envelope.packMessage(
             request.message ?? Data(), using: self.config.requestCompression
         )
 
         proceed(.success(HTTPRequest(
             url: request.url,
-            headers: request.headers._addingGRPCHeaders(using: self.config, grpcWeb: false),
+            headers: request.headers.addingGRPCHeaders(using: self.config, grpcWeb: false),
             message: envelopedRequestBody,
             method: request.method,
             trailers: nil,
@@ -72,12 +72,12 @@ extension GRPCInterceptor: UnaryInterceptor {
             return
         }
 
-        let (grpcCode, connectError) = ConnectError._parseGRPCHeaders(
+        let (grpcCode, connectError) = ConnectError.parseGRPCHeaders(
             response.headers,
             trailers: response.trailers
         )
         guard grpcCode == .ok, let rawData = response.message, !rawData.isEmpty else {
-            if response.trailers._grpcStatus() == nil && response.message?.isEmpty == false {
+            if response.trailers.grpcStatus() == nil && response.message?.isEmpty == false {
                 proceed(HTTPResponse(
                     code: .internalError,
                     headers: response.headers,
@@ -117,7 +117,7 @@ extension GRPCInterceptor: UnaryInterceptor {
             .headers[HeaderConstants.grpcContentEncoding]?
             .first
             .flatMap { self.config.responseCompressionPool(forName: $0) }
-        if compressionPool == nil && Envelope._isCompressed(rawData) {
+        if compressionPool == nil && Envelope.isCompressed(rawData) {
             proceed(HTTPResponse(
                 code: .internalError, headers: response.headers, message: nil,
                 trailers: response.trailers, error: ConnectError(
@@ -140,7 +140,7 @@ extension GRPCInterceptor: UnaryInterceptor {
         }
 
         do {
-            let messageData = try Envelope._unpackMessage(
+            let messageData = try Envelope.unpackMessage(
                 rawData, compressionPool: compressionPool
             ).unpacked
             proceed(HTTPResponse(
@@ -172,7 +172,7 @@ extension GRPCInterceptor: StreamInterceptor {
     ) {
         proceed(.success(HTTPRequest(
             url: request.url,
-            headers: request.headers._addingGRPCHeaders(using: self.config, grpcWeb: false),
+            headers: request.headers.addingGRPCHeaders(using: self.config, grpcWeb: false),
             message: request.message,
             method: request.method,
             trailers: nil,
@@ -182,7 +182,7 @@ extension GRPCInterceptor: StreamInterceptor {
 
     @Sendable
     func handleStreamRawInput(_ input: Data, proceed: @escaping (Data) -> Void) {
-        proceed(Envelope._packMessage(input, using: self.config.requestCompression))
+        proceed(Envelope.packMessage(input, using: self.config.requestCompression))
     }
 
     @Sendable
@@ -214,7 +214,7 @@ extension GRPCInterceptor: StreamInterceptor {
                 let responseCompressionPool = self.streamResponseHeaders.value?[
                     HeaderConstants.grpcContentEncoding
                 ]?.first.flatMap { self.config.responseCompressionPool(forName: $0) }
-                if responseCompressionPool == nil && Envelope._isCompressed(rawData) {
+                if responseCompressionPool == nil && Envelope.isCompressed(rawData) {
                     proceed(.complete(
                         code: .internalError, error: ConnectError(
                             code: .internalError, message: "received unexpected compressed message"
@@ -223,7 +223,7 @@ extension GRPCInterceptor: StreamInterceptor {
                     return
                 }
 
-                let unpackedMessage = try Envelope._unpackMessage(
+                let unpackedMessage = try Envelope.unpackMessage(
                     rawData, compressionPool: responseCompressionPool
                 ).unpacked
                 proceed(.message(unpackedMessage))
@@ -239,7 +239,7 @@ extension GRPCInterceptor: StreamInterceptor {
                 return
             }
 
-            let (grpcCode, connectError) = ConnectError._parseGRPCHeaders(
+            let (grpcCode, connectError) = ConnectError.parseGRPCHeaders(
                 self.streamResponseHeaders.value,
                 trailers: trailers
             )
@@ -275,8 +275,8 @@ extension GRPCInterceptor: StreamInterceptor {
 
 private extension Envelope {
     static func containsMultipleGRPCMessages(_ packedData: Data) -> Bool {
-        let messageLength = self._messageLength(forPackedData: packedData)
-        return packedData.count > messageLength + self._prefixLength
+        let messageLength = self.messageLength(forPackedData: packedData)
+        return packedData.count > messageLength + self.prefixLength
     }
 }
 

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectTests/EnvelopeTests.swift
@@ -20,16 +20,16 @@ struct EnvelopeTests {
     @Test
     func packingAndUnpackingCompressedMessage() throws {
         let originalData = Data(repeating: 0xa, count: 50)
-        let packed = Envelope._packMessage(
+        let packed = Envelope.packMessage(
             originalData, using: .init(minBytes: 10, pool: GzipCompressionPool())
         )
         let compressed = try GzipCompressionPool().compress(data: originalData)
         #expect(packed[0] == 1) // Compression flag = true
-        #expect(Envelope._isCompressed(packed))
-        #expect(Envelope._messageLength(forPackedData: packed) == compressed.count)
+        #expect(Envelope.isCompressed(packed))
+        #expect(Envelope.messageLength(forPackedData: packed) == compressed.count)
         #expect(packed[5...] == compressed) // Post-prefix data should match compressed value
 
-        let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
+        let unpacked = try Envelope.unpackMessage(packed, compressionPool: GzipCompressionPool())
         #expect(unpacked.unpacked == originalData)
         #expect(unpacked.headerByte == 1) // Compression flag = true
     }
@@ -37,14 +37,14 @@ struct EnvelopeTests {
     @Test
     func packingAndUnpackingUncompressedMessageBecauseCompressionMinBytesIsNil() throws {
         let originalData = Data(repeating: 0xa, count: 50)
-        let packed = Envelope._packMessage(originalData, using: nil)
+        let packed = Envelope.packMessage(originalData, using: nil)
         #expect(packed[0] == 0) // Compression flag = false
-        #expect(Envelope._isCompressed(packed) == false)
-        #expect(Envelope._messageLength(forPackedData: packed) == originalData.count)
+        #expect(Envelope.isCompressed(packed) == false)
+        #expect(Envelope.messageLength(forPackedData: packed) == originalData.count)
         #expect(packed[5...] == originalData) // Post-prefix data should match compressed value
 
         // Compression pool should be ignored since the message is not compressed
-        let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
+        let unpacked = try Envelope.unpackMessage(packed, compressionPool: GzipCompressionPool())
         #expect(unpacked.unpacked == originalData)
         #expect(unpacked.headerByte == 0) // Compression flag = false
     }
@@ -52,16 +52,16 @@ struct EnvelopeTests {
     @Test
     func packingAndUnpackingUncompressedMessageBecauseMessageIsTooSmall() throws {
         let originalData = Data(repeating: 0xa, count: 50)
-        let packed = Envelope._packMessage(
+        let packed = Envelope.packMessage(
             originalData, using: .init(minBytes: 100, pool: GzipCompressionPool())
         )
         #expect(packed[0] == 0) // Compression flag = false
-        #expect(Envelope._isCompressed(packed) == false)
-        #expect(Envelope._messageLength(forPackedData: packed) == originalData.count)
+        #expect(Envelope.isCompressed(packed) == false)
+        #expect(Envelope.messageLength(forPackedData: packed) == originalData.count)
         #expect(packed[5...] == originalData) // Post-prefix data should match compressed value
 
         // Compression pool should be ignored since the message is not compressed
-        let unpacked = try Envelope._unpackMessage(packed, compressionPool: GzipCompressionPool())
+        let unpacked = try Envelope.unpackMessage(packed, compressionPool: GzipCompressionPool())
         #expect(unpacked.unpacked == originalData)
         #expect(unpacked.headerByte == 0) // Compression flag = false
     }
@@ -69,17 +69,17 @@ struct EnvelopeTests {
     @Test
     func throwsWhenUnpackingCompressedMessageWithoutDecompressionPool() throws {
         let originalData = Data(repeating: 0xa, count: 50)
-        let packed = Envelope._packMessage(
+        let packed = Envelope.packMessage(
             originalData, using: .init(minBytes: 10, pool: GzipCompressionPool())
         )
         let compressed = try GzipCompressionPool().compress(data: originalData)
         #expect(packed[0] == 1) // Compression flag = true
-        #expect(Envelope._isCompressed(packed))
-        #expect(Envelope._messageLength(forPackedData: packed) == compressed.count)
+        #expect(Envelope.isCompressed(packed))
+        #expect(Envelope.messageLength(forPackedData: packed) == compressed.count)
         #expect(packed[5...] == compressed) // Post-prefix data should match compressed value
 
         #expect(throws: Envelope.Error.missingExpectedCompressionPool) {
-            try Envelope._unpackMessage(packed, compressionPool: nil)
+            try Envelope.unpackMessage(packed, compressionPool: nil)
         }
     }
 
@@ -88,7 +88,7 @@ struct EnvelopeTests {
         // Messages are incomplete if they do not contain enough data for the 5-byte prefix
         for length in 0..<5 {
             let data = Data(repeating: 0xa, count: length)
-            #expect(Envelope._messageLength(forPackedData: data) == -1)
+            #expect(Envelope.messageLength(forPackedData: data) == -1)
         }
     }
 }


### PR DESCRIPTION
Closes #419.

Replaces the pre-5.9 `public` + underscore + fake-deprecation workaround in `PackageInternal/` with the real `package` access level, now that CocoaPods (the blocker) is gone. Bumps `swift-tools-version` to 5.9, drops underscores from the 9 renamed symbols and their ~54 call sites, and renames `Headers+GRPC.swift` to `Headers+gRPC.swift` to match `Trailers+gRPC.swift`.

Source-breaking for anyone calling these despite the disclaimer — intended, ships with the other 2.0 breaking changes (#416, #414).