### PR TITLE
Remove Combine from the `ConnectMocks` async mocks

### DIFF
--- a/Libraries/ConnectMocks/MockBidirectionalAsyncStream.swift
+++ b/Libraries/ConnectMocks/MockBidirectionalAsyncStream.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Combine
 import Connect
 import SwiftProtobuf
 
@@ -28,8 +27,10 @@ open class MockBidirectionalAsyncStream<
     Input: ProtobufMessage,
     Output: ProtobufMessage
 >: BidirectionalAsyncStreamInterface, @unchecked Sendable {
-    /// Used to store cancellables from the stream.
-    private var cancellables = [AnyCancellable]()
+    /// The stream returned by `results()`, created on that function's first call and then reused.
+    private var resultsStream: AsyncStream<StreamResult<Output>>?
+    /// Set to `nil` once `outputs` have been emitted so that they are emitted only one time.
+    private var resultsContinuation: AsyncStream<StreamResult<Output>>.Continuation?
 
     /// Closure that is called when `close()` is invoked.
     public var onClose: (() -> Void)?
@@ -40,9 +41,9 @@ open class MockBidirectionalAsyncStream<
     public var outputs: [StreamResult<Output>]
 
     /// All inputs that have been sent through the stream.
-    @Published public private(set) var inputs = [Input]()
+    public private(set) var inputs = [Input]()
     /// True if `close()` has been called.
-    @Published public private(set) var isClosed = false
+    public private(set) var isClosed = false
 
     /// Designated initializer.
     ///
@@ -56,22 +57,23 @@ open class MockBidirectionalAsyncStream<
     open func send(_ input: Input) throws -> Self {
         self.inputs.append(input)
         self.onSend?(input)
+        self.emitOutputsIfReady()
         return self
     }
 
+    /// Returns the same stream on every call, matching the production implementation.
+    /// `outputs` are emitted and the stream is finished once an input has been sent,
+    /// regardless of whether `send()` or this function is called first.
     open func results() -> AsyncStream<Connect.StreamResult<Output>> {
-        // Wait until a request is sent over the stream to return the results.
-        return AsyncStream { continuation in
-            self.$inputs
-                .first { !$0.isEmpty }
-                .sink { _ in
-                    for output in self.outputs {
-                        continuation.yield(output)
-                    }
-                    continuation.finish()
-                }
-                .store(in: &self.cancellables)
+        if let resultsStream = self.resultsStream {
+            return resultsStream
         }
+
+        let (stream, continuation) = AsyncStream.makeStream(of: StreamResult<Output>.self)
+        self.resultsStream = stream
+        self.resultsContinuation = continuation
+        self.emitOutputsIfReady()
+        return stream
     }
 
     open func close() {
@@ -80,4 +82,16 @@ open class MockBidirectionalAsyncStream<
     }
 
     open func cancel() {}
+
+    private func emitOutputsIfReady() {
+        guard !self.inputs.isEmpty, let continuation = self.resultsContinuation else {
+            return
+        }
+
+        self.resultsContinuation = nil
+        for output in self.outputs {
+            continuation.yield(output)
+        }
+        continuation.finish()
+    }
 }

--- a/Libraries/ConnectMocks/MockServerOnlyAsyncStream.swift
+++ b/Libraries/ConnectMocks/MockServerOnlyAsyncStream.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Combine
 import Connect
 import SwiftProtobuf
 
@@ -28,8 +27,10 @@ open class MockServerOnlyAsyncStream<
     Input: ProtobufMessage,
     Output: ProtobufMessage
 >: ServerOnlyAsyncStreamInterface, @unchecked Sendable {
-    /// Used to store cancellables from the stream.
-    private var cancellables = [AnyCancellable]()
+    /// The stream returned by `results()`, created on that function's first call and then reused.
+    private var resultsStream: AsyncStream<StreamResult<Output>>?
+    /// Set to `nil` once `outputs` have been emitted so that they are emitted only one time.
+    private var resultsContinuation: AsyncStream<StreamResult<Output>>.Continuation?
 
     /// Closure that is called when `send()` is invoked.
     public var onSend: ((Input) -> Void)?
@@ -38,7 +39,7 @@ open class MockServerOnlyAsyncStream<
     public var outputs: [StreamResult<Output>]
 
     /// All inputs that have been sent through the stream.
-    @Published public private(set) var inputs = [Input]()
+    public private(set) var inputs = [Input]()
 
     /// Designated initializer.
     ///
@@ -51,22 +52,35 @@ open class MockServerOnlyAsyncStream<
     open func send(_ input: Input) throws {
         self.inputs.append(input)
         self.onSend?(input)
+        self.emitOutputsIfReady()
     }
 
+    /// Returns the same stream on every call, matching the production implementation.
+    /// `outputs` are emitted and the stream is finished once an input has been sent,
+    /// regardless of whether `send()` or this function is called first.
     open func results() -> AsyncStream<Connect.StreamResult<Output>> {
-        // Wait until a request is sent over the stream to return the results.
-        return AsyncStream { continuation in
-            self.$inputs
-                .first { !$0.isEmpty }
-                .sink { _ in
-                    for output in self.outputs {
-                        continuation.yield(output)
-                    }
-                    continuation.finish()
-                }
-                .store(in: &self.cancellables)
+        if let resultsStream = self.resultsStream {
+            return resultsStream
         }
+
+        let (stream, continuation) = AsyncStream.makeStream(of: StreamResult<Output>.self)
+        self.resultsStream = stream
+        self.resultsContinuation = continuation
+        self.emitOutputsIfReady()
+        return stream
     }
 
     open func cancel() {}
+
+    private func emitOutputsIfReady() {
+        guard !self.inputs.isEmpty, let continuation = self.resultsContinuation else {
+            return
+        }
+
+        self.resultsContinuation = nil
+        for output in self.outputs {
+            continuation.yield(output)
+        }
+        continuation.finish()
+    }
 }

--- a/Tests/UnitTests/ConnectLibraryTests/ConnectMocksTests/ConnectMocksTests.swift
+++ b/Tests/UnitTests/ConnectLibraryTests/ConnectMocksTests/ConnectMocksTests.swift
@@ -128,6 +128,58 @@ struct ConnectMocksTests {
         #expect(client.mockAsyncBidiStream.isClosed)
     }
 
+    @Test
+    func mockBidirectionalStreamAsyncAwaitWithResultsRequestedBeforeSending() async throws {
+        let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
+        var expectedResults: [StreamResult<Connectrpc_Conformance_V1_BidiStreamResponse>] =
+        [
+            .headers(["x-header": ["123"]]),
+            .message(.with { $0.payload.data = Data(repeating: 0, count: 123) }),
+            .complete(code: .ok, error: nil, trailers: nil),
+        ]
+
+        // Deliberately request the results before sending inputs or configuring outputs.
+        let stream = client.bidiStream()
+        _ = stream.results()
+        client.mockAsyncBidiStream.outputs = Array(expectedResults)
+        try stream.send(.init())
+        try stream.send(.init())
+
+        // Requesting the results again must return the same stream, carrying the outputs.
+        for await result in stream.results() {
+            #expect(result == expectedResults.removeFirst())
+        }
+
+        #expect(client.mockAsyncBidiStream.inputs.count == 2)
+        #expect(expectedResults.isEmpty)
+    }
+
+    // MARK: - Client-only stream
+
+    @Test
+    func mockClientOnlyStreamAsyncAwait() async throws {
+        let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
+        var expectedResults: [StreamResult<Connectrpc_Conformance_V1_ClientStreamResponse>] =
+        [
+            .headers(["x-header": ["123"]]),
+            .message(.with { $0.payload.data = Data(repeating: 0, count: 123) }),
+            .complete(code: .ok, error: nil, trailers: nil),
+        ]
+        client.mockAsyncClientStream.outputs = Array(expectedResults)
+
+        let stream = client.clientStream()
+        try stream.send(.init())
+        stream.closeAndReceive()
+
+        for await result in stream.results() {
+            #expect(result == expectedResults.removeFirst())
+        }
+
+        #expect(client.mockAsyncClientStream.inputs.count == 1)
+        #expect(expectedResults.isEmpty)
+        #expect(client.mockAsyncClientStream.isClosed)
+    }
+
     // MARK: - Server-only stream
 
     @Test
@@ -187,6 +239,31 @@ struct ConnectMocksTests {
 
         #expect(sentInputs == expectedInputs)
         #expect(client.mockAsyncServerStream.inputs == expectedInputs)
+        #expect(expectedResults.isEmpty)
+    }
+
+    @Test
+    func mockServerOnlyStreamAsyncAwaitWithResultsRequestedBeforeSending() async throws {
+        let client = Connectrpc_Conformance_V1_ConformanceServiceClientMock()
+        var expectedResults: [StreamResult<Connectrpc_Conformance_V1_ServerStreamResponse>] =
+        [
+            .headers(["x-header": ["123"]]),
+            .message(.with { $0.payload.data = Data(repeating: 0, count: 123) }),
+            .complete(code: .ok, error: nil, trailers: nil),
+        ]
+
+        // Deliberately request the results before sending an input or configuring outputs.
+        let stream = client.serverStream()
+        _ = stream.results()
+        client.mockAsyncServerStream.outputs = Array(expectedResults)
+        try stream.send(.init())
+
+        // Requesting the results again must return the same stream, carrying the outputs.
+        for await result in stream.results() {
+            #expect(result == expectedResults.removeFirst())
+        }
+
+        #expect(client.mockAsyncServerStream.inputs.count == 1)
         #expect(expectedResults.isEmpty)
     }
 }


### PR DESCRIPTION
Part of #421.

`ConnectMocks` used Combine for one thing: `@Published` on `inputs`/`isClosed`, which the async mock streams subscribed to inside `results()` to know when to emit their canned `outputs`. Now that iOS 13 is the floor (#416), Combine is unconditionally available, so this is dependency hygiene rather than an availability fix — async/await consumers shouldn't have to link Combine, and a stored continuation is simpler than the publisher bridge it replaces.

## Changes

`MockBidirectionalAsyncStream` and `MockServerOnlyAsyncStream` drop `import Combine`, `@Published`, and `cancellables`. `results()` now memoizes a single `AsyncStream` (via `AsyncStream.makeStream`) and stores its continuation; a private `emitOutputsIfReady()`, called from both `send()` and `results()`, emits `outputs` and finishes the stream once an input has been sent — reproducing the order-independence `@Published`'s value replay gave for free. `inputs`/`isClosed` stay `public private(set)`. `MockClientOnlyAsyncStream` needs no changes since it inherits all of this. `ConnectMocksTests` gets three new cases covering both call orderings and the repeat-`results()` case.

Two deviations from the issue's proposal: `results()` memoizes one stream instead of a fresh stream per call, matching production's `BidirectionalAsyncStream` (`return self.asyncStream`) and avoiding a silent-empty-stream footgun on a second call — and there's no separate `didFlushOutputs` flag, since nil-ing `resultsContinuation` after emitting encodes the same state in one fewer property.

As a side effect this also fixes a retain cycle (`self` → `cancellables` → `AnyCancellable` → `Sink` → `self`) that kept a mock alive if `results()` was called but nothing was ever sent.

## Behavior changes

`$inputs`/`$isClosed` are gone from the public API — source-breaking, targets the same major as #416/#419. `results()` is now single-consumer, so repeat calls share one stream instead of each replaying all outputs. Outputs now emit after `onSend` runs rather than during `inputs.append(...)`, since `@Published` used to publish in `willSet`.

## Scope

Limited to the async mocks, so this doesn't close #421 — `ConnectMocks` still imports Combine from the callback mocks (`MockBidirectionalStream`/`MockServerOnlyStream`) until #420 lands. The generator and checked-in generated mock are untouched.

## Verification

New tests were written against the existing Combine implementation and pass there first, so they pin parity, not just the replacement — and each was checked against a deliberately broken implementation, where removing `emitOutputsIfReady()` from either `send()` hangs the corresponding test. `AsyncStream.makeStream`, the one novel API here, was typechecked under `-swift-version 6` at all four platform floors (it's gated at SwiftStdlib 5.1 and `@backDeployed`, so no `@available` guard is needed).

`make testunit` (79 tests, 17 suites), `swiftlint lint --strict`, `make buildplugins && make generate` (clean diff), `make licenseheaders` (clean diff), and `xcodebuild` for iOS/macOS/the Eliza example all pass; tvOS/watchOS aren't buildable locally but are covered by CI. `make testconformance` — NIO 1681/1681; urlsession shows a pre-existing single-test flake, confirmed by reproducing it on a clean tree and by `nm` showing zero `ConnectMocks` symbols in the conformance binary.
