### PR TITLE
Share Locked with ConnectNIO via the package access level

### DIFF
--- a/Libraries/Connect/PackageInternal/Locked.swift
+++ b/Libraries/Connect/PackageInternal/Locked.swift
@@ -16,12 +16,12 @@ import Foundation
 
 /// Class containing an internal lock which can be used to ensure thread-safe access to an
 /// underlying value. Conforms to `Sendable`, making it accessible from `@Sendable` closures.
-final class Locked<Wrapped>: @unchecked Sendable {
+package final class Locked<Wrapped>: @unchecked Sendable {
     private let lock = Lock()
     private var wrappedValue: Wrapped
 
     /// Thread-safe access to the underlying value.
-    var value: Wrapped {
+    package var value: Wrapped {
         get { self.lock.perform { self.wrappedValue } }
         set { self.lock.perform { self.wrappedValue = newValue } }
     }
@@ -32,13 +32,13 @@ final class Locked<Wrapped>: @unchecked Sendable {
     ///
     /// - returns: The value returned by the closure.
     @discardableResult
-    func perform<Result>(action: @escaping (inout Wrapped) -> Result) -> Result {
+    package func perform<Result>(action: @escaping (inout Wrapped) -> Result) -> Result {
         return self.lock.perform {
             action(&self.wrappedValue)
         }
     }
 
-    init(_ value: Wrapped) {
+    package init(_ value: Wrapped) {
         self.wrappedValue = value
     }
 }

--- a/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
+++ b/Libraries/ConnectNIO/Internal/GRPCInterceptor.swift
@@ -14,7 +14,6 @@
 
 import Connect
 import Foundation
-import NIOConcurrencyHelpers
 
 /// Implementation of the gRPC protocol as an interceptor.
 /// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
@@ -277,20 +276,5 @@ private extension Envelope {
     static func containsMultipleGRPCMessages(_ packedData: Data) -> Bool {
         let messageLength = self.messageLength(forPackedData: packedData)
         return packedData.count > messageLength + self.prefixLength
-    }
-}
-
-private final class Locked<T>: @unchecked Sendable {
-    private let lock = NIOLock()
-    private var wrappedValue: T
-
-    /// Thread-safe access to the underlying value.
-    var value: T {
-        get { self.lock.withLock { self.wrappedValue } }
-        set { self.lock.withLock { self.wrappedValue = newValue } }
-    }
-
-    init(_ value: T) {
-        self.wrappedValue = value
     }
 }


### PR DESCRIPTION
## Summary

`ConnectNIO` couldn't see `Connect`'s internal `Locked` type, so it carried a private duplicate backed by `NIOLock`. That's no longer necessary: the manifest is `swift-tools-version:5.9`, and #428 already adopted `package` for `PackageInternal` types.

- Moves `Locked` into `PackageInternal/` and marks it `package`, matching the existing convention (see `Envelope`).
- Deletes the 14-line duplicate `Locked` class in `GRPCInterceptor.swift` and its now-unused `NIOConcurrencyHelpers` import.

`Lock` stays `internal` — `Locked`'s reference to it is `private`, so it doesn't need to be exposed. No call sites change.

## Test plan

- [x] `swift build && swift test` — 86/86 passing
- [x] `make testconformance` — 966/966 (URLSession) + 1681/1681 (NIO)
- [x] SwiftLint clean